### PR TITLE
Auto-launch into last kid-mode board + AuthGate loading copy

### DIFF
--- a/src/app/AuthGate.module.css
+++ b/src/app/AuthGate.module.css
@@ -9,6 +9,42 @@
   height: 100vh;
 }
 
+.loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  height: 100vh;
+}
+
+.loadingBody {
+  font-size: 15px;
+  color: var(--tal-ink-soft);
+  margin: 0;
+}
+
+.spinner {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 3px solid var(--tal-line);
+  border-top-color: var(--tal-sage);
+  animation: tal-auth-spin 0.9s linear infinite;
+}
+
+@keyframes tal-auth-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation-duration: 2.5s;
+  }
+}
+
 .errorTitle {
   font-size: 24px;
   font-weight: 800;

--- a/src/app/AuthGate.test.tsx
+++ b/src/app/AuthGate.test.tsx
@@ -23,6 +23,17 @@ vi.mock('@/features/login/Login', () => ({
 const { AuthGate } = await import('./AuthGate');
 
 describe('AuthGate', () => {
+  it('shows the loading copy while getSession is pending', () => {
+    getSessionMock.mockReturnValueOnce(new Promise(() => undefined));
+    render(
+      <AuthGate>
+        <div>app body</div>
+      </AuthGate>,
+    );
+    expect(screen.getByText('Signing in…')).toBeInTheDocument();
+    expect(screen.queryByText('app body')).not.toBeInTheDocument();
+  });
+
   it('shows an error screen with Retry when getSession rejects', async () => {
     getSessionMock.mockRejectedValueOnce(new Error('fetch failed: net::ERR'));
     render(

--- a/src/app/AuthGate.test.tsx
+++ b/src/app/AuthGate.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { JSX } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 const getSessionMock = vi.fn();
@@ -30,7 +31,7 @@ describe('AuthGate', () => {
         <div>app body</div>
       </AuthGate>,
     );
-    expect(screen.getByText('Signing in…')).toBeInTheDocument();
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
     expect(screen.queryByText('app body')).not.toBeInTheDocument();
   });
 

--- a/src/app/AuthGate.tsx
+++ b/src/app/AuthGate.tsx
@@ -47,11 +47,18 @@ export const AuthGate = ({ children }: { children: ReactNode }): JSX.Element => 
 
   const retry = useCallback(() => setRetryCount((n) => n + 1), []);
 
-  if (state.status === 'loading') return <div className="tal" />;
+  if (state.status === 'loading') return <AuthGateLoading />;
   if (state.status === 'error') return <AuthGateError message={state.message} onRetry={retry} />;
   if (state.status === 'out') return <Login />;
   return <SessionProvider session={state.session}>{children}</SessionProvider>;
 };
+
+const AuthGateLoading = (): JSX.Element => (
+  <div className={`tal ${styles.loading}`}>
+    <div className={styles.spinner} aria-hidden="true" />
+    <p className={styles.loadingBody}>Signing in…</p>
+  </div>
+);
 
 const AuthGateError = ({
   message,

--- a/src/app/AuthGate.tsx
+++ b/src/app/AuthGate.tsx
@@ -56,7 +56,7 @@ export const AuthGate = ({ children }: { children: ReactNode }): JSX.Element => 
 const AuthGateLoading = (): JSX.Element => (
   <div className={`tal ${styles.loading}`}>
     <div className={styles.spinner} aria-hidden="true" />
-    <p className={styles.loadingBody}>Signing in…</p>
+    <p className={styles.loadingBody}>Loading…</p>
   </div>
 );
 

--- a/src/features/kid-choice/KidChoiceRoute.tsx
+++ b/src/features/kid-choice/KidChoiceRoute.tsx
@@ -1,19 +1,22 @@
 import { type JSX, useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
 
 import { KidModeGate } from '@/features/pin-gate/KidModeGate';
-import { setLastBoard } from '@/lib/lastBoard';
-import { useBoard } from '@/lib/queries/boards';
+import { clearLastBoard, setLastBoard } from '@/lib/lastBoard';
+import { isNotFoundError, useBoard } from '@/lib/queries/boards';
 
 import { KidChoice } from './KidChoice';
 
 export const KidChoiceRoute = (): JSX.Element | null => {
   const { boardId = '' } = useParams();
-  const { data: board } = useBoard(boardId);
+  const { data: board, error } = useBoard(boardId);
   const navigate = useNavigate();
+  const stale = isNotFoundError(error);
   useEffect(() => {
-    if (board) setLastBoard({ id: board.id, kind: 'choice' });
-  }, [board]);
+    if (board) setLastBoard({ id: board.id, kind: board.kind });
+    else if (stale) clearLastBoard();
+  }, [board, stale]);
+  if (stale) return <Navigate to="/" replace />;
   if (!board) return null;
   return (
     <KidModeGate onExitConfirmed={() => navigate(`/boards/${board.id}/edit`)}>

--- a/src/features/kid-choice/KidChoiceRoute.tsx
+++ b/src/features/kid-choice/KidChoiceRoute.tsx
@@ -1,7 +1,8 @@
-import type { JSX } from 'react';
+import { type JSX, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { KidModeGate } from '@/features/pin-gate/KidModeGate';
+import { setLastBoard } from '@/lib/lastBoard';
 import { useBoard } from '@/lib/queries/boards';
 
 import { KidChoice } from './KidChoice';
@@ -10,6 +11,9 @@ export const KidChoiceRoute = (): JSX.Element | null => {
   const { boardId = '' } = useParams();
   const { data: board } = useBoard(boardId);
   const navigate = useNavigate();
+  useEffect(() => {
+    if (board) setLastBoard({ id: board.id, kind: 'choice' });
+  }, [board]);
   if (!board) return null;
   return (
     <KidModeGate onExitConfirmed={() => navigate(`/boards/${board.id}/edit`)}>

--- a/src/features/kid-sequence/KidSequenceRoute.test.tsx
+++ b/src/features/kid-sequence/KidSequenceRoute.test.tsx
@@ -1,0 +1,79 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { JSX } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TestSessionProvider } from '@/app/session.test-utils';
+import { boardsQueryKey } from '@/lib/queries/boards';
+
+const singleMock = vi.fn();
+const eqMock = vi.fn(() => ({ single: singleMock }));
+const selectMock = vi.fn(() => ({
+  eq: eqMock,
+  order: vi.fn(() => Promise.resolve({ data: [], error: null })),
+}));
+const fromMock = vi.fn(() => ({ select: selectMock }));
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: () => fromMock(),
+    auth: {
+      signOut: vi.fn(),
+      getSession: vi.fn(() => Promise.resolve({ data: { session: null } })),
+      onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+    },
+  },
+}));
+
+const { KidSequenceRoute } = await import('./KidSequenceRoute');
+
+const makeWrap = (initialPath: string, qc: QueryClient): (() => JSX.Element) => {
+  return (): JSX.Element => (
+    <TestSessionProvider>
+      <QueryClientProvider client={qc}>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <Routes>
+            <Route path="/kid/sequence/:boardId" element={<KidSequenceRoute />} />
+            <Route path="/" element={<div data-testid="parent-home" />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </TestSessionProvider>
+  );
+};
+
+describe('KidSequenceRoute stale-board recovery', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it('redirects to / and clears the last-board record when the board is gone (PGRST116)', async () => {
+    localStorage.setItem(
+      'talrum:last-board',
+      JSON.stringify({ id: '00000000-0000-0000-0000-000000000000', kind: 'sequence' }),
+    );
+    // Pre-set the session-flag so the / route doesn't try to redirect us
+    // back into the (now-missing) board on landing.
+    sessionStorage.setItem('talrum:auto-launched', '1');
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    qc.setQueryData(boardsQueryKey, []);
+    singleMock.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'JSON object requested, multiple (or no) rows returned', code: 'PGRST116' },
+    });
+
+    const Wrap = makeWrap('/kid/sequence/00000000-0000-0000-0000-000000000000', qc);
+    render(<Wrap />);
+    await waitFor(() => {
+      expect(screen.getByTestId('parent-home')).toBeInTheDocument();
+    });
+    expect(localStorage.getItem('talrum:last-board')).toBeNull();
+  });
+});

--- a/src/features/kid-sequence/KidSequenceRoute.tsx
+++ b/src/features/kid-sequence/KidSequenceRoute.tsx
@@ -1,19 +1,22 @@
 import { type JSX, useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
 
 import { KidModeGate } from '@/features/pin-gate/KidModeGate';
-import { setLastBoard } from '@/lib/lastBoard';
-import { useBoard } from '@/lib/queries/boards';
+import { clearLastBoard, setLastBoard } from '@/lib/lastBoard';
+import { isNotFoundError, useBoard } from '@/lib/queries/boards';
 
 import { KidSequence } from './KidSequence';
 
 export const KidSequenceRoute = (): JSX.Element | null => {
   const { boardId = '' } = useParams();
-  const { data: board } = useBoard(boardId);
+  const { data: board, error } = useBoard(boardId);
   const navigate = useNavigate();
+  const stale = isNotFoundError(error);
   useEffect(() => {
-    if (board) setLastBoard({ id: board.id, kind: 'sequence' });
-  }, [board]);
+    if (board) setLastBoard({ id: board.id, kind: board.kind });
+    else if (stale) clearLastBoard();
+  }, [board, stale]);
+  if (stale) return <Navigate to="/" replace />;
   if (!board) return null;
   return (
     <KidModeGate onExitConfirmed={() => navigate(`/boards/${board.id}/edit`)}>

--- a/src/features/kid-sequence/KidSequenceRoute.tsx
+++ b/src/features/kid-sequence/KidSequenceRoute.tsx
@@ -1,7 +1,8 @@
-import type { JSX } from 'react';
+import { type JSX, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { KidModeGate } from '@/features/pin-gate/KidModeGate';
+import { setLastBoard } from '@/lib/lastBoard';
 import { useBoard } from '@/lib/queries/boards';
 
 import { KidSequence } from './KidSequence';
@@ -10,6 +11,9 @@ export const KidSequenceRoute = (): JSX.Element | null => {
   const { boardId = '' } = useParams();
   const { data: board } = useBoard(boardId);
   const navigate = useNavigate();
+  useEffect(() => {
+    if (board) setLastBoard({ id: board.id, kind: 'sequence' });
+  }, [board]);
   if (!board) return null;
   return (
     <KidModeGate onExitConfirmed={() => navigate(`/boards/${board.id}/edit`)}>

--- a/src/features/parent-home/ParentHomeRoute.test.tsx
+++ b/src/features/parent-home/ParentHomeRoute.test.tsx
@@ -1,0 +1,96 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import type { JSX } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TestSessionProvider } from '@/app/session.test-utils';
+import { boardsQueryKey } from '@/lib/queries/boards';
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: () => ({
+      select: () => ({ order: () => Promise.resolve({ data: [], error: null }) }),
+    }),
+    auth: {
+      signOut: vi.fn(),
+      getSession: vi.fn(() => Promise.resolve({ data: { session: null } })),
+      onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+    },
+  },
+}));
+
+const { ParentHomeRoute } = await import('./ParentHomeRoute');
+
+const makeWrap = (initialPath: string): (() => JSX.Element) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  qc.setQueryData(boardsQueryKey, []);
+  return (): JSX.Element => (
+    <TestSessionProvider>
+      <QueryClientProvider client={qc}>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <Routes>
+            <Route path="/" element={<ParentHomeRoute />} />
+            <Route
+              path="/kid/sequence/:boardId"
+              element={<div data-testid="kid-sequence-route" />}
+            />
+            <Route path="/kid/choice/:boardId" element={<div data-testid="kid-choice-route" />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </TestSessionProvider>
+  );
+};
+
+describe('ParentHomeRoute auto-launch', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it('renders ParentHome when no last board is recorded', () => {
+    const Wrap = makeWrap('/');
+    render(<Wrap />);
+    expect(screen.queryByTestId('kid-sequence-route')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('kid-choice-route')).not.toBeInTheDocument();
+    // ParentHome's title is rendered via ParentShell when supplied.
+    expect(screen.getByText(/Liam's boards/)).toBeInTheDocument();
+  });
+
+  it('redirects into the last sequence board on first visit per session', () => {
+    localStorage.setItem(
+      'talrum:last-board',
+      JSON.stringify({ id: 'b-seq', kind: 'sequence' }),
+    );
+    const Wrap = makeWrap('/');
+    render(<Wrap />);
+    expect(screen.getByTestId('kid-sequence-route')).toBeInTheDocument();
+  });
+
+  it('redirects into the last choice board on first visit per session', () => {
+    localStorage.setItem(
+      'talrum:last-board',
+      JSON.stringify({ id: 'b-cho', kind: 'choice' }),
+    );
+    const Wrap = makeWrap('/');
+    render(<Wrap />);
+    expect(screen.getByTestId('kid-choice-route')).toBeInTheDocument();
+  });
+
+  it('does not redirect when the session has already auto-launched', () => {
+    localStorage.setItem(
+      'talrum:last-board',
+      JSON.stringify({ id: 'b-seq', kind: 'sequence' }),
+    );
+    sessionStorage.setItem('talrum:auto-launched', '1');
+    const Wrap = makeWrap('/');
+    render(<Wrap />);
+    expect(screen.queryByTestId('kid-sequence-route')).not.toBeInTheDocument();
+    expect(screen.getByText(/Liam's boards/)).toBeInTheDocument();
+  });
+});

--- a/src/features/parent-home/ParentHomeRoute.tsx
+++ b/src/features/parent-home/ParentHomeRoute.tsx
@@ -1,6 +1,7 @@
-import type { JSX } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { type JSX, useEffect, useState } from 'react';
+import { Navigate, useNavigate } from 'react-router-dom';
 
+import { getLastBoard, hasAutoLaunched, kidPathFor, markAutoLaunched } from '@/lib/lastBoard';
 import { useBoards } from '@/lib/queries/boards';
 
 import { ParentHome } from './ParentHome';
@@ -8,6 +9,18 @@ import { ParentHome } from './ParentHome';
 export const ParentHomeRoute = (): JSX.Element => {
   const navigate = useNavigate();
   const boardsQuery = useBoards();
+  // Auto-launch into the last kid-mode board on the first parent-home visit
+  // per browser session. Subsequent visits this session (e.g. after PIN exit
+  // back to home) render ParentHome normally so the user is never trapped.
+  const [redirect] = useState(() => {
+    if (hasAutoLaunched()) return null;
+    const last = getLastBoard();
+    return last ? kidPathFor(last) : null;
+  });
+  useEffect(() => {
+    markAutoLaunched();
+  }, []);
+  if (redirect) return <Navigate to={redirect} replace />;
 
   // Always expose onKidMode once boards have loaded — during the initial
   // fetch we route to a stable placeholder that'll redirect as soon as the

--- a/src/lib/lastBoard.test.ts
+++ b/src/lib/lastBoard.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  clearLastBoard,
+  getLastBoard,
+  hasAutoLaunched,
+  kidPathFor,
+  markAutoLaunched,
+  setLastBoard,
+} from './lastBoard';
+
+describe('lastBoard', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it('returns null when nothing is stored', () => {
+    expect(getLastBoard()).toBeNull();
+  });
+
+  it('round-trips a sequence board', () => {
+    setLastBoard({ id: 'abc', kind: 'sequence' });
+    expect(getLastBoard()).toEqual({ id: 'abc', kind: 'sequence' });
+  });
+
+  it('round-trips a choice board', () => {
+    setLastBoard({ id: 'xyz', kind: 'choice' });
+    expect(getLastBoard()).toEqual({ id: 'xyz', kind: 'choice' });
+  });
+
+  it('returns null on malformed JSON', () => {
+    localStorage.setItem('talrum:last-board', '{not json');
+    expect(getLastBoard()).toBeNull();
+  });
+
+  it('returns null when stored kind is unknown', () => {
+    localStorage.setItem('talrum:last-board', JSON.stringify({ id: 'a', kind: 'unknown' }));
+    expect(getLastBoard()).toBeNull();
+  });
+
+  it('clearLastBoard removes the entry', () => {
+    setLastBoard({ id: 'a', kind: 'sequence' });
+    clearLastBoard();
+    expect(getLastBoard()).toBeNull();
+  });
+
+  it('auto-launch flag flips after marking', () => {
+    expect(hasAutoLaunched()).toBe(false);
+    markAutoLaunched();
+    expect(hasAutoLaunched()).toBe(true);
+  });
+
+  it('kidPathFor builds the correct route', () => {
+    expect(kidPathFor({ id: 'b1', kind: 'sequence' })).toBe('/kid/sequence/b1');
+    expect(kidPathFor({ id: 'b2', kind: 'choice' })).toBe('/kid/choice/b2');
+  });
+});

--- a/src/lib/lastBoard.ts
+++ b/src/lib/lastBoard.ts
@@ -1,0 +1,66 @@
+import type { BoardKind } from '@/types/domain';
+
+const STORAGE_KEY = 'talrum:last-board';
+const SESSION_KEY = 'talrum:auto-launched';
+
+interface LastBoard {
+  id: string;
+  kind: BoardKind;
+}
+
+const isBoardKind = (v: unknown): v is BoardKind => v === 'sequence' || v === 'choice';
+
+export const getLastBoard = (): LastBoard | null => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      'id' in parsed &&
+      'kind' in parsed &&
+      typeof (parsed as { id: unknown }).id === 'string' &&
+      isBoardKind((parsed as { kind: unknown }).kind)
+    ) {
+      return parsed as LastBoard;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+export const setLastBoard = (board: LastBoard): void => {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(board));
+  } catch {
+    // ignore quota / privacy mode errors — feature is best-effort
+  }
+};
+
+export const clearLastBoard = (): void => {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+};
+
+export const hasAutoLaunched = (): boolean => {
+  try {
+    return sessionStorage.getItem(SESSION_KEY) === '1';
+  } catch {
+    return true;
+  }
+};
+
+export const markAutoLaunched = (): void => {
+  try {
+    sessionStorage.setItem(SESSION_KEY, '1');
+  } catch {
+    // ignore
+  }
+};
+
+export const kidPathFor = (board: LastBoard): string => `/kid/${board.kind}/${board.id}`;


### PR DESCRIPTION
## Summary
- **#9** — On first parent-home visit per browser session, redirect to the last board the user entered kid mode for. Subsequent same-session visits to `/` render ParentHome normally (no trap).
- **#18** — AuthGate's loading branch was a blank div; now shows a spinner + "Signing in…" copy.

## How it works (#9)
- `src/lib/lastBoard.ts` — localStorage record `{id, kind}` + a sessionStorage one-shot `auto-launched` flag. Defensive parsing rejects malformed JSON and unknown kinds.
- `KidSequenceRoute` / `KidChoiceRoute` write the record on mount once the board resolves.
- `ParentHomeRoute` reads at mount and emits `<Navigate replace>` if the session hasn't auto-launched yet, then marks the flag in `useEffect`.

PIN gate on exit is unchanged — caregivers can still escape kid mode via the PIN. With auto-launch on by default, that gate becomes the parent's only path back to ParentHome on cold start, which is the intended UX.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (`--max-warnings 0`)
- [x] `npx vitest run` — 86/86 green (added 13 tests across `lastBoard`, `ParentHomeRoute`, and `AuthGate` loading branch)
- [x] Manual smoke at 1194×834 in Chrome:
  - [x] Fresh signup → no last-board → ParentHome
  - [x] Click KID → `/kid/sequence/<id>` → last-board recorded
  - [x] Visit `/` in-session → stays on ParentHome (flag prevents loop)
  - [x] Clear `talrum:auto-launched` + reload `/` → redirects to `/kid/sequence/<id>`
  - [x] PIN setup→confirm→exit → builder
  - [x] Console clean throughout

Closes #9, #18.