### PR TITLE
Phase 5 MVP: minimum viable sharing

### DIFF
--- a/src/features/board-builder/BoardBuilder.module.css
+++ b/src/features/board-builder/BoardBuilder.module.css
@@ -6,6 +6,22 @@
   margin-top: -4px;
 }
 
+.shareBtn {
+  margin-left: auto;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--tal-ink);
+  background: var(--tal-surface);
+  border: 1px solid var(--tal-line);
+  border-radius: var(--tal-r-pill);
+  padding: 6px 14px;
+  cursor: pointer;
+}
+
+.shareBtn:hover {
+  background: var(--tal-bg);
+}
+
 .back {
   display: inline-flex;
   align-items: center;

--- a/src/features/board-builder/BoardBuilder.test.tsx
+++ b/src/features/board-builder/BoardBuilder.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import type { JSX } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { Board } from '@/types/domain';
+
+vi.mock('@/lib/queries/boards', () => ({
+  useRenameBoard: () => ({ mutate: vi.fn() }),
+  useSetBoardKind: () => ({ mutate: vi.fn() }),
+  useSetKidReorderable: () => ({ mutate: vi.fn() }),
+  useSetLabelsVisible: () => ({ mutate: vi.fn() }),
+  useSetStepIds: () => ({ mutate: vi.fn() }),
+  useSetVoiceMode: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock('@/lib/queries/pictograms', () => ({
+  usePictograms: () => ({ data: [] }),
+  usePictogramsById: () => new Map(),
+}));
+
+vi.mock('@/layouts/ParentShell', () => ({
+  ParentShell: ({ children }: { children: JSX.Element }): JSX.Element => <div>{children}</div>,
+}));
+
+const { BoardBuilder } = await import('./BoardBuilder');
+
+const baseBoard: Board = {
+  id: 'board-1',
+  ownerId: 'owner-1',
+  kidId: 'kid-1',
+  name: 'Morning routine',
+  kind: 'sequence',
+  labelsVisible: true,
+  voiceMode: 'tts',
+  stepIds: [],
+  kidReorderable: false,
+  accent: 'peach',
+  accentInk: 'peach-ink',
+  updatedLabel: 'Edited just now',
+};
+
+const noop = (): void => undefined;
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('BoardBuilder Share button', () => {
+  it('renders the Share button when isOwner=true', () => {
+    render(
+      <BoardBuilder
+        board={baseBoard}
+        isOwner
+        onBack={noop}
+        onOpenPicker={noop}
+        onOpenShare={noop}
+        onKidMode={noop}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Share' })).toBeInTheDocument();
+  });
+
+  it('hides the Share button when isOwner=false', () => {
+    render(
+      <BoardBuilder
+        board={baseBoard}
+        isOwner={false}
+        onBack={noop}
+        onOpenPicker={noop}
+        onOpenShare={noop}
+        onKidMode={noop}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'Share' })).not.toBeInTheDocument();
+  });
+
+  it('invokes onOpenShare when the button is clicked', () => {
+    const onOpenShare = vi.fn();
+    render(
+      <BoardBuilder
+        board={baseBoard}
+        isOwner
+        onBack={noop}
+        onOpenPicker={noop}
+        onOpenShare={onOpenShare}
+        onKidMode={noop}
+      />,
+    );
+    screen.getByRole('button', { name: 'Share' }).click();
+    expect(onOpenShare).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/board-builder/BoardBuilder.tsx
+++ b/src/features/board-builder/BoardBuilder.tsx
@@ -25,8 +25,10 @@ const TITLE_DEBOUNCE_MS = 300;
 
 interface BoardBuilderProps {
   board: Board;
+  isOwner: boolean;
   onBack: () => void;
   onOpenPicker: () => void;
+  onOpenShare: () => void;
   onKidMode: () => void;
 }
 
@@ -50,8 +52,10 @@ const buildSteps = (stepIds: string[], byId: Map<string, Pictogram>): Step[] =>
 
 export const BoardBuilder = ({
   board,
+  isOwner,
   onBack,
   onOpenPicker,
+  onOpenShare,
   onKidMode,
 }: BoardBuilderProps): JSX.Element => {
   const pictogramsById = usePictogramsById();
@@ -124,6 +128,11 @@ export const BoardBuilder = ({
         </button>
         <span className={styles.crumbSep}>/</span>
         <span className={styles.crumbPath}>Editing</span>
+        {isOwner && (
+          <button type="button" onClick={onOpenShare} className={styles.shareBtn}>
+            Share
+          </button>
+        )}
       </div>
 
       <input

--- a/src/features/board-builder/BoardBuilderRoute.tsx
+++ b/src/features/board-builder/BoardBuilderRoute.tsx
@@ -1,11 +1,13 @@
 import { type JSX, useCallback } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
+import { useSessionUser } from '@/app/session';
 import { PictoPicker } from '@/features/pictogram-picker/PictoPicker';
 import { isNotFoundError, useBoard, useBoards } from '@/lib/queries/boards';
 
 import { BoardBuilder } from './BoardBuilder';
 import { BoardNotFound } from './BoardNotFound';
+import { ShareModal } from './ShareModal';
 
 export const BoardBuilderRoute = (): JSX.Element | null => {
   const { boardId = '' } = useParams();
@@ -13,8 +15,10 @@ export const BoardBuilderRoute = (): JSX.Element | null => {
   const boardsQuery = useBoards();
   const board = boardQuery.data;
   const navigate = useNavigate();
+  const me = useSessionUser();
   const [searchParams, setSearchParams] = useSearchParams();
   const pickerOpen = searchParams.get('picker') === '1';
+  const shareOpen = searchParams.get('share') === '1';
 
   const openPicker = useCallback((): void => {
     const next = new URLSearchParams(searchParams);
@@ -25,6 +29,18 @@ export const BoardBuilderRoute = (): JSX.Element | null => {
   const closePicker = useCallback((): void => {
     const next = new URLSearchParams(searchParams);
     next.delete('picker');
+    setSearchParams(next, { replace: true });
+  }, [searchParams, setSearchParams]);
+
+  const openShare = useCallback((): void => {
+    const next = new URLSearchParams(searchParams);
+    next.set('share', '1');
+    setSearchParams(next);
+  }, [searchParams, setSearchParams]);
+
+  const closeShare = useCallback((): void => {
+    const next = new URLSearchParams(searchParams);
+    next.delete('share');
     setSearchParams(next, { replace: true });
   }, [searchParams, setSearchParams]);
 
@@ -52,15 +68,22 @@ export const BoardBuilderRoute = (): JSX.Element | null => {
 
   if (!board) return null;
 
+  const isOwner = board.ownerId === me.id;
+
   return (
     <>
       <BoardBuilder
         board={board}
+        isOwner={isOwner}
         onBack={() => navigate('/')}
         onOpenPicker={openPicker}
+        onOpenShare={openShare}
         onKidMode={() => navigate(`/kid/${board.kind}/${board.id}`)}
       />
       {pickerOpen && <PictoPicker onClose={closePicker} />}
+      {shareOpen && (
+        <ShareModal boardId={board.id} isOwner={isOwner} onClose={closeShare} />
+      )}
     </>
   );
 };

--- a/src/features/board-builder/ShareModal.module.css
+++ b/src/features/board-builder/ShareModal.module.css
@@ -1,0 +1,189 @@
+.wrap {
+  padding: 28px 28px 24px;
+  max-width: 520px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.title {
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--tal-ink);
+  margin: 0 0 2px;
+}
+
+.subtitle {
+  font-size: 13px;
+  color: var(--tal-ink-muted);
+  margin: 0;
+}
+
+.closeBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--tal-ink-soft);
+  border: none;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.section {
+  border-top: 1px solid var(--tal-line-soft);
+  padding: 16px 0;
+}
+
+.section:first-of-type {
+  border-top: none;
+  padding-top: 4px;
+}
+
+.sectionLabel {
+  display: block;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--tal-ink-muted);
+  margin: 0 0 8px;
+}
+
+.idRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.idValue {
+  flex: 1 1 auto;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 13px;
+  color: var(--tal-ink);
+  background: var(--tal-bg);
+  border: 1px solid var(--tal-line-soft);
+  border-radius: var(--tal-r-md);
+  padding: 8px 10px;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.copyBtn {
+  flex-shrink: 0;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--tal-ink);
+  background: var(--tal-surface);
+  border: 1px solid var(--tal-line);
+  border-radius: var(--tal-r-md);
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.copyBtn:hover {
+  background: var(--tal-bg);
+}
+
+.empty {
+  font-size: 14px;
+  color: var(--tal-ink-muted);
+  margin: 0;
+}
+
+.memberList {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.memberRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  background: var(--tal-bg);
+  border-radius: var(--tal-r-md);
+}
+
+.memberId {
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 13px;
+  color: var(--tal-ink);
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.memberRole {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--tal-ink-muted);
+  background: var(--tal-surface);
+  padding: 2px 8px;
+  border-radius: var(--tal-r-pill);
+  flex-shrink: 0;
+}
+
+.removeBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--tal-ink-soft);
+  border: none;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.removeBtn:hover {
+  color: var(--tal-ink);
+  background: var(--tal-surface);
+}
+
+.addRow {
+  display: flex;
+  gap: 8px;
+}
+
+.input {
+  flex: 1 1 auto;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 13px;
+  padding: 8px 10px;
+  border: 1px solid var(--tal-line);
+  border-radius: var(--tal-r-md);
+  background: var(--tal-surface);
+  color: var(--tal-ink);
+  outline: none;
+}
+
+.input:focus {
+  border-color: var(--tal-ink-soft);
+}
+
+.error {
+  margin: 8px 0 0;
+  font-size: 13px;
+  color: var(--tal-coral-ink, var(--tal-ink));
+}

--- a/src/features/board-builder/ShareModal.test.tsx
+++ b/src/features/board-builder/ShareModal.test.tsx
@@ -189,3 +189,61 @@ describe('ShareModal — non-owner', () => {
     expect(screen.queryByText('Add someone')).not.toBeInTheDocument();
   });
 });
+
+describe('ShareModal — members loading state (#35)', () => {
+  it('renders "Loading…" instead of "No one yet." while the query is pending', () => {
+    const onClose = vi.fn();
+    useBoardMembersMock.mockReturnValue({ data: undefined, isPending: true });
+    render(
+      <SessionContext.Provider
+        value={{
+          session: {} as Session,
+          user: fakeUser(ME_ID),
+          signOut: async () => undefined,
+        }}
+      >
+        <ShareModal boardId="board-1" isOwner onClose={onClose} />
+      </SessionContext.Provider>,
+    );
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+    expect(screen.queryByText('No one yet.')).not.toBeInTheDocument();
+  });
+});
+
+describe('ShareModal — clipboard error (#36)', () => {
+  const realClipboard = navigator.clipboard;
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: realClipboard,
+      configurable: true,
+    });
+  });
+
+  it('shows an inline error if clipboard.writeText rejects', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: () => Promise.reject(new Error('denied')) },
+      configurable: true,
+    });
+    renderModal([]);
+    fireEvent.click(screen.getByRole('button', { name: 'Copy your sharing ID' }));
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('select the ID and copy manually'),
+    );
+  });
+
+  it('shows an inline error when running in an insecure context', () => {
+    const realIsSecure = window.isSecureContext;
+    Object.defineProperty(window, 'isSecureContext', { value: false, configurable: true });
+    try {
+      renderModal([]);
+      fireEvent.click(screen.getByRole('button', { name: 'Copy your sharing ID' }));
+      expect(screen.getByRole('alert')).toHaveTextContent('select the ID and copy manually');
+    } finally {
+      Object.defineProperty(window, 'isSecureContext', {
+        value: realIsSecure,
+        configurable: true,
+      });
+    }
+  });
+});

--- a/src/features/board-builder/ShareModal.test.tsx
+++ b/src/features/board-builder/ShareModal.test.tsx
@@ -1,0 +1,191 @@
+import type { Session, User } from '@supabase/supabase-js';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { JSX } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SessionContext } from '@/app/session';
+import type { BoardMember } from '@/lib/queries/board-members';
+import type * as BoardMembersModule from '@/lib/queries/board-members';
+
+const useBoardMembersMock = vi.fn();
+const addMutateMock = vi.fn();
+const removeMutateMock = vi.fn();
+let lastAddOptions: { onSuccess?: () => void; onError?: (err: unknown) => void } | undefined;
+
+const baseAddState = {
+  mutate: (
+    input: unknown,
+    opts?: { onSuccess?: () => void; onError?: (err: unknown) => void },
+  ) => {
+    lastAddOptions = opts;
+    addMutateMock(input);
+  },
+  isPending: false,
+};
+
+let addState: typeof baseAddState = { ...baseAddState };
+
+const removeState = {
+  mutate: (input: unknown) => {
+    removeMutateMock(input);
+  },
+  isPending: false,
+};
+
+vi.mock('@/lib/queries/board-members', async (importActual) => {
+  const actual = await importActual<typeof BoardMembersModule>();
+  return {
+    ...actual,
+    useBoardMembers: () => useBoardMembersMock(),
+    useAddBoardMember: () => addState,
+    useRemoveBoardMember: () => removeState,
+  };
+});
+
+const { ShareModal } = await import('./ShareModal');
+
+const ME_ID = '11111111-1111-4111-8111-111111111111';
+const OTHER_ID = '22222222-2222-4222-8222-222222222222';
+
+const fakeUser = (id: string): User =>
+  ({
+    id,
+    email: 'me@example.com',
+    app_metadata: {},
+    user_metadata: {},
+    aud: 'authenticated',
+    created_at: '2026-04-25T00:00:00Z',
+  }) as User;
+
+const renderModal = (
+  members: BoardMember[],
+  isOwner = true,
+  meId = ME_ID,
+): { onClose: ReturnType<typeof vi.fn> } => {
+  const onClose = vi.fn();
+  useBoardMembersMock.mockReturnValue({ data: members, isSuccess: true });
+  const Wrapper = ({ children }: { children: JSX.Element }): JSX.Element => (
+    <SessionContext.Provider
+      value={{
+        session: {} as Session,
+        user: fakeUser(meId),
+        signOut: async () => undefined,
+      }}
+    >
+      {children}
+    </SessionContext.Provider>
+  );
+  render(
+    <Wrapper>
+      <ShareModal boardId="board-1" isOwner={isOwner} onClose={onClose} />
+    </Wrapper>,
+  );
+  return { onClose };
+};
+
+beforeEach(() => {
+  addMutateMock.mockReset();
+  removeMutateMock.mockReset();
+  useBoardMembersMock.mockReset();
+  addState = { ...baseAddState };
+  lastAddOptions = undefined;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ShareModal — owner', () => {
+  it('renders the three sections (sharing ID, members, add form)', () => {
+    renderModal([
+      { boardId: 'board-1', userId: OTHER_ID, role: 'viewer' },
+    ]);
+    expect(screen.getByText('Your sharing ID')).toBeInTheDocument();
+    expect(screen.getByText('Shared with')).toBeInTheDocument();
+    expect(screen.getByText('Add someone')).toBeInTheDocument();
+    // The sharing ID is shown verbatim so the owner can copy it.
+    expect(screen.getByText(ME_ID)).toBeInTheDocument();
+    // The member is rendered with their role.
+    expect(screen.getByText(OTHER_ID)).toBeInTheDocument();
+    expect(screen.getByText('viewer')).toBeInTheDocument();
+  });
+
+  it('shows "No one yet." when the board has no members', () => {
+    renderModal([]);
+    expect(screen.getByText('No one yet.')).toBeInTheDocument();
+  });
+
+  it('rejects a non-UUID input with an inline error and does not fire the mutation', () => {
+    renderModal([]);
+    fireEvent.change(screen.getByLabelText('Sharing ID'), { target: { value: 'not-a-uuid' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    expect(screen.getByRole('alert')).toHaveTextContent("doesn't look like a valid sharing ID");
+    expect(addMutateMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects pasting one's own sharing ID with an inline error", () => {
+    renderModal([]);
+    fireEvent.change(screen.getByLabelText('Sharing ID'), { target: { value: ME_ID } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    expect(screen.getByRole('alert')).toHaveTextContent("your own sharing ID");
+    expect(addMutateMock).not.toHaveBeenCalled();
+  });
+
+  it('fires useAddBoardMember on a valid UUID and clears the input on success', async () => {
+    renderModal([]);
+    const input = screen.getByLabelText('Sharing ID') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: OTHER_ID } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    expect(addMutateMock).toHaveBeenCalledWith({
+      boardId: 'board-1',
+      userId: OTHER_ID,
+      role: 'viewer',
+    });
+    act(() => {
+      lastAddOptions?.onSuccess?.();
+    });
+    await waitFor(() => expect(input.value).toBe(''));
+  });
+
+  it('renders an inline error when the mutation reports a 23505 (already a member)', async () => {
+    renderModal([]);
+    fireEvent.change(screen.getByLabelText('Sharing ID'), { target: { value: OTHER_ID } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    act(() => {
+      lastAddOptions?.onError?.({ code: '23505', message: 'duplicate' });
+    });
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('already has access'),
+    );
+  });
+
+  it('fires useRemoveBoardMember when an X button is clicked on a member row', () => {
+    renderModal([
+      { boardId: 'board-1', userId: OTHER_ID, role: 'viewer' },
+    ]);
+    fireEvent.click(screen.getByRole('button', { name: `Remove ${OTHER_ID}` }));
+    expect(removeMutateMock).toHaveBeenCalledWith({
+      boardId: 'board-1',
+      userId: OTHER_ID,
+    });
+  });
+
+  it('closes when the close button is clicked', () => {
+    const { onClose } = renderModal([]);
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});
+
+describe('ShareModal — non-owner', () => {
+  it('shows the sharing ID but hides the members + add sections', () => {
+    renderModal(
+      [{ boardId: 'board-1', userId: OTHER_ID, role: 'viewer' }],
+      false,
+      OTHER_ID,
+    );
+    expect(screen.getByText('Your sharing ID')).toBeInTheDocument();
+    expect(screen.queryByText('Shared with')).not.toBeInTheDocument();
+    expect(screen.queryByText('Add someone')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/board-builder/ShareModal.tsx
+++ b/src/features/board-builder/ShareModal.tsx
@@ -1,0 +1,185 @@
+import { type FormEvent, type JSX, useState } from 'react';
+
+import { useSessionUser } from '@/app/session';
+import {
+  isAlreadyMemberError,
+  isShareForbiddenError,
+  useAddBoardMember,
+  useBoardMembers,
+  useRemoveBoardMember,
+} from '@/lib/queries/board-members';
+import { XIcon } from '@/ui/icons';
+import { Modal } from '@/ui/Modal/Modal';
+
+import styles from './ShareModal.module.css';
+
+const TITLE_ID = 'share-modal-title';
+
+// RFC 4122 v4 / v7 / generic UUID surface check. Supabase uses gen_random_uuid()
+// which emits v4; browser-pasted IDs from a sibling user will look the same.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface ShareModalProps {
+  boardId: string;
+  isOwner: boolean;
+  onClose: () => void;
+}
+
+const useCopy = (): { copied: boolean; copy: (text: string) => void } => {
+  const [copied, setCopied] = useState(false);
+  const copy = (text: string): void => {
+    if (typeof navigator === 'undefined' || !navigator.clipboard) return;
+    void navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+  return { copied, copy };
+};
+
+export const ShareModal = ({ boardId, isOwner, onClose }: ShareModalProps): JSX.Element => {
+  const me = useSessionUser();
+  const members = useBoardMembers(boardId);
+  const addMember = useAddBoardMember();
+  const removeMember = useRemoveBoardMember();
+  const { copied, copy } = useCopy();
+
+  const [draftId, setDraftId] = useState('');
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const submitting = addMember.isPending;
+
+  const submit = (e: FormEvent): void => {
+    e.preventDefault();
+    const trimmed = draftId.trim().toLowerCase();
+    if (!UUID_RE.test(trimmed)) {
+      setSubmitError("That doesn't look like a valid sharing ID.");
+      return;
+    }
+    if (trimmed === me.id) {
+      setSubmitError("That's your own sharing ID.");
+      return;
+    }
+    setSubmitError(null);
+    addMember.mutate(
+      { boardId, userId: trimmed, role: 'viewer' },
+      {
+        onSuccess: () => {
+          setDraftId('');
+        },
+        onError: (err) => {
+          if (isAlreadyMemberError(err)) {
+            setSubmitError("That person already has access to this board.");
+            return;
+          }
+          if (isShareForbiddenError(err)) {
+            setSubmitError("You can't share this board.");
+            return;
+          }
+          setSubmitError("Couldn't add that person. Try again.");
+        },
+      },
+    );
+  };
+
+  return (
+    <Modal onClose={onClose} labelledBy={TITLE_ID}>
+      <div className={styles.wrap}>
+        <header className={styles.header}>
+          <div>
+            <h2 id={TITLE_ID} className={styles.title}>
+              Share this board
+            </h2>
+            <p className={styles.subtitle}>
+              People you share with see this board on their own iPad. They can't make changes.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className={styles.closeBtn}
+          >
+            <XIcon size={18} />
+          </button>
+        </header>
+
+        <section className={styles.section}>
+          <span className={styles.sectionLabel}>Your sharing ID</span>
+          <div className={styles.idRow}>
+            <div className={styles.idValue}>{me.id}</div>
+            <button
+              type="button"
+              onClick={() => copy(me.id)}
+              className={styles.copyBtn}
+              aria-label="Copy your sharing ID"
+            >
+              {copied ? 'Copied' : 'Copy'}
+            </button>
+          </div>
+        </section>
+
+        {isOwner && (
+          <>
+            <section className={styles.section}>
+              <span className={styles.sectionLabel}>Shared with</span>
+              {members.data && members.data.length > 0 ? (
+                <ul className={styles.memberList}>
+                  {members.data.map((m) => (
+                    <li key={m.userId} className={styles.memberRow}>
+                      <span className={styles.memberId}>{m.userId}</span>
+                      <span className={styles.memberRole}>{m.role}</span>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          removeMember.mutate({ boardId, userId: m.userId })
+                        }
+                        aria-label={`Remove ${m.userId}`}
+                        className={styles.removeBtn}
+                        disabled={removeMember.isPending}
+                      >
+                        <XIcon size={14} />
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className={styles.empty}>No one yet.</p>
+              )}
+            </section>
+
+            <section className={styles.section}>
+              <span className={styles.sectionLabel}>Add someone</span>
+              <form className={styles.addRow} onSubmit={submit}>
+                <input
+                  type="text"
+                  className={styles.input}
+                  placeholder="Paste a sharing ID"
+                  autoComplete="off"
+                  value={draftId}
+                  onChange={(e) => {
+                    setDraftId(e.target.value);
+                    if (submitError) setSubmitError(null);
+                  }}
+                  aria-label="Sharing ID"
+                />
+                <button
+                  type="submit"
+                  className={styles.copyBtn}
+                  disabled={submitting || draftId.trim() === ''}
+                >
+                  {submitting ? 'Adding…' : 'Add'}
+                </button>
+              </form>
+              {submitError && (
+                <p role="alert" className={styles.error}>
+                  {submitError}
+                </p>
+              )}
+            </section>
+          </>
+        )}
+      </div>
+    </Modal>
+  );
+};

--- a/src/features/board-builder/ShareModal.tsx
+++ b/src/features/board-builder/ShareModal.tsx
@@ -25,16 +25,39 @@ interface ShareModalProps {
   onClose: () => void;
 }
 
-const useCopy = (): { copied: boolean; copy: (text: string) => void } => {
+interface CopyState {
+  copied: boolean;
+  error: string | null;
+  copy: (text: string) => void;
+}
+
+const useCopy = (): CopyState => {
   const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const copy = (text: string): void => {
-    if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-    void navigator.clipboard.writeText(text).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    });
+    // Insecure context (http://) blocks clipboard API in Chrome/Safari; the
+    // call would reject with an unhelpful DOMException. Short-circuit and
+    // surface the same fallback copy.
+    if (
+      typeof navigator === 'undefined' ||
+      !navigator.clipboard ||
+      (typeof window !== 'undefined' && window.isSecureContext === false)
+    ) {
+      setError("Couldn't copy — select the ID and copy manually.");
+      return;
+    }
+    setError(null);
+    void navigator.clipboard.writeText(text).then(
+      () => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      },
+      () => {
+        setError("Couldn't copy — select the ID and copy manually.");
+      },
+    );
   };
-  return { copied, copy };
+  return { copied, error, copy };
 };
 
 export const ShareModal = ({ boardId, isOwner, onClose }: ShareModalProps): JSX.Element => {
@@ -42,7 +65,7 @@ export const ShareModal = ({ boardId, isOwner, onClose }: ShareModalProps): JSX.
   const members = useBoardMembers(boardId);
   const addMember = useAddBoardMember();
   const removeMember = useRemoveBoardMember();
-  const { copied, copy } = useCopy();
+  const { copied, error: copyError, copy } = useCopy();
 
   const [draftId, setDraftId] = useState('');
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -117,13 +140,25 @@ export const ShareModal = ({ boardId, isOwner, onClose }: ShareModalProps): JSX.
               {copied ? 'Copied' : 'Copy'}
             </button>
           </div>
+          {copyError && (
+            <p role="alert" className={styles.error}>
+              {copyError}
+            </p>
+          )}
         </section>
 
         {isOwner && (
           <>
             <section className={styles.section}>
               <span className={styles.sectionLabel}>Shared with</span>
-              {members.data && members.data.length > 0 ? (
+              {members.isPending ? (
+                // Distinct from the empty state so an owner who's already
+                // shared with someone doesn't see "No one yet." flash before
+                // the first fetch lands.
+                <p className={styles.empty} role="status" aria-live="polite">
+                  Loading…
+                </p>
+              ) : members.data && members.data.length > 0 ? (
                 <ul className={styles.memberList}>
                   {members.data.map((m) => (
                     <li key={m.userId} className={styles.memberRow}>

--- a/src/lib/queries/board-members.test.tsx
+++ b/src/lib/queries/board-members.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import type { JSX, ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -7,14 +7,32 @@ import type { Database } from '@/types/supabase';
 
 type Row = Database['public']['Tables']['board_members']['Row'];
 
+// SELECT builder mocks
 const orderMock = vi.fn<() => Promise<{ data: Row[] | null; error: unknown }>>();
-const eqMock = vi.fn(() => ({ order: orderMock }));
-const selectMock = vi.fn(() => ({ eq: eqMock }));
-const fromMock = vi.fn(() => ({ select: selectMock }));
+const selectEqMock = vi.fn(() => ({ order: orderMock }));
+const selectMock = vi.fn(() => ({ eq: selectEqMock }));
+
+// INSERT mock
+const insertMock = vi.fn<(payload: unknown) => Promise<{ error: unknown }>>();
+
+// DELETE builder mocks: delete().eq().eq() returning a Promise.
+const deleteEq2Mock = vi.fn<() => Promise<{ error: unknown }>>();
+const deleteEq1Mock = vi.fn(() => ({ eq: deleteEq2Mock }));
+const deleteMock = vi.fn(() => ({ eq: deleteEq1Mock }));
+
+const fromMock = vi.fn(() => ({ select: selectMock, insert: insertMock, delete: deleteMock }));
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: () => fromMock() } }));
 
-const { boardMembersQueryKey, rowToBoardMember, useBoardMembers } = await import('./board-members');
+const {
+  boardMembersQueryKey,
+  isAlreadyMemberError,
+  isShareForbiddenError,
+  rowToBoardMember,
+  useAddBoardMember,
+  useBoardMembers,
+  useRemoveBoardMember,
+} = await import('./board-members');
 
 const makeWrapper = (qc: QueryClient) => {
   const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
@@ -43,7 +61,7 @@ describe('boardMembersQueryKey', () => {
 describe('useBoardMembers', () => {
   beforeEach(() => {
     orderMock.mockReset();
-    eqMock.mockClear();
+    selectEqMock.mockClear();
     selectMock.mockClear();
     fromMock.mockClear();
   });
@@ -65,12 +83,106 @@ describe('useBoardMembers', () => {
       { boardId: 'b1', userId: 'u-alice', role: 'viewer' },
       { boardId: 'b1', userId: 'u-bob', role: 'editor' },
     ]);
-    expect(eqMock).toHaveBeenCalledWith('board_id', 'b1');
+    expect(selectEqMock).toHaveBeenCalledWith('board_id', 'b1');
   });
 
   it('is disabled when boardId is empty (no fetch fires)', () => {
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     renderHook(() => useBoardMembers(''), { wrapper: makeWrapper(qc) });
     expect(fromMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('useAddBoardMember', () => {
+  beforeEach(() => {
+    insertMock.mockReset();
+    fromMock.mockClear();
+  });
+
+  it('inserts the row and invalidates the per-board members cache', async () => {
+    insertMock.mockResolvedValueOnce({ error: null });
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+
+    const { result } = renderHook(() => useAddBoardMember(), { wrapper: makeWrapper(qc) });
+
+    act(() => {
+      result.current.mutate({ boardId: 'b1', userId: 'u-bob', role: 'viewer' });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(insertMock).toHaveBeenCalledWith({
+      board_id: 'b1',
+      user_id: 'u-bob',
+      role: 'viewer',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: boardMembersQueryKey('b1'),
+    });
+  });
+
+  it('rejects with the supabase error so callers can branch on .code', async () => {
+    insertMock.mockResolvedValueOnce({
+      error: { code: '23505', message: 'duplicate key' },
+    });
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    const { result } = renderHook(() => useAddBoardMember(), { wrapper: makeWrapper(qc) });
+
+    act(() => {
+      result.current.mutate({ boardId: 'b1', userId: 'u-bob', role: 'viewer' });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(isAlreadyMemberError(result.current.error)).toBe(true);
+    expect(isShareForbiddenError(result.current.error)).toBe(false);
+  });
+});
+
+describe('useRemoveBoardMember', () => {
+  beforeEach(() => {
+    deleteEq2Mock.mockReset();
+    deleteEq1Mock.mockClear();
+    deleteMock.mockClear();
+    fromMock.mockClear();
+  });
+
+  it('deletes the row by composite key and invalidates the cache', async () => {
+    deleteEq2Mock.mockResolvedValueOnce({ error: null });
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+
+    const { result } = renderHook(() => useRemoveBoardMember(), { wrapper: makeWrapper(qc) });
+
+    act(() => {
+      result.current.mutate({ boardId: 'b1', userId: 'u-bob' });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(deleteEq1Mock).toHaveBeenCalledWith('board_id', 'b1');
+    expect(deleteEq2Mock).toHaveBeenCalledWith('user_id', 'u-bob');
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: boardMembersQueryKey('b1'),
+    });
+  });
+});
+
+describe('error classifiers', () => {
+  it('isAlreadyMemberError matches a 23505 unique-violation', () => {
+    expect(isAlreadyMemberError({ code: '23505', message: 'dup' })).toBe(true);
+    expect(isAlreadyMemberError({ code: '42501', message: 'rls' })).toBe(false);
+    expect(isAlreadyMemberError(null)).toBe(false);
+    expect(isAlreadyMemberError('not an object')).toBe(false);
+  });
+
+  it('isShareForbiddenError matches a 42501 RLS denial', () => {
+    expect(isShareForbiddenError({ code: '42501', message: 'rls' })).toBe(true);
+    expect(isShareForbiddenError({ code: '23505', message: 'dup' })).toBe(false);
   });
 });

--- a/src/lib/queries/board-members.test.tsx
+++ b/src/lib/queries/board-members.test.tsx
@@ -1,0 +1,76 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { JSX, ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Database } from '@/types/supabase';
+
+type Row = Database['public']['Tables']['board_members']['Row'];
+
+const orderMock = vi.fn<() => Promise<{ data: Row[] | null; error: unknown }>>();
+const eqMock = vi.fn(() => ({ order: orderMock }));
+const selectMock = vi.fn(() => ({ eq: eqMock }));
+const fromMock = vi.fn(() => ({ select: selectMock }));
+
+vi.mock('@/lib/supabase', () => ({ supabase: { from: () => fromMock() } }));
+
+const { boardMembersQueryKey, rowToBoardMember, useBoardMembers } = await import('./board-members');
+
+const makeWrapper = (qc: QueryClient) => {
+  const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+describe('rowToBoardMember', () => {
+  it('maps snake_case row to camelCase domain shape', () => {
+    expect(rowToBoardMember({ board_id: 'b1', user_id: 'u1', role: 'viewer' })).toEqual({
+      boardId: 'b1',
+      userId: 'u1',
+      role: 'viewer',
+    });
+  });
+});
+
+describe('boardMembersQueryKey', () => {
+  it('returns a tuple keyed by board id so caches segregate per board', () => {
+    expect(boardMembersQueryKey('b1')).toEqual(['board-members', 'b1']);
+    expect(boardMembersQueryKey('b2')).toEqual(['board-members', 'b2']);
+  });
+});
+
+describe('useBoardMembers', () => {
+  beforeEach(() => {
+    orderMock.mockReset();
+    eqMock.mockClear();
+    selectMock.mockClear();
+    fromMock.mockClear();
+  });
+
+  it('fetches members for a board and maps rows to domain', async () => {
+    orderMock.mockResolvedValueOnce({
+      data: [
+        { board_id: 'b1', user_id: 'u-alice', role: 'viewer' },
+        { board_id: 'b1', user_id: 'u-bob', role: 'editor' },
+      ],
+      error: null,
+    });
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    const { result } = renderHook(() => useBoardMembers('b1'), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([
+      { boardId: 'b1', userId: 'u-alice', role: 'viewer' },
+      { boardId: 'b1', userId: 'u-bob', role: 'editor' },
+    ]);
+    expect(eqMock).toHaveBeenCalledWith('board_id', 'b1');
+  });
+
+  it('is disabled when boardId is empty (no fetch fires)', () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    renderHook(() => useBoardMembers(''), { wrapper: makeWrapper(qc) });
+    expect(fromMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/queries/board-members.ts
+++ b/src/lib/queries/board-members.ts
@@ -1,4 +1,10 @@
-import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import {
+  useMutation,
+  type UseMutationResult,
+  useQuery,
+  useQueryClient,
+  type UseQueryResult,
+} from '@tanstack/react-query';
 
 import { supabase } from '@/lib/supabase';
 import type { Database } from '@/types/supabase';
@@ -40,3 +46,64 @@ export const useBoardMembers = (boardId: string): UseQueryResult<BoardMember[]> 
     queryFn: () => fetchBoardMembers(boardId),
     enabled: boardId !== '',
   });
+
+// ─── Error classification ───────────────────────────────────────────────────
+// Postgres returns coded errors that the UI can render as friendly copy.
+// Phase 5 only surfaces two: the PK collision when re-inviting a user, and
+// the RLS rejection when a non-owner tries to share. Anything else falls
+// through to a generic "couldn't add member" message.
+
+export const isAlreadyMemberError = (err: unknown): boolean =>
+  typeof err === 'object' && err !== null && 'code' in err && err.code === '23505';
+
+export const isShareForbiddenError = (err: unknown): boolean =>
+  typeof err === 'object' && err !== null && 'code' in err && err.code === '42501';
+
+// ─── Mutations ──────────────────────────────────────────────────────────────
+// Direct supabase writes (no outbox). Sharing is rare, low-throughput, and
+// failing loudly when offline is fine — the user can re-paste the ID once
+// they're back online. Going through the outbox would also bypass the
+// `is_board_owner` RLS check at enqueue time and we'd only learn at drain.
+
+interface AddBoardMemberInput {
+  boardId: string;
+  userId: string;
+  role: BoardMemberRole;
+}
+
+export const useAddBoardMember = (): UseMutationResult<void, Error, AddBoardMemberInput> => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ boardId, userId, role }) => {
+      const { error } = await supabase
+        .from('board_members')
+        .insert({ board_id: boardId, user_id: userId, role });
+      if (error) throw error;
+    },
+    onSuccess: (_data, { boardId }) => {
+      qc.invalidateQueries({ queryKey: boardMembersQueryKey(boardId) });
+    },
+  });
+};
+
+interface RemoveBoardMemberInput {
+  boardId: string;
+  userId: string;
+}
+
+export const useRemoveBoardMember = (): UseMutationResult<void, Error, RemoveBoardMemberInput> => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ boardId, userId }) => {
+      const { error } = await supabase
+        .from('board_members')
+        .delete()
+        .eq('board_id', boardId)
+        .eq('user_id', userId);
+      if (error) throw error;
+    },
+    onSuccess: (_data, { boardId }) => {
+      qc.invalidateQueries({ queryKey: boardMembersQueryKey(boardId) });
+    },
+  });
+};

--- a/src/lib/queries/board-members.ts
+++ b/src/lib/queries/board-members.ts
@@ -1,0 +1,42 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { supabase } from '@/lib/supabase';
+import type { Database } from '@/types/supabase';
+
+type BoardMemberRow = Database['public']['Tables']['board_members']['Row'];
+
+export type BoardMemberRole = 'owner' | 'editor' | 'viewer';
+
+export interface BoardMember {
+  boardId: string;
+  userId: string;
+  role: BoardMemberRole;
+}
+
+export const rowToBoardMember = (row: BoardMemberRow): BoardMember => ({
+  boardId: row.board_id,
+  userId: row.user_id,
+  role: row.role as BoardMemberRole,
+});
+
+export const boardMembersQueryKey = (boardId: string): readonly ['board-members', string] => [
+  'board-members',
+  boardId,
+];
+
+const fetchBoardMembers = async (boardId: string): Promise<BoardMember[]> => {
+  const { data, error } = await supabase
+    .from('board_members')
+    .select('*')
+    .eq('board_id', boardId)
+    .order('user_id');
+  if (error) throw error;
+  return data.map(rowToBoardMember);
+};
+
+export const useBoardMembers = (boardId: string): UseQueryResult<BoardMember[]> =>
+  useQuery({
+    queryKey: boardMembersQueryKey(boardId),
+    queryFn: () => fetchBoardMembers(boardId),
+    enabled: boardId !== '',
+  });

--- a/supabase/migrations/20260425010000_phase5_share.sql
+++ b/supabase/migrations/20260425010000_phase5_share.sql
@@ -1,0 +1,107 @@
+-- Phase 5: minimum viable sharing.
+--
+-- Owners can already grant other users access to a board via the
+-- `board_members` table that's existed since Phase 2. The phase-3 RLS for
+-- `boards` already honors membership (`is_board_member` on SELECT,
+-- `is_board_editor` on UPDATE). This migration extends that visibility
+-- across the data the board *references*: the owner's pictograms, the
+-- owner's kid record, and the storage bytes for any photo/audio
+-- pictograms on the owner's boards.
+--
+-- Permissive on purpose. A member sees ALL of the owner's pictograms
+-- and ALL of the owner's kids whenever the member belongs to ANY of the
+-- owner's boards — not just the rows referenced by the shared board's
+-- `step_ids`. Trade: simpler policy SQL, no array scans inside RLS, and
+-- a member can still re-add a removed pictogram without the owner
+-- re-sharing. Storage bytes follow the same rule via the file-path
+-- prefix (which encodes the file's owner_id).
+--
+-- Writes stay owner-only across the board. Phase 5 surfaces only the
+-- viewer role; the editor branch in `boards_update` is unchanged but
+-- not yet exposed in UI.
+
+-- ─── pictograms ─────────────────────────────────────────────────────────────
+
+drop policy pictograms_owner_all on pictograms;
+
+create policy pictograms_select on pictograms
+  for select
+  using (
+    owner_id = auth.uid()
+    or exists (
+      select 1
+      from boards b
+      join board_members bm on bm.board_id = b.id
+      where b.owner_id = pictograms.owner_id
+        and bm.user_id = auth.uid()
+    )
+  );
+
+create policy pictograms_owner_write on pictograms
+  for all
+  using (owner_id = auth.uid())
+  with check (owner_id = auth.uid());
+
+-- ─── kids ───────────────────────────────────────────────────────────────────
+
+drop policy kids_owner_all on kids;
+
+create policy kids_select on kids
+  for select
+  using (
+    owner_id = auth.uid()
+    or exists (
+      select 1
+      from boards b
+      join board_members bm on bm.board_id = b.id
+      where b.owner_id = kids.owner_id
+        and bm.user_id = auth.uid()
+    )
+  );
+
+create policy kids_owner_write on kids
+  for all
+  using (owner_id = auth.uid())
+  with check (owner_id = auth.uid());
+
+-- ─── storage: pictogram-images SELECT ───────────────────────────────────────
+-- Existing INSERT/UPDATE/DELETE policies stay owner-only (path-prefix gated).
+-- Only the read policy widens.
+
+drop policy pictogram_images_owner_select on storage.objects;
+
+create policy pictogram_images_member_select on storage.objects
+  for select
+  using (
+    bucket_id = 'pictogram-images'
+    and (
+      auth.uid()::text = (storage.foldername(name))[1]
+      or exists (
+        select 1
+        from boards b
+        join board_members bm on bm.board_id = b.id
+        where b.owner_id::text = (storage.foldername(name))[1]
+          and bm.user_id = auth.uid()
+      )
+    )
+  );
+
+-- ─── storage: pictogram-audio SELECT ────────────────────────────────────────
+
+drop policy pictogram_audio_owner_select on storage.objects;
+
+create policy pictogram_audio_member_select on storage.objects
+  for select
+  using (
+    bucket_id = 'pictogram-audio'
+    and (
+      auth.uid()::text = (storage.foldername(name))[1]
+      or exists (
+        select 1
+        from boards b
+        join board_members bm on bm.board_id = b.id
+        where b.owner_id::text = (storage.foldername(name))[1]
+          and bm.user_id = auth.uid()
+      )
+    )
+  );


### PR DESCRIPTION
## Summary

The smallest possible "share a board with another user" cut. Owner pastes a sharing ID (the other person's user UUID), member sees the board read-only on their own iPad. No email infrastructure, no edge functions, no invite tokens, no notifications.

## What's in here

- **One migration** widens SELECT RLS on `pictograms`, `kids`, and the two storage buckets so a `board_members` row grants the member visibility into the owner's data referenced by the shared board. Writes stay owner-only. Schema unchanged.
- **`useBoardMembers(boardId)`** query hook + **`useAddBoardMember`** / **`useRemoveBoardMember`** mutations, direct supabase calls (no outbox — sharing is rare and offline failure is fine).
- **`ShareModal`** with three sections: copyable sharing ID, members list with remove, add-by-UUID form. Inline error states for invalid UUID, your-own-id, already-member (`23505`), RLS-forbidden (`42501`).
- **Owner-only Share button** in `BoardBuilder` header; `?share=1` URL param for back-button + deep-link parity with `?picker=1`.

## What's deferred to a hypothetical Phase 6

Email-based invites, editor role UI, "you've been added" notifications, cross-board sharing settings page. All explicitly out of scope per the plan — sharing is not a high-value feature for current single-caregiver / single-iPad use cases.

## Test plan

- [x] `tsc -b` clean
- [x] `eslint --max-warnings 0` clean
- [x] `vitest run` 149/149 green (+21 new tests)
- [x] `vite build` clean, PWA precache unchanged
- [x] `supabase db reset` applies the migration cleanly
- [ ] Two-profile manual smoke: A signs up, B signs up, A pastes B's sharing ID into Morning routine's Share modal, B reloads ParentHome and sees the board, B opens it and pictograms render (illus + photo + audio), B's edit attempts fail-rollback, A removes B and B's view disappears on next reload
- [ ] RLS isolation: an unrelated third user C still sees nothing of A or B

🤖 Generated with [Claude Code](https://claude.com/claude-code)