### PR TITLE
Phase 4 follow-up batch: close #28 #29 #30 #31 #32

### DIFF
--- a/src/app/AuthGate.test.tsx
+++ b/src/app/AuthGate.test.tsx
@@ -2,7 +2,7 @@ import type { Session } from '@supabase/supabase-js';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { JSX } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const getSessionMock = vi.fn();
 type AuthChangeListener = (event: string, session: Session | null) => void;
@@ -46,6 +46,11 @@ const { useSessionUser } = await import('./session');
 
 const UserIdProbe = (): JSX.Element => <div data-testid="probe-user-id">{useSessionUser().id}</div>;
 
+afterEach(() => {
+  getSessionMock.mockReset();
+  onAuthStateChangeMock.mockClear();
+});
+
 describe('AuthGate', () => {
   it('shows the loading copy while getSession is pending', () => {
     getSessionMock.mockReturnValueOnce(new Promise(() => undefined));
@@ -76,6 +81,32 @@ describe('AuthGate', () => {
     await waitFor(() => {
       expect(screen.getByText('login screen')).toBeInTheDocument();
     });
+  });
+
+  it('swaps the spinner for an offline hint after 5s if getSession hangs while offline (#30)', async () => {
+    const originalOnline = navigator.onLine;
+    Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+    getSessionMock.mockReturnValueOnce(new Promise(() => undefined));
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      render(
+        <AuthGate>
+          <div>app body</div>
+        </AuthGate>,
+      );
+      // Spinner is up before the hung-getSession timer fires.
+      expect(screen.getByText('Loading…')).toBeInTheDocument();
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+      await waitFor(() => {
+        expect(screen.getByText("You're offline")).toBeInTheDocument();
+      });
+      expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+      Object.defineProperty(navigator, 'onLine', { value: originalOnline, configurable: true });
+    }
   });
 
   // Regression cover for cross-user re-auth: signing out and back in as a

--- a/src/app/AuthGate.tsx
+++ b/src/app/AuthGate.tsx
@@ -55,7 +55,7 @@ export const AuthGate = ({ children }: { children: ReactNode }): JSX.Element => 
 
   const retry = useCallback(() => setRetryCount((n) => n + 1), []);
 
-  if (state.status === 'loading') return <AuthGateLoading />;
+  if (state.status === 'loading') return <AuthGateLoading onRetry={retry} />;
   if (state.status === 'error') return <AuthGateError message={state.message} onRetry={retry} />;
   if (state.status === 'out') return <Login />;
   return <SessionProvider session={state.session}>{children}</SessionProvider>;
@@ -69,12 +69,42 @@ const AuthGateOfflineHint = (): JSX.Element | null => {
   );
 };
 
-const AuthGateLoading = (): JSX.Element => (
-  <div className={`tal ${styles.loading}`}>
-    <div className={styles.spinner} aria-hidden="true" />
-    <p className={styles.loadingBody}>Loading…</p>
-  </div>
-);
+const HUNG_GETSESSION_HINT_MS = 5000;
+
+/**
+ * If `getSession()` neither resolves nor rejects within 5s and the device
+ * is offline, swap the spinner for the offline hint + Retry button (#30).
+ * supabase-js usually rejects fast on offline, but if a request hangs the
+ * user shouldn't stare at a forever-spinner with no escape hatch.
+ */
+const AuthGateLoading = ({ onRetry }: { onRetry: () => void }): JSX.Element => {
+  const online = useOnline();
+  const [hung, setHung] = useState(false);
+  useEffect(() => {
+    const id = setTimeout(() => setHung(true), HUNG_GETSESSION_HINT_MS);
+    return () => clearTimeout(id);
+  }, []);
+
+  if (hung && !online) {
+    return (
+      <div className={`tal ${styles.error}`}>
+        <h1 className={styles.errorTitle}>You're offline</h1>
+        <p className={styles.errorBody}>
+          We can't reach the server right now. Retry once your connection is back.
+        </p>
+        <button type="button" onClick={onRetry} className={styles.errorRetry}>
+          Retry
+        </button>
+      </div>
+    );
+  }
+  return (
+    <div className={`tal ${styles.loading}`}>
+      <div className={styles.spinner} aria-hidden="true" />
+      <p className={styles.loadingBody}>Loading…</p>
+    </div>
+  );
+};
 
 const AuthGateError = ({
   message,

--- a/src/app/AuthGate.tsx
+++ b/src/app/AuthGate.tsx
@@ -55,7 +55,7 @@ export const AuthGate = ({ children }: { children: ReactNode }): JSX.Element => 
 
   const retry = useCallback(() => setRetryCount((n) => n + 1), []);
 
-  if (state.status === 'loading') return <AuthGateLoading onRetry={retry} />;
+  if (state.status === 'loading') return <AuthGateLoading key={retryCount} onRetry={retry} />;
   if (state.status === 'error') return <AuthGateError message={state.message} onRetry={retry} />;
   if (state.status === 'out') return <Login />;
   return <SessionProvider session={state.session}>{children}</SessionProvider>;

--- a/src/lib/outbox/drain.ts
+++ b/src/lib/outbox/drain.ts
@@ -114,6 +114,11 @@ let listenersAttached = false;
 export const startOutbox = (): void => {
   if (listenersAttached) return;
   listenersAttached = true;
+  // Prime lastStatus from IDB before any subscribe() call lands a stale zero
+  // pendingCount on a cold boot with persisted entries (#29). emit() is async,
+  // but we'd rather race a microtask than render a "synced" indicator that
+  // snaps to "3 pending" once the first drain completes.
+  void emit();
   if (typeof window !== 'undefined') {
     window.addEventListener('online', () => {
       void drain();

--- a/src/lib/outbox/drain.ts
+++ b/src/lib/outbox/drain.ts
@@ -131,3 +131,22 @@ export const startOutbox = (): void => {
 };
 
 export const kick = (): Promise<void> => drain();
+
+/**
+ * Test-only: reset the module-level state that startOutbox accumulates so a
+ * second test in the same file can re-exercise the cold-boot prime path.
+ * Production code never calls this; the listenersAttached flag is a one-shot
+ * guard against double-registering window listeners during normal app boot.
+ */
+export const __test_resetOutbox = (): void => {
+  draining = false;
+  pendingDrain = false;
+  listenersAttached = false;
+  subscribers.clear();
+  lastStatus = {
+    online: typeof navigator === 'undefined' ? true : navigator.onLine,
+    pendingCount: 0,
+    failedCount: 0,
+    draining: false,
+  };
+};

--- a/src/lib/outbox/handlers.test.ts
+++ b/src/lib/outbox/handlers.test.ts
@@ -120,9 +120,8 @@ describe('runHandler · createPhotoPicto', () => {
   });
 
   it('treats a 5xx storage error as transient — not Unretryable (#32)', async () => {
-    uploadMock.mockResolvedValue({
-      error: Object.assign(new Error('boom'), { statusCode: 500 }),
-    });
+    const uploadErr = Object.assign(new Error('boom'), { statusCode: 500 });
+    uploadMock.mockResolvedValue({ error: uploadErr });
     const entry: CreatePhotoPictogramEntry = {
       ...baseProps,
       kind: 'createPhotoPicto',
@@ -140,6 +139,12 @@ describe('runHandler · createPhotoPicto', () => {
     }
     expect(caught).toBeDefined();
     expect(caught).not.toBeInstanceOf(UnretryableOutboxError);
+    // Lock in that the original storage error reaches the drain layer with
+    // its statusCode intact — drain.ts uses this to bump attemptCount and
+    // schedule a retry. A regression that re-wrapped 5xx in some other
+    // custom subclass would trip this.
+    expect(caught).toBe(uploadErr);
+    expect((caught as { statusCode?: number }).statusCode).toBe(500);
     // Insert never ran because upload threw first; the bucket cleanup path
     // only fires when insert fails after a successful upload.
     expect(insertMock).not.toHaveBeenCalled();

--- a/src/lib/outbox/handlers.test.ts
+++ b/src/lib/outbox/handlers.test.ts
@@ -119,6 +119,33 @@ describe('runHandler · createPhotoPicto', () => {
     );
   });
 
+  it('treats a 5xx storage error as transient — not Unretryable (#32)', async () => {
+    uploadMock.mockResolvedValue({
+      error: Object.assign(new Error('boom'), { statusCode: 500 }),
+    });
+    const entry: CreatePhotoPictogramEntry = {
+      ...baseProps,
+      kind: 'createPhotoPicto',
+      pictogramId: 'p-1',
+      ownerId: 'o-1',
+      label: 'Park',
+      blob: new Blob(['x'], { type: 'image/jpeg' }),
+      extension: 'jpg',
+    };
+    let caught: unknown;
+    try {
+      await runHandler(entry);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect(caught).not.toBeInstanceOf(UnretryableOutboxError);
+    // Insert never ran because upload threw first; the bucket cleanup path
+    // only fires when insert fails after a successful upload.
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(removeMock).not.toHaveBeenCalled();
+  });
+
   it('cleans up the uploaded blob if insert fails', async () => {
     insertMock.mockResolvedValue({
       error: { code: '23505', message: 'unique violation', details: '', hint: '' },

--- a/src/lib/outbox/outbox.test.ts
+++ b/src/lib/outbox/outbox.test.ts
@@ -18,7 +18,9 @@ vi.mock('@/lib/supabase', () => ({
 }));
 
 const { deleteEntry, listEntries, putEntry } = await import('./store');
-const { drain, getStatus, startOutbox, subscribeStatus } = await import('./drain');
+const { __test_resetOutbox, drain, getStatus, startOutbox, subscribeStatus } = await import(
+  './drain'
+);
 const { enqueueAndDrain } = await import('./index');
 
 const baseEntry = (over: Partial<UpdateBoardEntry> = {}): UpdateBoardEntry => ({
@@ -193,12 +195,19 @@ describe('enqueueAndDrain', () => {
 });
 
 describe('startOutbox', () => {
+  beforeEach(() => {
+    // startOutbox is one-shot in production (window listeners must not
+    // register twice). Reset module state so each test in this block exercises
+    // the cold-boot prime path on its own terms.
+    __test_resetOutbox();
+  });
+
   it('primes lastStatus from IDB so cold-boot subscribers see real counts (#29)', async () => {
     setOnline(false); // drain is offline-noop; emit() is the only source updating lastStatus.
     await putEntry(baseEntry({ id: '01HZZP' }));
     await putEntry(baseEntry({ id: '01HZZQ' }));
     const seen: number[] = [];
-    startOutbox(); // Idempotent — only the first call in the suite primes.
+    startOutbox();
     const unsub = subscribeStatus((s) => seen.push(s.pendingCount));
     // Two macrotask ticks: one for emit()'s listEntries, one for the
     // offline-branch emit() inside drain().

--- a/src/lib/outbox/outbox.test.ts
+++ b/src/lib/outbox/outbox.test.ts
@@ -18,7 +18,7 @@ vi.mock('@/lib/supabase', () => ({
 }));
 
 const { deleteEntry, listEntries, putEntry } = await import('./store');
-const { drain, getStatus, subscribeStatus } = await import('./drain');
+const { drain, getStatus, startOutbox, subscribeStatus } = await import('./drain');
 const { enqueueAndDrain } = await import('./index');
 
 const baseEntry = (over: Partial<UpdateBoardEntry> = {}): UpdateBoardEntry => ({
@@ -189,5 +189,22 @@ describe('enqueueAndDrain', () => {
     unsub();
     // First push is the initial status (0); second is post-enqueue (1).
     expect(seen[seen.length - 1]).toBe(1);
+  });
+});
+
+describe('startOutbox', () => {
+  it('primes lastStatus from IDB so cold-boot subscribers see real counts (#29)', async () => {
+    setOnline(false); // drain is offline-noop; emit() is the only source updating lastStatus.
+    await putEntry(baseEntry({ id: '01HZZP' }));
+    await putEntry(baseEntry({ id: '01HZZQ' }));
+    const seen: number[] = [];
+    startOutbox(); // Idempotent — only the first call in the suite primes.
+    const unsub = subscribeStatus((s) => seen.push(s.pendingCount));
+    // Two macrotask ticks: one for emit()'s listEntries, one for the
+    // offline-branch emit() inside drain().
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    unsub();
+    expect(seen).toContain(2);
   });
 });

--- a/src/lib/queries/pictograms.test.ts
+++ b/src/lib/queries/pictograms.test.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { Pictogram } from '@/types/domain';
 import type { Database } from '@/types/supabase';
 
-import { pictogramToInsert, rowToPictogram } from './pictograms';
+import {
+  __test_revokePictogramBlobs,
+  pictogramsQueryKey,
+  pictogramToInsert,
+  rowToPictogram,
+} from './pictograms';
 
 type Row = Database['public']['Tables']['pictograms']['Row'];
 
@@ -64,6 +70,49 @@ describe('rowToPictogram', () => {
       style: 'photo',
       imagePath: 'photos/park.jpg',
     });
+  });
+});
+
+describe('revokePictogramBlobs (#28)', () => {
+  // jsdom doesn't ship URL.revokeObjectURL; install a stub so vi.spyOn has
+  // something to wrap. restoreAllMocks unwraps the spy, not the stub itself —
+  // leaving the stub in place is harmless.
+  if (typeof URL.revokeObjectURL !== 'function') {
+    (URL as { revokeObjectURL: (u: string) => void }).revokeObjectURL = () => undefined;
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('revokes blob:-prefixed imagePath and audioPath in the cache', () => {
+    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    const qc = new QueryClient();
+    qc.setQueryData<Pictogram[]>(pictogramsQueryKey, [
+      { id: 'a', label: 'A', style: 'photo', imagePath: 'blob:http://localhost/photo-a' },
+      {
+        id: 'b',
+        label: 'B',
+        style: 'illus',
+        glyph: 'sun',
+        tint: 'oklch(90% 0.06 90)',
+        audioPath: 'blob:http://localhost/audio-b',
+      },
+      // Already-uploaded rows have real signed-URL paths; never revoke those.
+      { id: 'c', label: 'C', style: 'photo', imagePath: 'photos/c.jpg' },
+    ]);
+    __test_revokePictogramBlobs(qc);
+    expect(revokeSpy).toHaveBeenCalledWith('blob:http://localhost/photo-a');
+    expect(revokeSpy).toHaveBeenCalledWith('blob:http://localhost/audio-b');
+    expect(revokeSpy).not.toHaveBeenCalledWith('photos/c.jpg');
+    expect(revokeSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('is a no-op when the pictograms cache is empty', () => {
+    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    const qc = new QueryClient();
+    __test_revokePictogramBlobs(qc);
+    expect(revokeSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/queries/pictograms.ts
+++ b/src/lib/queries/pictograms.ts
@@ -117,9 +117,20 @@ const patchPictogramInList = (
  * so the next refetch resolves the real URL into the cache slot we just freed.
  *
  * Called by onSuccess and onError of every pictogram mutation that plants a
- * blob URL. Two concurrent uploads racing here would mean the earlier one's
- * sweep also revokes the still-pending one's blob — accept the brief broken-
- * image flash; this app does not realistically run concurrent uploads.
+ * blob URL. Known accepted races:
+ *
+ *   - Two concurrent uploads: the earlier one's sweep also revokes the later
+ *     one's still-pending blob → brief broken-image flash on the second tile
+ *     until invalidation refetches the real signed URL.
+ *   - Audio mid-buffer: revoking a `blob:` URL while an `<audio>` element is
+ *     mid-load can stop playback. Recordings are small (KBs), uploads are
+ *     normally faster than the user can hit play immediately after recording,
+ *     so this rarely surfaces in practice.
+ *
+ * Both are accepted tradeoffs in exchange for the simpler "scan all blobs"
+ * implementation; the alternative (per-mutation id tracking through
+ * onSuccess/onError contexts) is significantly more wiring for a workflow
+ * that doesn't realistically produce concurrent uploads.
  */
 const revokePictogramBlobs = (qc: QueryClient): void => {
   const list = qc.getQueryData<Pictogram[]>(pictogramsQueryKey);

--- a/src/lib/queries/pictograms.ts
+++ b/src/lib/queries/pictograms.ts
@@ -1,4 +1,5 @@
 import {
+  type QueryClient,
   useMutation,
   type UseMutationResult,
   useQuery,
@@ -107,6 +108,34 @@ const patchPictogramInList = (
   patch: (p: Pictogram) => Pictogram,
 ): Pictogram[] | undefined => list?.map((p) => (p.id === id ? patch(p) : p));
 
+/**
+ * Walk every pictogram currently in the cache and `URL.revokeObjectURL` any
+ * `blob:` imagePath / audioPath. Optimistic mutations plant local blob URLs
+ * for instant render; once the outbox uploads succeed the next `invalidateQueries`
+ * refetch replaces the row with a real signed-URL path, but the blob keeps
+ * its memory reference unless we explicitly revoke. Sweep before invalidation
+ * so the next refetch resolves the real URL into the cache slot we just freed.
+ *
+ * Called by onSuccess and onError of every pictogram mutation that plants a
+ * blob URL. Two concurrent uploads racing here would mean the earlier one's
+ * sweep also revokes the still-pending one's blob — accept the brief broken-
+ * image flash; this app does not realistically run concurrent uploads.
+ */
+const revokePictogramBlobs = (qc: QueryClient): void => {
+  const list = qc.getQueryData<Pictogram[]>(pictogramsQueryKey);
+  if (!list) return;
+  for (const p of list) {
+    if (p.style === 'photo' && p.imagePath?.startsWith('blob:')) {
+      URL.revokeObjectURL(p.imagePath);
+    }
+    if (p.audioPath?.startsWith('blob:')) {
+      URL.revokeObjectURL(p.audioPath);
+    }
+  }
+};
+
+export const __test_revokePictogramBlobs = revokePictogramBlobs;
+
 interface SetAudioInput {
   pictogramId: string;
   blob: Blob;
@@ -140,6 +169,11 @@ export const useSetPictogramAudio = (): UseMutationResult<void, Error, SetAudioI
         ...(previousPath ? { previousPath } : {}),
       }),
     onSuccess: () => {
+      revokePictogramBlobs(qc);
+      qc.invalidateQueries({ queryKey: pictogramsQueryKey });
+    },
+    onError: () => {
+      revokePictogramBlobs(qc);
       qc.invalidateQueries({ queryKey: pictogramsQueryKey });
     },
   });
@@ -192,10 +226,12 @@ export const useCreatePhotoPictogram = (): UseMutationResult<
       return { id, imagePath: `${ownerId}/${id}.${extension}` };
     },
     onSuccess: () => {
+      revokePictogramBlobs(qc);
       qc.invalidateQueries({ queryKey: pictogramsQueryKey });
     },
     onError: (_err, _input, _ctx) => {
       // Drop the optimistic row; the user got an error.
+      revokePictogramBlobs(qc);
       qc.invalidateQueries({ queryKey: pictogramsQueryKey });
     },
   });
@@ -215,6 +251,11 @@ export const useClearPictogramAudio = (): UseMutationResult<void, Error, ClearAu
     mutationFn: ({ pictogramId, path }) =>
       enqueueAndDrain({ kind: 'clearPictoAudio', pictogramId, path }),
     onSuccess: () => {
+      revokePictogramBlobs(qc);
+      qc.invalidateQueries({ queryKey: pictogramsQueryKey });
+    },
+    onError: () => {
+      revokePictogramBlobs(qc);
       qc.invalidateQueries({ queryKey: pictogramsQueryKey });
     },
   });

--- a/src/ui/OfflineIndicator/OfflineIndicator.test.tsx
+++ b/src/ui/OfflineIndicator/OfflineIndicator.test.tsx
@@ -1,19 +1,25 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const useOutboxStatusMock = vi.fn();
+const kickMock = vi.fn();
+const peekEntriesMock = vi.fn();
+const discardEntryMock = vi.fn();
 
 vi.mock('@/lib/outbox', () => ({
   useOutboxStatus: () => useOutboxStatusMock(),
-  kick: vi.fn(),
-  peekEntries: vi.fn(),
-  discardEntry: vi.fn(),
+  kick: (...args: unknown[]) => kickMock(...args),
+  peekEntries: (...args: unknown[]) => peekEntriesMock(...args),
+  discardEntry: (...args: unknown[]) => discardEntryMock(...args),
 }));
 
 const { OfflineIndicator } = await import('./OfflineIndicator');
 
 afterEach(() => {
   useOutboxStatusMock.mockReset();
+  kickMock.mockReset();
+  peekEntriesMock.mockReset();
+  discardEntryMock.mockReset();
 });
 
 describe('OfflineIndicator', () => {
@@ -61,5 +67,27 @@ describe('OfflineIndicator', () => {
     expect(screen.getByRole('status')).toHaveTextContent(/2 sync changes failed/);
     expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Discard' })).toBeInTheDocument();
+  });
+
+  it('discards failed entries without kicking the drain (#31)', async () => {
+    useOutboxStatusMock.mockReturnValue({
+      online: true,
+      pendingCount: 1,
+      failedCount: 1,
+      draining: false,
+    });
+    peekEntriesMock.mockResolvedValue([
+      { id: 'a', status: 'failed' },
+      { id: 'b', status: 'pending' },
+    ]);
+    discardEntryMock.mockResolvedValue(undefined);
+    render(<OfflineIndicator />);
+    fireEvent.click(screen.getByRole('button', { name: 'Discard' }));
+    // Let the discardAllFailed promise chain settle.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(discardEntryMock).toHaveBeenCalledWith('a');
+    expect(discardEntryMock).not.toHaveBeenCalledWith('b');
+    expect(kickMock).not.toHaveBeenCalled();
   });
 });

--- a/src/ui/OfflineIndicator/OfflineIndicator.tsx
+++ b/src/ui/OfflineIndicator/OfflineIndicator.tsx
@@ -7,7 +7,6 @@ import styles from './OfflineIndicator.module.css';
 const discardAllFailed = async (): Promise<void> => {
   const entries = await peekEntries();
   await Promise.all(entries.filter((e) => e.status === 'failed').map((e) => discardEntry(e.id)));
-  await kick();
 };
 
 /**


### PR DESCRIPTION
Closes #28
Closes #29
Closes #30
Closes #31
Closes #32

## Summary

Closes the five Phase 4 review follow-ups before piling Phase 5 (sharing UI / household invites) on top of the same outbox + pictogram-mutation infrastructure. Each fix is single-digit lines plus a test or two; one commit per issue.

- **#31** — `OfflineIndicator.discardAllFailed` no longer calls `kick()`. Discard is a self-contained user action; the next mutation or `online` event triggers drain naturally.
- **#32** — Lock in the 5xx storage transient classification with a unit test on `handleCreatePhotoPictogram`. Cosmetic refactor half (`buildEntry` extraction) declined — six lines of duplication is cheaper than re-touching the hot path on every future entry kind.
- **#29** — `startOutbox` now `emit()`s before scheduling the first drain so cold-boot subscribers see real counts within a microtask, not zero counts that snap once drain finishes.
- **#30** — `AuthGateLoading` swaps spinner → offline hint + Retry after 5s if `getSession()` hasn't completed and `useOnline()` reports offline.
- **#28** — Sweep `blob:`-prefixed `imagePath` / `audioPath` in the pictograms cache and `URL.revokeObjectURL` them in `onSuccess` / `onError` of every pictogram mutation that plants a blob URL.

## Test plan

- [x] `npx tsc -b` clean
- [x] `npm run lint` clean (`eslint --max-warnings 0`)
- [x] `npx vitest run` — 128/128 passing (was 122 on main; +6 new tests)
- Manual smoke (defer to merge):
  - [ ] Offline → make 3 mutations → reload → indicator shows non-zero count immediately, no flicker (#29)
  - [ ] With 1 failed + 1 pending entry, click Discard → only failed disappears (#31)
  - [ ] Photo upload offline → reconnect → blob URL count drops to zero post-drain (#28)
  - [ ] Block ``auth.token`` requests in DevTools → reload → AuthGate shows offline hint after ~5s (#30)