### PR TITLE
Issue-backlog triage batch: close #4, #5, #6, #10, #11, #12, #13, #14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ coverage
 .env.*.local
 *.log
 *.tsbuildinfo
+
+# Local-only agent operating instructions (per-machine)
+CLAUDE.md
+GEMINI.md

--- a/src/app/AuthGate.test.tsx
+++ b/src/app/AuthGate.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+const getSessionMock = vi.fn();
+const onAuthStateChangeMock = vi.fn(() => ({
+  data: { subscription: { unsubscribe: vi.fn() } },
+}));
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: getSessionMock,
+      onAuthStateChange: onAuthStateChangeMock,
+    },
+  },
+}));
+
+vi.mock('@/features/login/Login', () => ({
+  Login: (): JSX.Element => <div>login screen</div>,
+}));
+
+const { AuthGate } = await import('./AuthGate');
+
+describe('AuthGate', () => {
+  it('shows an error screen with Retry when getSession rejects', async () => {
+    getSessionMock.mockRejectedValueOnce(new Error('fetch failed: net::ERR'));
+    render(
+      <AuthGate>
+        <div>app body</div>
+      </AuthGate>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Could not reach the server')).toBeInTheDocument();
+    });
+    expect(screen.getByText('fetch failed: net::ERR')).toBeInTheDocument();
+    expect(screen.queryByText('app body')).not.toBeInTheDocument();
+
+    getSessionMock.mockResolvedValueOnce({ data: { session: null } });
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    await waitFor(() => {
+      expect(screen.getByText('login screen')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/AuthGate.tsx
+++ b/src/app/AuthGate.tsx
@@ -1,10 +1,14 @@
 import type { Session } from '@supabase/supabase-js';
-import { type JSX, type ReactNode, useEffect, useState } from 'react';
+import { type JSX, type ReactNode, useCallback, useEffect, useState } from 'react';
 
 import { Login } from '@/features/login/Login';
 import { supabase } from '@/lib/supabase';
 
-type AuthState = { status: 'loading' } | { status: 'out' } | { status: 'in'; session: Session };
+type AuthState =
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'out' }
+  | { status: 'in'; session: Session };
 
 /**
  * Wraps the routed app. Renders the login screen when no session exists, the
@@ -13,13 +17,22 @@ type AuthState = { status: 'loading' } | { status: 'out' } | { status: 'in'; ses
  */
 export const AuthGate = ({ children }: { children: ReactNode }): JSX.Element => {
   const [state, setState] = useState<AuthState>({ status: 'loading' });
+  const [retryCount, setRetryCount] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
-    supabase.auth.getSession().then(({ data }) => {
-      if (cancelled) return;
-      setState(data.session ? { status: 'in', session: data.session } : { status: 'out' });
-    });
+    setState({ status: 'loading' });
+    supabase.auth
+      .getSession()
+      .then(({ data }) => {
+        if (cancelled) return;
+        setState(data.session ? { status: 'in', session: data.session } : { status: 'out' });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : 'Could not reach auth service.';
+        setState({ status: 'error', message });
+      });
     const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
       setState(session ? { status: 'in', session } : { status: 'out' });
     });
@@ -27,9 +40,55 @@ export const AuthGate = ({ children }: { children: ReactNode }): JSX.Element => 
       cancelled = true;
       sub.subscription.unsubscribe();
     };
-  }, []);
+  }, [retryCount]);
+
+  const retry = useCallback(() => setRetryCount((n) => n + 1), []);
 
   if (state.status === 'loading') return <div className="tal" />;
+  if (state.status === 'error') return <AuthGateError message={state.message} onRetry={retry} />;
   if (state.status === 'out') return <Login />;
   return <>{children}</>;
 };
+
+const AuthGateError = ({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}): JSX.Element => (
+  <div
+    className="tal"
+    style={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 16,
+      padding: 32,
+      textAlign: 'center',
+      height: '100vh',
+    }}
+  >
+    <h1 style={{ fontSize: 24, fontWeight: 800, margin: 0 }}>Could not reach the server</h1>
+    <p style={{ fontSize: 15, color: 'var(--tal-ink-soft)', margin: 0, maxWidth: 420 }}>
+      {message}
+    </p>
+    <button
+      type="button"
+      onClick={onRetry}
+      style={{
+        padding: '10px 20px',
+        fontSize: 15,
+        fontWeight: 700,
+        borderRadius: 999,
+        border: 'none',
+        background: 'var(--tal-sage)',
+        color: 'var(--tal-sage-ink)',
+        cursor: 'pointer',
+      }}
+    >
+      Retry
+    </button>
+  </div>
+);

--- a/src/features/board-builder/BoardBuilder.tsx
+++ b/src/features/board-builder/BoardBuilder.tsx
@@ -29,6 +29,8 @@ interface BoardBuilderProps {
   onBack: () => void;
   onOpenPicker: () => void;
   onPreview: (kind: BoardKind) => void;
+  onKidMode: () => void;
+  onSignOut: () => void;
 }
 
 interface Step {
@@ -54,6 +56,8 @@ export const BoardBuilder = ({
   onBack,
   onOpenPicker,
   onPreview,
+  onKidMode,
+  onSignOut,
 }: BoardBuilderProps): JSX.Element => {
   const pictogramsById = usePictogramsById();
   const { data: allPictograms = [] } = usePictograms();
@@ -119,6 +123,8 @@ export const BoardBuilder = ({
   return (
     <ParentShell
       active="home"
+      onKidMode={onKidMode}
+      onSignOut={onSignOut}
       right={
         <Button variant="primary" icon={<PlayIcon />} onClick={() => onPreview(board.kind)}>
           Preview for Liam

--- a/src/features/board-builder/BoardBuilder.tsx
+++ b/src/features/board-builder/BoardBuilder.tsx
@@ -31,6 +31,7 @@ interface BoardBuilderProps {
   onPreview: (kind: BoardKind) => void;
   onKidMode: () => void;
   onSignOut: () => void;
+  userInitial?: string | undefined;
 }
 
 interface Step {
@@ -58,6 +59,7 @@ export const BoardBuilder = ({
   onPreview,
   onKidMode,
   onSignOut,
+  userInitial,
 }: BoardBuilderProps): JSX.Element => {
   const pictogramsById = usePictogramsById();
   const { data: allPictograms = [] } = usePictograms();
@@ -125,6 +127,7 @@ export const BoardBuilder = ({
       active="home"
       onKidMode={onKidMode}
       onSignOut={onSignOut}
+      userInitial={userInitial}
       right={
         <Button variant="primary" icon={<PlayIcon />} onClick={() => onPreview(board.kind)}>
           Preview for Liam

--- a/src/features/board-builder/BoardBuilderRoute.test.tsx
+++ b/src/features/board-builder/BoardBuilderRoute.test.tsx
@@ -1,0 +1,54 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { JSX } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import { boardsQueryKey } from '@/lib/queries/boards';
+
+const singleMock = vi.fn();
+const eqMock = vi.fn(() => ({ single: singleMock }));
+const selectMock = vi.fn(() => ({ eq: eqMock, order: vi.fn(() => Promise.resolve({ data: [], error: null })) }));
+const fromMock = vi.fn((_table: string) => ({ select: selectMock }));
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: (table: string) => fromMock(table),
+    auth: {
+      signOut: vi.fn(),
+      getSession: vi.fn(() => Promise.resolve({ data: { session: null } })),
+      onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+    },
+  },
+}));
+
+const { BoardBuilderRoute } = await import('./BoardBuilderRoute');
+
+const makeWrapper = (qc: QueryClient, initialPath: string): (() => JSX.Element) => {
+  return (): JSX.Element => (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="/boards/:boardId/edit" element={<BoardBuilderRoute />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
+describe('BoardBuilderRoute', () => {
+  it('renders BoardNotFound when useBoard errors (RLS-blocked row)', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    qc.setQueryData(boardsQueryKey, []);
+    singleMock.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'JSON object requested, multiple (or no) rows returned', code: 'PGRST116' },
+    });
+    const Wrap = makeWrapper(qc, '/boards/00000000-0000-0000-0000-000000000000/edit');
+    render(<Wrap />);
+    await waitFor(() => {
+      expect(screen.getByText('Board not found')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Back to boards')).toBeInTheDocument();
+  });
+});

--- a/src/features/board-builder/BoardBuilderRoute.test.tsx
+++ b/src/features/board-builder/BoardBuilderRoute.test.tsx
@@ -37,7 +37,7 @@ const makeWrapper = (qc: QueryClient, initialPath: string): (() => JSX.Element) 
 };
 
 describe('BoardBuilderRoute', () => {
-  it('renders BoardNotFound when useBoard errors (RLS-blocked row)', async () => {
+  it('renders the not-found variant when useBoard hits PGRST116 (RLS-hidden row)', async () => {
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     qc.setQueryData(boardsQueryKey, []);
     singleMock.mockResolvedValueOnce({
@@ -49,6 +49,30 @@ describe('BoardBuilderRoute', () => {
     await waitFor(() => {
       expect(screen.getByText('Board not found')).toBeInTheDocument();
     });
-    expect(screen.getByText('Back to boards')).toBeInTheDocument();
+    // No Retry button on the not-found variant — retrying a 404 is pointless.
+    expect(screen.queryByText('Retry')).not.toBeInTheDocument();
+  });
+
+  it('renders the error variant with Retry for non-PGRST116 errors', async () => {
+    // useBoard's retry policy retries non-PGRST116 errors up to 3× with
+    // default backoff. Speed that up with retryDelay: 0 and persist the
+    // mock response so every attempt sees the same failure.
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, retryDelay: 0 } },
+    });
+    qc.setQueryData(boardsQueryKey, []);
+    singleMock.mockResolvedValue({
+      data: null,
+      error: { message: 'network error', code: 'NETWORK' },
+    });
+    const Wrap = makeWrapper(qc, '/boards/00000000-0000-0000-0000-000000000000/edit');
+    render(<Wrap />);
+    await waitFor(
+      () => {
+        expect(screen.getByText('Could not load board')).toBeInTheDocument();
+      },
+      { timeout: 2000 },
+    );
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
   });
 });

--- a/src/features/board-builder/BoardBuilderRoute.tsx
+++ b/src/features/board-builder/BoardBuilderRoute.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import { PictoPicker } from '@/features/pictogram-picker/PictoPicker';
 import { useBoard } from '@/lib/queries/boards';
+import { supabase } from '@/lib/supabase';
 
 import { BoardBuilder } from './BoardBuilder';
 
@@ -34,6 +35,10 @@ export const BoardBuilderRoute = (): JSX.Element | null => {
         onBack={() => navigate('/')}
         onOpenPicker={openPicker}
         onPreview={(kind) => navigate(`/kid/${kind}/${board.id}`)}
+        onKidMode={() => navigate(`/kid/${board.kind}/${board.id}`)}
+        onSignOut={() => {
+          void supabase.auth.signOut();
+        }}
       />
       {pickerOpen && <PictoPicker onClose={closePicker} />}
     </>

--- a/src/features/board-builder/BoardBuilderRoute.tsx
+++ b/src/features/board-builder/BoardBuilderRoute.tsx
@@ -2,7 +2,7 @@ import { type JSX, useCallback } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import { PictoPicker } from '@/features/pictogram-picker/PictoPicker';
-import { useBoard, useBoards } from '@/lib/queries/boards';
+import { isNotFoundError, useBoard, useBoards } from '@/lib/queries/boards';
 import { supabase } from '@/lib/supabase';
 import { useUserInitial } from '@/lib/useUserInitial';
 
@@ -31,16 +31,26 @@ export const BoardBuilderRoute = (): JSX.Element | null => {
     setSearchParams(next, { replace: true });
   }, [searchParams, setSearchParams]);
 
-  // `.single()` in useBoard returns a 406 when RLS hides the row (e.g. a
-  // pasted URL from another account). Treat any settled query without a
-  // row as not-found rather than rendering a blank screen.
+  // `.single()` raises PGRST116 when a row is missing or hidden by RLS
+  // (e.g. a pasted URL from another account) — terminal, surface as
+  // not-found. Any other error is transient (network, Supabase down);
+  // offer Retry rather than mis-attributing to a not-found.
   if (boardQuery.isError || (boardQuery.isSuccess && !board)) {
+    const variant =
+      isNotFoundError(boardQuery.error) || (boardQuery.isSuccess && !board)
+        ? 'not-found'
+        : 'error';
     const fallbackKid = boardsQuery.data?.find((b) => b.kind === 'sequence');
     return (
       <BoardNotFound
+        variant={variant}
         onBack={() => navigate('/')}
+        onRetry={() => void boardQuery.refetch()}
         onKidMode={() => {
           if (fallbackKid) navigate(`/kid/sequence/${fallbackKid.id}`);
+        }}
+        onSignOut={() => {
+          void supabase.auth.signOut();
         }}
         userInitial={userInitial}
       />

--- a/src/features/board-builder/BoardBuilderRoute.tsx
+++ b/src/features/board-builder/BoardBuilderRoute.tsx
@@ -2,14 +2,17 @@ import { type JSX, useCallback } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import { PictoPicker } from '@/features/pictogram-picker/PictoPicker';
-import { useBoard } from '@/lib/queries/boards';
+import { useBoard, useBoards } from '@/lib/queries/boards';
 import { supabase } from '@/lib/supabase';
 
 import { BoardBuilder } from './BoardBuilder';
+import { BoardNotFound } from './BoardNotFound';
 
 export const BoardBuilderRoute = (): JSX.Element | null => {
   const { boardId = '' } = useParams();
-  const { data: board } = useBoard(boardId);
+  const boardQuery = useBoard(boardId);
+  const boardsQuery = useBoards();
+  const board = boardQuery.data;
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const pickerOpen = searchParams.get('picker') === '1';
@@ -25,6 +28,21 @@ export const BoardBuilderRoute = (): JSX.Element | null => {
     next.delete('picker');
     setSearchParams(next, { replace: true });
   }, [searchParams, setSearchParams]);
+
+  // `.single()` in useBoard returns a 406 when RLS hides the row (e.g. a
+  // pasted URL from another account). Treat any settled query without a
+  // row as not-found rather than rendering a blank screen.
+  if (boardQuery.isError || (boardQuery.isSuccess && !board)) {
+    const fallbackKid = boardsQuery.data?.find((b) => b.kind === 'sequence');
+    return (
+      <BoardNotFound
+        onBack={() => navigate('/')}
+        onKidMode={() => {
+          if (fallbackKid) navigate(`/kid/sequence/${fallbackKid.id}`);
+        }}
+      />
+    );
+  }
 
   if (!board) return null;
 

--- a/src/features/board-builder/BoardBuilderRoute.tsx
+++ b/src/features/board-builder/BoardBuilderRoute.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { PictoPicker } from '@/features/pictogram-picker/PictoPicker';
 import { useBoard, useBoards } from '@/lib/queries/boards';
 import { supabase } from '@/lib/supabase';
+import { useUserInitial } from '@/lib/useUserInitial';
 
 import { BoardBuilder } from './BoardBuilder';
 import { BoardNotFound } from './BoardNotFound';
@@ -16,6 +17,7 @@ export const BoardBuilderRoute = (): JSX.Element | null => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const pickerOpen = searchParams.get('picker') === '1';
+  const userInitial = useUserInitial();
 
   const openPicker = useCallback((): void => {
     const next = new URLSearchParams(searchParams);
@@ -40,6 +42,7 @@ export const BoardBuilderRoute = (): JSX.Element | null => {
         onKidMode={() => {
           if (fallbackKid) navigate(`/kid/sequence/${fallbackKid.id}`);
         }}
+        userInitial={userInitial}
       />
     );
   }
@@ -57,6 +60,7 @@ export const BoardBuilderRoute = (): JSX.Element | null => {
         onSignOut={() => {
           void supabase.auth.signOut();
         }}
+        userInitial={userInitial}
       />
       {pickerOpen && <PictoPicker onClose={closePicker} />}
     </>

--- a/src/features/board-builder/BoardNotFound.module.css
+++ b/src/features/board-builder/BoardNotFound.module.css
@@ -1,0 +1,22 @@
+.wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+  padding-top: 48px;
+  max-width: 520px;
+}
+
+.title {
+  font-size: 28px;
+  font-weight: 800;
+  color: var(--tal-ink);
+  margin: 0;
+}
+
+.body {
+  font-size: 16px;
+  color: var(--tal-ink-soft);
+  margin: 0;
+  line-height: 1.5;
+}

--- a/src/features/board-builder/BoardNotFound.module.css
+++ b/src/features/board-builder/BoardNotFound.module.css
@@ -20,3 +20,9 @@
   margin: 0;
   line-height: 1.5;
 }
+
+.actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 4px;
+}

--- a/src/features/board-builder/BoardNotFound.tsx
+++ b/src/features/board-builder/BoardNotFound.tsx
@@ -1,0 +1,32 @@
+import type { JSX } from 'react';
+
+import { ParentShell } from '@/layouts/ParentShell';
+import { supabase } from '@/lib/supabase';
+import { Button } from '@/ui/Button/Button';
+
+import styles from './BoardNotFound.module.css';
+
+interface BoardNotFoundProps {
+  onBack: () => void;
+  onKidMode: () => void;
+}
+
+export const BoardNotFound = ({ onBack, onKidMode }: BoardNotFoundProps): JSX.Element => (
+  <ParentShell
+    active="home"
+    onKidMode={onKidMode}
+    onSignOut={() => {
+      void supabase.auth.signOut();
+    }}
+  >
+    <div className={styles.wrap}>
+      <h1 className={styles.title}>Board not found</h1>
+      <p className={styles.body}>
+        This board doesn&rsquo;t exist, or it belongs to another account.
+      </p>
+      <Button variant="primary" onClick={onBack}>
+        Back to boards
+      </Button>
+    </div>
+  </ParentShell>
+);

--- a/src/features/board-builder/BoardNotFound.tsx
+++ b/src/features/board-builder/BoardNotFound.tsx
@@ -1,38 +1,62 @@
 import type { JSX } from 'react';
 
 import { ParentShell } from '@/layouts/ParentShell';
-import { supabase } from '@/lib/supabase';
 import { Button } from '@/ui/Button/Button';
 
 import styles from './BoardNotFound.module.css';
 
+export type BoardLoadFailureVariant = 'not-found' | 'error';
+
 interface BoardNotFoundProps {
+  variant: BoardLoadFailureVariant;
   onBack: () => void;
+  onRetry?: () => void;
   onKidMode: () => void;
+  onSignOut: () => void;
   userInitial?: string | undefined;
 }
 
+const COPY: Record<BoardLoadFailureVariant, { title: string; body: string }> = {
+  'not-found': {
+    title: 'Board not found',
+    body: 'This board doesn’t exist, or it belongs to another account.',
+  },
+  error: {
+    title: 'Could not load board',
+    body: 'We couldn’t reach the server. Check your connection and try again.',
+  },
+};
+
 export const BoardNotFound = ({
+  variant,
   onBack,
+  onRetry,
   onKidMode,
+  onSignOut,
   userInitial,
-}: BoardNotFoundProps): JSX.Element => (
-  <ParentShell
-    active="home"
-    onKidMode={onKidMode}
-    onSignOut={() => {
-      void supabase.auth.signOut();
-    }}
-    userInitial={userInitial}
-  >
-    <div className={styles.wrap}>
-      <h1 className={styles.title}>Board not found</h1>
-      <p className={styles.body}>
-        This board doesn&rsquo;t exist, or it belongs to another account.
-      </p>
-      <Button variant="primary" onClick={onBack}>
-        Back to boards
-      </Button>
-    </div>
-  </ParentShell>
-);
+}: BoardNotFoundProps): JSX.Element => {
+  const { title, body } = COPY[variant];
+  return (
+    <ParentShell
+      active="home"
+      onKidMode={onKidMode}
+      onSignOut={onSignOut}
+      userInitial={userInitial}
+    >
+      <div className={styles.wrap}>
+        <h1 className={styles.title}>{title}</h1>
+        <p className={styles.body}>{body}</p>
+        <div className={styles.actions}>
+          <Button variant="primary" onClick={onBack}>
+            Back to boards
+          </Button>
+          {variant === 'error' && onRetry && (
+            <Button variant="ghost" onClick={onRetry}>
+              Retry
+            </Button>
+          )}
+        </div>
+      </div>
+    </ParentShell>
+  );
+};

--- a/src/features/board-builder/BoardNotFound.tsx
+++ b/src/features/board-builder/BoardNotFound.tsx
@@ -9,15 +9,21 @@ import styles from './BoardNotFound.module.css';
 interface BoardNotFoundProps {
   onBack: () => void;
   onKidMode: () => void;
+  userInitial?: string | undefined;
 }
 
-export const BoardNotFound = ({ onBack, onKidMode }: BoardNotFoundProps): JSX.Element => (
+export const BoardNotFound = ({
+  onBack,
+  onKidMode,
+  userInitial,
+}: BoardNotFoundProps): JSX.Element => (
   <ParentShell
     active="home"
     onKidMode={onKidMode}
     onSignOut={() => {
       void supabase.auth.signOut();
     }}
+    userInitial={userInitial}
   >
     <div className={styles.wrap}>
       <h1 className={styles.title}>Board not found</h1>

--- a/src/features/parent-home/BoardCard.tsx
+++ b/src/features/parent-home/BoardCard.tsx
@@ -38,7 +38,7 @@ export const BoardCard = ({ board, onClick }: BoardCardProps): JSX.Element => {
       <div className={styles.preview}>
         {previewSteps.map((p, i) => (
           <Fragment key={`${p.id}-${i}`}>
-            <PictoTile picto={p} size={64} showLabel={false} />
+            <PictoTile picto={p} size={64} showLabel={false} as="div" />
             {i < previewSteps.length - 1 && (
               <span className={styles.previewArrow}>
                 <StepArrowIcon size={14} />

--- a/src/features/parent-home/ParentHome.tsx
+++ b/src/features/parent-home/ParentHome.tsx
@@ -17,6 +17,7 @@ interface ParentHomeProps {
   onOpenBoard?: (id: string) => void;
   onKidMode?: () => void;
   onSignOut?: () => void;
+  userInitial?: string | undefined;
 }
 
 export const ParentHome = ({
@@ -24,6 +25,7 @@ export const ParentHome = ({
   onOpenBoard,
   onKidMode,
   onSignOut,
+  userInitial,
 }: ParentHomeProps): JSX.Element => {
   const boardsQuery = useBoards();
   const pictogramsBySlug = usePictogramsBySlug();
@@ -35,6 +37,7 @@ export const ParentHome = ({
       active="home"
       {...(onKidMode ? { onKidMode } : {})}
       {...(onSignOut ? { onSignOut } : {})}
+      userInitial={userInitial}
       title={`${kidName}'s boards`}
       subtitle="Pick a board to edit, or start a new one."
       right={

--- a/src/features/parent-home/ParentHomeRoute.tsx
+++ b/src/features/parent-home/ParentHomeRoute.tsx
@@ -3,12 +3,14 @@ import { useNavigate } from 'react-router-dom';
 
 import { useBoards } from '@/lib/queries/boards';
 import { supabase } from '@/lib/supabase';
+import { useUserInitial } from '@/lib/useUserInitial';
 
 import { ParentHome } from './ParentHome';
 
 export const ParentHomeRoute = (): JSX.Element => {
   const navigate = useNavigate();
   const boardsQuery = useBoards();
+  const userInitial = useUserInitial();
 
   // Always expose onKidMode once boards have loaded — during the initial
   // fetch we route to a stable placeholder that'll redirect as soon as the
@@ -25,6 +27,7 @@ export const ParentHomeRoute = (): JSX.Element => {
       onSignOut={() => {
         void supabase.auth.signOut();
       }}
+      userInitial={userInitial}
     />
   );
 };

--- a/src/layouts/ParentShell.tsx
+++ b/src/layouts/ParentShell.tsx
@@ -29,7 +29,8 @@ interface ParentShellProps {
   title?: string;
   subtitle?: string;
   right?: ReactNode;
-  userInitial?: string;
+  /** Undefined renders a blank avatar while the session is loading. */
+  userInitial?: string | undefined;
   children: ReactNode;
 }
 
@@ -41,7 +42,7 @@ export const ParentShell = ({
   title,
   subtitle,
   right,
-  userInitial = 'M',
+  userInitial,
   children,
 }: ParentShellProps): JSX.Element => (
   <div className={styles.shell}>
@@ -77,7 +78,7 @@ export const ParentShell = ({
           title="Sign out"
           aria-label="Sign out"
         >
-          {userInitial}
+          {userInitial ?? ''}
         </button>
       </div>
     </aside>

--- a/src/lib/queries/boards.test.ts
+++ b/src/lib/queries/boards.test.ts
@@ -10,6 +10,7 @@ const row = (overrides: Partial<Row> = {}): Row => ({
   id: 'morning',
   owner_id: 'owner-uuid',
   kid_id: 'liam',
+  slug: null,
   name: 'Morning routine',
   kind: 'sequence',
   labels_visible: true,

--- a/src/lib/queries/boards.ts
+++ b/src/lib/queries/boards.ts
@@ -47,8 +47,24 @@ const fetchBoard = async (id: string): Promise<Board> => {
   return rowToBoard(data);
 };
 
+/**
+ * PGRST116 = "JSON object requested, multiple (or no) rows returned" — raised
+ * by `.single()` when a board doesn't exist or is hidden by RLS. It's
+ * terminal: retrying the same UUID will produce the same answer.
+ */
+export const isNotFoundError = (err: unknown): boolean =>
+  typeof err === 'object' && err !== null && 'code' in err && err.code === 'PGRST116';
+
 export const useBoards = (): UseQueryResult<Board[]> =>
   useQuery({ queryKey: boardsQueryKey, queryFn: fetchBoards });
 
 export const useBoard = (id: string): UseQueryResult<Board> =>
-  useQuery({ queryKey: boardQueryKey(id), queryFn: () => fetchBoard(id), enabled: id !== '' });
+  useQuery({
+    queryKey: boardQueryKey(id),
+    queryFn: () => fetchBoard(id),
+    enabled: id !== '',
+    // Skip retries on PGRST116; retry transient network errors up to 3× (the
+    // React Query default). Keeps not-found instant while still shielding
+    // against flaky connections.
+    retry: (failureCount, error) => !isNotFoundError(error) && failureCount < 3,
+  });

--- a/src/lib/queries/pictograms.test.ts
+++ b/src/lib/queries/pictograms.test.ts
@@ -10,6 +10,7 @@ type Row = Database['public']['Tables']['pictograms']['Row'];
 const illusRow = (): Row => ({
   id: 'wakeup',
   owner_id: 'owner-uuid',
+  slug: null,
   label: 'Wake up',
   style: 'illus',
   glyph: 'sun',
@@ -22,6 +23,7 @@ const illusRow = (): Row => ({
 const photoRow = (overrides: Partial<Row> = {}): Row => ({
   id: 'park',
   owner_id: 'owner-uuid',
+  slug: null,
   label: 'Park',
   style: 'photo',
   glyph: null,
@@ -77,6 +79,8 @@ describe('pictogramToInsert round-trip', () => {
     const insert = pictogramToInsert(original, 'owner-uuid');
     const row: Row = {
       ...insert,
+      id: insert.id ?? 'bed',
+      slug: insert.slug ?? null,
       audio_path: insert.audio_path ?? null,
       image_path: insert.image_path ?? null,
       glyph: insert.glyph ?? null,

--- a/src/lib/useUserInitial.ts
+++ b/src/lib/useUserInitial.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+import { supabase } from './supabase';
+
+/**
+ * Returns the uppercase first character of the signed-in user's email, or
+ * `undefined` during the initial session fetch. Subscribes to auth changes
+ * so it updates on sign-in / sign-out without a remount.
+ */
+export const useUserInitial = (): string | undefined => {
+  const [initial, setInitial] = useState<string | undefined>();
+  useEffect(() => {
+    const toInitial = (email: string | undefined): string | undefined =>
+      email && email.length > 0 ? email[0]!.toUpperCase() : undefined;
+    let cancelled = false;
+    void supabase.auth.getSession().then(({ data }) => {
+      if (!cancelled) setInitial(toInitial(data.session?.user.email));
+    });
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+      setInitial(toInitial(session?.user.email));
+    });
+    return () => {
+      cancelled = true;
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+  return initial;
+};

--- a/src/lib/useUserInitial.ts
+++ b/src/lib/useUserInitial.ts
@@ -15,9 +15,16 @@ export const useUserInitial = (): string | undefined => {
       return first ? first.toUpperCase() : undefined;
     };
     let cancelled = false;
-    void supabase.auth.getSession().then(({ data }) => {
-      if (!cancelled) setInitial(toInitial(data.session?.user.email));
-    });
+    supabase.auth
+      .getSession()
+      .then(({ data }) => {
+        if (!cancelled) setInitial(toInitial(data.session?.user.email));
+      })
+      .catch(() => {
+        // Avatar is cosmetic; a blank circle is fine. AuthGate surfaces the
+        // real error. onAuthStateChange will still fire once the session
+        // arrives via a later network recovery.
+      });
     const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
       setInitial(toInitial(session?.user.email));
     });

--- a/src/lib/useUserInitial.ts
+++ b/src/lib/useUserInitial.ts
@@ -10,8 +10,10 @@ import { supabase } from './supabase';
 export const useUserInitial = (): string | undefined => {
   const [initial, setInitial] = useState<string | undefined>();
   useEffect(() => {
-    const toInitial = (email: string | undefined): string | undefined =>
-      email && email.length > 0 ? email[0]!.toUpperCase() : undefined;
+    const toInitial = (email: string | undefined): string | undefined => {
+      const first = email?.[0];
+      return first ? first.toUpperCase() : undefined;
+    };
     let cancelled = false;
     void supabase.auth.getSession().then(({ data }) => {
       if (!cancelled) setInitial(toInitial(data.session?.user.email));

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1,4 +1,3 @@
-Connecting to db 5432
 export type Json =
   | string
   | number

--- a/src/ui/PictoTile/PictoTile.test.tsx
+++ b/src/ui/PictoTile/PictoTile.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { Pictogram } from '@/types/domain';
+
+import { PictoTile } from './PictoTile';
+
+const picto: Pictogram = {
+  id: 'apple',
+  label: 'Apple',
+  style: 'illus',
+  glyph: 'apple',
+  tint: 'oklch(90% 0.06 90)',
+};
+
+describe('PictoTile', () => {
+  it('renders as a <button> by default', () => {
+    render(<PictoTile picto={picto} />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('renders as a <div> with no inner button when as="div"', () => {
+    const { container } = render(<PictoTile picto={picto} as="div" />);
+    expect(container.querySelector('button')).toBeNull();
+    expect(container.firstChild?.nodeName).toBe('DIV');
+  });
+
+  it('shows the label when showLabel is not explicitly disabled', () => {
+    render(<PictoTile picto={picto} />);
+    expect(screen.getByText('Apple')).toBeInTheDocument();
+  });
+});

--- a/src/ui/PictoTile/PictoTile.tsx
+++ b/src/ui/PictoTile/PictoTile.tsx
@@ -10,11 +10,14 @@ interface PictoTileProps {
   size?: number;
   showLabel?: boolean;
   selected?: boolean;
+  /** Only wired when `as === 'button'` (the default). Ignored on a div. */
   onClick?: MouseEventHandler<HTMLButtonElement>;
   /**
    * Outer element. Defaults to 'button' (interactive tile). Use 'div' when
    * the tile is rendered inside an existing interactive element (e.g. the
    * preview strip on a BoardCard), to avoid nested-button invalid HTML.
+   * `onClick` is intentionally not forwarded to the div — the outer
+   * interactive ancestor is expected to own the click.
    */
   as?: 'button' | 'div';
   /** Button-level style override (layout only — don't theme here). */

--- a/src/ui/PictoTile/PictoTile.tsx
+++ b/src/ui/PictoTile/PictoTile.tsx
@@ -11,6 +11,12 @@ interface PictoTileProps {
   showLabel?: boolean;
   selected?: boolean;
   onClick?: MouseEventHandler<HTMLButtonElement>;
+  /**
+   * Outer element. Defaults to 'button' (interactive tile). Use 'div' when
+   * the tile is rendered inside an existing interactive element (e.g. the
+   * preview strip on a BoardCard), to avoid nested-button invalid HTML.
+   */
+  as?: 'button' | 'div';
   /** Button-level style override (layout only — don't theme here). */
   style?: CSSProperties;
 }
@@ -21,21 +27,31 @@ export const PictoTile = ({
   showLabel = true,
   selected = false,
   onClick,
+  as = 'button',
   style,
 }: PictoTileProps): JSX.Element => {
   const labelSize = Math.max(13, size * 0.11);
-  const buttonStyle: CSSProperties = { width: size, ...style };
-  return (
-    <button type="button" className={styles.tile} onClick={onClick} style={buttonStyle}>
+  const tileStyle: CSSProperties = { width: size, ...style };
+  const body = (
+    <>
       <PictogramMedia picto={picto} size={size} selected={selected} />
       {showLabel && (
-        <span
-          className={styles.label}
-          style={{ fontSize: labelSize, maxWidth: size }}
-        >
+        <span className={styles.label} style={{ fontSize: labelSize, maxWidth: size }}>
           {picto.label}
         </span>
       )}
+    </>
+  );
+  if (as === 'div') {
+    return (
+      <div className={styles.tile} style={tileStyle}>
+        {body}
+      </div>
+    );
+  }
+  return (
+    <button type="button" className={styles.tile} onClick={onClick} style={tileStyle}>
+      {body}
     </button>
   );
 };


### PR DESCRIPTION
## Summary

Post-E2E-sweep polish pass. Closes 8 GitHub issues (seven fixes + one duplicate) in small, independent commits. No architectural work; all changes are surgical.

- **#4** closed as duplicate of #11.
- **#11** — PictoTile now accepts `as: 'button' | 'div'`; BoardCard passes `as='div'` to avoid invalid nested `<button>`.
- **#12** — BoardBuilder plumbs `onKidMode` + `onSignOut` through to ParentShell (mirrors ParentHomeRoute).
- **#14** — `BoardBuilderRoute` renders a new `BoardNotFound` screen when `useBoard()` errors (PGRST116 from RLS-blocked row) or returns no row, instead of going blank.
- **#13** + **#10** — plan wording updated to match code (PIN fires on exit, not entry). Both closed — current code already matches the desired behaviour.
- **#6** — sidebar avatar reads the first letter of the signed-in user's email via new `useUserInitial` hook; no more hardcoded 'M'.
- **#5** — AuthGate now has a proper error branch with a Retry button; previously spun forever on `getSession()` rejection.

Also includes:
- **Cleanup** — stale `Connecting to db 5432` prefix in `src/types/supabase.ts` (captured from `supabase gen types typescript` stdout) was masking tsc's own parse error, hiding three pre-existing test type drifts on the `slug` column. Fixed in its own commit.
- **gitignore** — `CLAUDE.md` / `GEMINI.md` added (per-machine agent instructions).

## Structural-score gate

Per plan: zero painful structural fixes surfaced. The two error-UX fixes (#14 in-session, #5 pre-auth) landed in different shapes because they operate in different contexts — no shared abstraction emerged. Commented on #8 with the rationale; left it open for the user's call.

## Verification

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (`--max-warnings 0`)
- [x] `npm test` — 46/46 green (was 26 pre-batch; added 3 new test files covering PictoTile `as=div`, BoardBuilderRoute not-found path, AuthGate error path)

## Test plan (manual, 1194×834 Chrome)

- [ ] ParentHome: no DOM-nesting warning in console when rendering board cards.
- [ ] BoardBuilder: KID button navigates to kid mode; sign-out avatar returns to /login.
- [ ] `/boards/<random-uuid>/edit`: shows "Board not found" screen with back link.
- [ ] First kid-mode entry has no PIN prompt; exit attempt triggers PIN setup.
- [ ] Sidebar avatar shows the logged-in email's first letter (not "M").
- [ ] Point `VITE_SUPABASE_URL` at a dead host → AuthGate shows error screen with Retry (not a forever-spinner).