### PR TITLE
Drop dead Preview button + PinPad setState fix + #19 test gaps

### DIFF
--- a/src/app/AuthGate.test.tsx
+++ b/src/app/AuthGate.test.tsx
@@ -1,12 +1,32 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import type { Session } from '@supabase/supabase-js';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { JSX } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 const getSessionMock = vi.fn();
-const onAuthStateChangeMock = vi.fn(() => ({
-  data: { subscription: { unsubscribe: vi.fn() } },
-}));
+type AuthChangeListener = (event: string, session: Session | null) => void;
+let lastAuthListener: AuthChangeListener | null = null;
+const onAuthStateChangeMock = vi.fn((listener: AuthChangeListener) => {
+  lastAuthListener = listener;
+  return { data: { subscription: { unsubscribe: vi.fn() } } };
+});
+
+const makeSession = (id: string, email: string): Session =>
+  ({
+    access_token: `token-${id}`,
+    refresh_token: 'r',
+    expires_in: 3600,
+    token_type: 'bearer',
+    user: {
+      id,
+      email,
+      app_metadata: {},
+      user_metadata: {},
+      aud: 'authenticated',
+      created_at: '2026-04-01T00:00:00Z',
+    },
+  }) as Session;
 
 vi.mock('@/lib/supabase', () => ({
   supabase: {
@@ -22,6 +42,9 @@ vi.mock('@/features/login/Login', () => ({
 }));
 
 const { AuthGate } = await import('./AuthGate');
+const { useSessionUser } = await import('./session');
+
+const UserIdProbe = (): JSX.Element => <div data-testid="probe-user-id">{useSessionUser().id}</div>;
 
 describe('AuthGate', () => {
   it('shows the loading copy while getSession is pending', () => {
@@ -52,6 +75,39 @@ describe('AuthGate', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
     await waitFor(() => {
       expect(screen.getByText('login screen')).toBeInTheDocument();
+    });
+  });
+
+  // Regression cover for cross-user re-auth: signing out and back in as a
+  // different user must propagate the new user.id all the way through
+  // SessionProvider so dependent hooks (mutations, useUserInitial) read the
+  // new user. Verifies AuthGate wires onAuthStateChange → setState →
+  // SessionProvider value without missing a session swap.
+  it('propagates a new session.user when onAuthStateChange fires after re-auth', async () => {
+    const sessionA = makeSession('user-a-id', 'a@example.com');
+    const sessionB = makeSession('user-b-id', 'b@example.com');
+    getSessionMock.mockResolvedValueOnce({ data: { session: sessionA } });
+    render(
+      <AuthGate>
+        <UserIdProbe />
+      </AuthGate>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-user-id')).toHaveTextContent('user-a-id');
+    });
+
+    act(() => {
+      lastAuthListener?.('SIGNED_OUT', null);
+    });
+    await waitFor(() => {
+      expect(screen.getByText('login screen')).toBeInTheDocument();
+    });
+
+    act(() => {
+      lastAuthListener?.('SIGNED_IN', sessionB);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-user-id')).toHaveTextContent('user-b-id');
     });
   });
 });

--- a/src/features/board-builder/BoardBuilder.tsx
+++ b/src/features/board-builder/BoardBuilder.tsx
@@ -10,9 +10,8 @@ import {
   useSetVoiceMode,
 } from '@/lib/queries/boards';
 import { usePictograms, usePictogramsById } from '@/lib/queries/pictograms';
-import type { Board, BoardKind, Pictogram } from '@/types/domain';
-import { Button } from '@/ui/Button/Button';
-import { ArrowLeftIcon, PlayIcon, PlusIcon, StepArrowIcon } from '@/ui/icons';
+import type { Board, Pictogram } from '@/types/domain';
+import { ArrowLeftIcon, PlusIcon, StepArrowIcon } from '@/ui/icons';
 import { PictoTile } from '@/ui/PictoTile/PictoTile';
 import { Reorderable } from '@/ui/Reorderable/Reorderable';
 
@@ -28,7 +27,6 @@ interface BoardBuilderProps {
   board: Board;
   onBack: () => void;
   onOpenPicker: () => void;
-  onPreview: (kind: BoardKind) => void;
   onKidMode: () => void;
 }
 
@@ -54,7 +52,6 @@ export const BoardBuilder = ({
   board,
   onBack,
   onOpenPicker,
-  onPreview,
   onKidMode,
 }: BoardBuilderProps): JSX.Element => {
   const pictogramsById = usePictogramsById();
@@ -119,15 +116,7 @@ export const BoardBuilder = ({
     setStepIds.mutate({ boardId: board.id, stepIds: [...board.stepIds, pictoId] });
 
   return (
-    <ParentShell
-      active="home"
-      onKidMode={onKidMode}
-      right={
-        <Button variant="primary" icon={<PlayIcon />} onClick={() => onPreview(board.kind)}>
-          Preview for Liam
-        </Button>
-      }
-    >
+    <ParentShell active="home" onKidMode={onKidMode}>
       <div className={styles.breadcrumb}>
         <button type="button" onClick={onBack} className={styles.back}>
           <ArrowLeftIcon size={16} />

--- a/src/features/board-builder/BoardBuilderRoute.test.tsx
+++ b/src/features/board-builder/BoardBuilderRoute.test.tsx
@@ -29,7 +29,10 @@ const makeWrapper = (qc: QueryClient, initialPath: string): (() => JSX.Element) 
   return (): JSX.Element => (
     <TestSessionProvider>
       <QueryClientProvider client={qc}>
-        <MemoryRouter initialEntries={[initialPath]}>
+        <MemoryRouter
+          initialEntries={[initialPath]}
+          future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+        >
           <Routes>
             <Route path="/boards/:boardId/edit" element={<BoardBuilderRoute />} />
           </Routes>

--- a/src/features/board-builder/BoardBuilderRoute.tsx
+++ b/src/features/board-builder/BoardBuilderRoute.tsx
@@ -58,7 +58,6 @@ export const BoardBuilderRoute = (): JSX.Element | null => {
         board={board}
         onBack={() => navigate('/')}
         onOpenPicker={openPicker}
-        onPreview={(kind) => navigate(`/kid/${kind}/${board.id}`)}
         onKidMode={() => navigate(`/kid/${board.kind}/${board.id}`)}
       />
       {pickerOpen && <PictoPicker onClose={closePicker} />}

--- a/src/features/kid-sequence/KidSequenceRoute.test.tsx
+++ b/src/features/kid-sequence/KidSequenceRoute.test.tsx
@@ -32,7 +32,10 @@ const makeWrap = (initialPath: string, qc: QueryClient): (() => JSX.Element) => 
   return (): JSX.Element => (
     <TestSessionProvider>
       <QueryClientProvider client={qc}>
-        <MemoryRouter initialEntries={[initialPath]}>
+        <MemoryRouter
+          initialEntries={[initialPath]}
+          future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+        >
           <Routes>
             <Route path="/kid/sequence/:boardId" element={<KidSequenceRoute />} />
             <Route path="/" element={<div data-testid="parent-home" />} />

--- a/src/features/parent-home/ParentHomeRoute.test.tsx
+++ b/src/features/parent-home/ParentHomeRoute.test.tsx
@@ -28,7 +28,10 @@ const makeWrap = (initialPath: string): (() => JSX.Element) => {
   return (): JSX.Element => (
     <TestSessionProvider>
       <QueryClientProvider client={qc}>
-        <MemoryRouter initialEntries={[initialPath]}>
+        <MemoryRouter
+          initialEntries={[initialPath]}
+          future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+        >
           <Routes>
             <Route path="/" element={<ParentHomeRoute />} />
             <Route

--- a/src/features/pictogram-picker/PictoPicker.test.tsx
+++ b/src/features/pictogram-picker/PictoPicker.test.tsx
@@ -1,0 +1,109 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { JSX, ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TestSessionProvider } from '@/app/session.test-utils';
+import { pictogramsQueryKey } from '@/lib/queries/pictograms';
+import type { Pictogram } from '@/types/domain';
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      signOut: vi.fn(),
+      getSession: vi.fn(() => Promise.resolve({ data: { session: null } })),
+      onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+    },
+  },
+}));
+
+const { PictoPicker } = await import('./PictoPicker');
+
+const SEED_PICTOGRAMS: Pictogram[] = [
+  { id: 'p-apple', slug: 'apple', label: 'Apple', style: 'illus', glyph: 'heart', tint: '#fff' },
+  { id: 'p-cup', slug: 'cup', label: 'Cup', style: 'illus', glyph: 'heart', tint: '#fff' },
+  { id: 'p-shoes', slug: 'shoes', label: 'Shoes', style: 'illus', glyph: 'heart', tint: '#fff' },
+];
+
+const wrap = (children: ReactNode): JSX.Element => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  qc.setQueryData(pictogramsQueryKey, SEED_PICTOGRAMS);
+  return (
+    <TestSessionProvider>
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    </TestSessionProvider>
+  );
+};
+
+describe('PictoPicker', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders the library tab by default with all seed pictograms', () => {
+    render(wrap(<PictoPicker onClose={vi.fn()} />));
+    expect(screen.getByRole('heading', { name: 'Add pictograms' })).toBeInTheDocument();
+    expect(screen.getByText('Apple')).toBeInTheDocument();
+    expect(screen.getByText('Cup')).toBeInTheDocument();
+    expect(screen.getByText('Shoes')).toBeInTheDocument();
+  });
+
+  it('switches between library, upload, and generate tabs', async () => {
+    const user = userEvent.setup();
+    render(wrap(<PictoPicker onClose={vi.fn()} />));
+    const tablist = screen.getByRole('tablist');
+    const libraryTab = within(tablist).getByRole('tab', { name: /Library/ });
+    const uploadTab = within(tablist).getByRole('tab', { name: /Upload/ });
+    const generateTab = within(tablist).getByRole('tab', { name: /Generate/ });
+
+    expect(libraryTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByPlaceholderText(/Search eat, dress/)).toBeInTheDocument();
+
+    await user.click(uploadTab);
+    expect(uploadTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.queryByPlaceholderText(/Search eat, dress/)).not.toBeInTheDocument();
+
+    await user.click(generateTab);
+    expect(generateTab).toHaveAttribute('aria-selected', 'true');
+
+    await user.click(libraryTab);
+    expect(libraryTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByPlaceholderText(/Search eat, dress/)).toBeInTheDocument();
+  });
+
+  it('toggles selection and reflects the count + label in the footer', async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    const onClose = vi.fn();
+    render(wrap(<PictoPicker onClose={onClose} onConfirm={onConfirm} />));
+
+    expect(screen.getByText('0 selected')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Apple' }));
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Add 1 to board/ })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Cup' }));
+    expect(screen.getByText('2 selected')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Apple' }));
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Add 1 to board/ }));
+    expect(onConfirm).toHaveBeenCalledWith(['p-cup']);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('filters the library by search query', async () => {
+    const user = userEvent.setup();
+    render(wrap(<PictoPicker onClose={vi.fn()} />));
+    await user.type(screen.getByPlaceholderText(/Search eat, dress/), 'app');
+    expect(screen.getByText('Apple')).toBeInTheDocument();
+    expect(screen.queryByText('Cup')).not.toBeInTheDocument();
+    expect(screen.queryByText('Shoes')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/pin-gate/KidModeGate.test.tsx
+++ b/src/features/pin-gate/KidModeGate.test.tsx
@@ -44,6 +44,26 @@ const tapDigits = async (
 };
 
 describe('KidModeGate', () => {
+  // Must run first: React deduplicates the "Cannot update a component while
+  // rendering a different component" warning per-process, so once any other
+  // setup→confirm test trips it the regression test would silently pass.
+  // PinPad.tap() used to call submit() from inside a setDigits updater; on
+  // the setup→confirm transition that synchronously schedules a setState on
+  // KidModeGate, which React flags via console.error. Fail if any
+  // console.error fires on the setup→confirm happy path.
+  it('does not emit React state-update warnings during setup→confirm transition', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const onExit = vi.fn();
+    const { user } = renderGate(onExit);
+
+    await user.click(screen.getByRole('button', { name: 'Exit kid mode' }));
+    await tapDigits(user, '1234');
+    expect(await screen.findByText('Confirm your PIN')).toBeInTheDocument();
+    await tapDigits(user, '1234');
+    expect(onExit).toHaveBeenCalledTimes(1);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
   it('skips the gate entirely when VITE_DISABLE_PIN is set', async () => {
     vi.stubEnv('VITE_DISABLE_PIN', '1');
     try {

--- a/src/features/pin-gate/PinPad.tsx
+++ b/src/features/pin-gate/PinPad.tsx
@@ -43,12 +43,10 @@ export const PinPad = ({
       return;
     }
     if (!key) return;
-    setDigits((d) => {
-      if (d.length >= PIN_LENGTH) return d;
-      const next = d + key;
-      if (next.length === PIN_LENGTH) void submit(next);
-      return next;
-    });
+    if (digits.length >= PIN_LENGTH) return;
+    const next = digits + key;
+    setDigits(next);
+    if (next.length === PIN_LENGTH) void submit(next);
   };
 
   return (

--- a/src/features/pin-gate/PinPad.tsx
+++ b/src/features/pin-gate/PinPad.tsx
@@ -44,6 +44,10 @@ export const PinPad = ({
     }
     if (!key) return;
     if (digits.length >= PIN_LENGTH) return;
+    // Read `digits` from closure (not via a setDigits updater) so submit's
+    // parent setStates don't fire while PinPad is mid-render. Trade-off: a
+    // double-tap inside one frame would coalesce to a single digit, which
+    // is fine for a 4-digit PIN entered by a parent on an iPad.
     const next = digits + key;
     setDigits(next);
     if (next.length === PIN_LENGTH) void submit(next);


### PR DESCRIPTION
## Summary
- **#20** — Drop the unrendered \`Preview for Liam\` button. ParentShell only renders its header (and the \`right\` slot) when \`title\` is truthy; BoardBuilder uses a breadcrumb + editable title, so the prop chain has been dead since the conditional header landed. KID in the sidebar is the canonical kid-mode path now that auto-launch (#9) is wired.
- **#19** — Three deferred coverage gaps:
  - PinPad setState-during-render fix: \`tap()\` used to call \`submit()\` from inside a \`setDigits\` updater. On the setup→confirm transition that synchronously schedules a setState on KidModeGate, which React flagged with the "Cannot update a component while rendering a different component" warning. Computed next digits outside the updater so the parent setState no longer races PinPad's render.
  - PictoPicker tests: render + tab-switch + selection toggle + search filter smoke tests.
  - Cross-user re-auth test: AuthGate verifies a SIGNED_OUT → SIGNED_IN cycle with a different user's session propagates the new \`user.id\` into consumers (regression cover for the case where re-auth might miss a session swap).
- **Test router parity** — \`MemoryRouter\` instances in route tests didn't carry future flags. Mirrored the v7 flags that production opts into (\`v7_startTransition\` on \`RouterProvider\`, \`v7_relativeSplatPath\` on \`createBrowserRouter\`) onto each test \`MemoryRouter\` so test output is clean and the test environment behaves as v7 will.

## Notes
The PinPad regression test is placed at the top of its describe block on purpose — React deduplicates the state-update warning per process, so once any other setup→confirm test trips it the regression test would silently pass. Verified by reverting the fix on a scratch copy: regression test fails, restoring the fix passes.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean (\`--max-warnings 0\`)
- [x] \`npx vitest run\` — 92/93 (one pre-existing flake in \`src/features/kid-choice/KidChoice.test.tsx\`, tracked as #24, fails on \`main\` too — not introduced by this PR)
- [x] Reverted-PinPad scratch test confirmed the new regression test catches the bug

Closes #19, #20.