### PR TITLE
Mock supabase in KidChoice + KidSequence tests (#24)

### DIFF
--- a/src/features/kid-choice/KidChoice.test.tsx
+++ b/src/features/kid-choice/KidChoice.test.tsx
@@ -10,6 +10,10 @@ import type { Board, Pictogram } from '@/types/domain';
 const speakPictogramMock = vi.fn();
 vi.mock('@/lib/voiceOut', () => ({ speakPictogram: speakPictogramMock }));
 
+// Mock supabase so the real client is never constructed and useQuery's
+// background refetch can't replace the seeded cache mid-test.
+vi.mock('@/lib/supabase', () => ({ supabase: {} }));
+
 const { KidChoice } = await import('./KidChoice');
 
 const park: Pictogram = { id: 'park-uuid', label: 'Park', style: 'photo' };

--- a/src/features/kid-sequence/KidSequence.test.tsx
+++ b/src/features/kid-sequence/KidSequence.test.tsx
@@ -10,6 +10,10 @@ import type { Board, Pictogram } from '@/types/domain';
 const speakPictogramMock = vi.fn();
 vi.mock('@/lib/voiceOut', () => ({ speakPictogram: speakPictogramMock }));
 
+// Mock supabase so the real client is never constructed and useQuery's
+// background refetch can't replace the seeded cache mid-test.
+vi.mock('@/lib/supabase', () => ({ supabase: {} }));
+
 const { KidSequence } = await import('./KidSequence');
 
 const apple: Pictogram = {


### PR DESCRIPTION
## Summary
\`KidChoice.test.tsx > picking an option\` failed on warm vitest runs but passed cold. Root cause traced to a React Query refetch race against the seeded cache.

## Root cause
- Test seeds the cache via \`qc.setQueryData(pictogramsQueryKey, [park, zoo])\`.
- \`useQuery\`'s default \`staleTime: 0\` triggers a background refetch on mount.
- Test does NOT mock \`@/lib/supabase\` (unlike every other test in the repo). With \`.env.local\` populated the real client is constructed; the refetch hits localhost:54321 and RLS returns \`[]\`, replacing the seed.
- Cold runs passed because supabase wasn't warm yet; warm runs the refetch completed before the assertion.

Confirmed by dumping post-click DOM: \`<div class=_choices/>\` was empty because \`usePictogramsById()\` rebuilt from data that had become \`[]\`.

## Fix
Mock \`@/lib/supabase\` to match the convention used by every other test in the codebase (\`Login.test.tsx\`, \`AuthGate.test.tsx\`, \`PictoPicker.test.tsx\`, the route tests). With \`from\` undefined the refetch throws, \`retry: false\` swallows it, the seeded cache is preserved.

Applied the same mock to \`KidSequence.test.tsx\` which had the identical setup and would have flaked the same way as soon as a future test in that file asserted on post-mount state.

(First iteration of this PR used \`staleTime: Infinity\` to suppress the refetch. Code review correctly flagged that as papering over a missing mock rather than following the codebase convention. Rewrote.)

## Test plan
- [x] 5 back-to-back warm runs of \`npx vitest run src/features/kid-choice/ src/features/kid-sequence/KidSequence.test.tsx\` all green
- [x] \`npx vitest run\` — full suite 93/93 green
- [x] \`npx tsc --noEmit\` clean

Closes #24.