### PR TITLE
Fix shared-board RLS via helper functions (#37)

### DIFF
--- a/supabase/migrations/20260425020000_storage_rls_helper.sql
+++ b/supabase/migrations/20260425020000_storage_rls_helper.sql
@@ -1,0 +1,69 @@
+-- Phase 5 follow-up: storage RLS via helper function (issue #37).
+--
+-- The original phase-5 migration (20260425010000) widened storage SELECT
+-- so board members could read the bytes of an owner's photo / audio
+-- pictograms. It did this by inlining a `boards × board_members` join
+-- inside each policy's USING clause. The unqualified `name` reference
+-- inside the EXISTS subquery resolved to `boards.name` (column
+-- shadowing) instead of the outer `storage.objects.name`. Effect: the
+-- predicate compared the file's owner_id against a board title, never
+-- matched, and the member branch was dead.
+--
+-- The bug was reachable because the phase-5 migration diverged from
+-- the helper-function pattern used everywhere else in the project's
+-- RLS (see `is_board_owner` / `is_board_member` / `is_board_editor` in
+-- 20260425000000_real_auth_onboarding.sql). This migration restores
+-- that pattern: a single SECURITY DEFINER helper takes the storage
+-- object name as a *function parameter* (not a column reference, so
+-- nothing in scope can shadow it) and the two storage SELECT policies
+-- become two-line predicates that call it.
+--
+-- Renames `pictogram_*_member_select` → `pictogram_*_select`. The old
+-- name was misleading — the helper covers both the owner and member
+-- branches. Writes stay owner-only via the policies created in
+-- 20260424160000 / 20260424170000, untouched here.
+
+drop policy pictogram_audio_member_select on storage.objects;
+drop policy pictogram_images_member_select on storage.objects;
+
+-- ─── helper ─────────────────────────────────────────────────────────────────
+--
+-- `p_object_name` is the value of `storage.objects.name` for the row
+-- being policy-checked. We accept it as an argument rather than reading
+-- it from a column reference so the function body is structurally
+-- immune to the column-shadowing class that broke the inline policy.
+--
+-- A pictogram storage path is `<owner_uuid>/<pictogram_uuid>.<ext>`,
+-- so `(storage.foldername(p_object_name))[1]` is the file owner's
+-- user_id as text.
+
+create or replace function is_pictogram_storage_visible(p_object_name text)
+returns boolean
+language sql security definer stable
+set search_path = public as $$
+  select
+    auth.uid()::text = (storage.foldername(p_object_name))[1]
+    or exists (
+      select 1
+      from boards b
+      join board_members bm on bm.board_id = b.id
+      where b.owner_id::text = (storage.foldername(p_object_name))[1]
+        and bm.user_id = auth.uid()
+    );
+$$;
+
+-- ─── policies ───────────────────────────────────────────────────────────────
+
+create policy pictogram_audio_select on storage.objects
+  for select
+  using (
+    bucket_id = 'pictogram-audio'
+    and is_pictogram_storage_visible(name)
+  );
+
+create policy pictogram_images_select on storage.objects
+  for select
+  using (
+    bucket_id = 'pictogram-images'
+    and is_pictogram_storage_visible(name)
+  );

--- a/supabase/migrations/20260425030000_owner_share_helper.sql
+++ b/supabase/migrations/20260425030000_owner_share_helper.sql
@@ -1,0 +1,47 @@
+-- Continue closing pattern divergences from Phase 5 (issue #37 follow-up).
+--
+-- 20260425010000 created `pictograms_select` and `kids_select` with the
+-- same inline `boards × board_members` EXISTS join shape that produced
+-- the storage RLS bug fixed in 20260425020000. These two are safe today
+-- because their inner predicates are table-qualified (`pictograms.owner_id`,
+-- `kids.owner_id`) — but the divergence from the helper-function pattern
+-- used everywhere else (`is_board_owner` / `is_board_member` /
+-- `is_board_editor` / `is_pictogram_storage_visible`) is the landmine.
+-- A future RLS author copying this shape into a new policy reintroduces
+-- the column-shadowing surface.
+--
+-- Extract `is_owner_shared_with_me(p_owner_id uuid)` and rewrite the two
+-- policies as one-line predicates that call it. The helper centralizes
+-- the visibility rule for any owner-scoped table the project shares via
+-- `board_members`; storage has its own helper because it takes a path
+-- string instead of a uuid.
+
+drop policy pictograms_select on pictograms;
+drop policy kids_select on kids;
+
+-- The visibility predicate for any owner-scoped table the project
+-- shares via board_members. Owner sees own rows; members of any of
+-- the owner's boards see the owner's rows. Symmetric to (but not
+-- nested in) `is_pictogram_storage_visible(text)` — keeping them
+-- parallel-but-separate avoids the cast-error trap of feeding a
+-- malformed storage path into a function expecting a uuid.
+
+create or replace function is_owner_shared_with_me(p_owner_id uuid)
+returns boolean
+language sql security definer stable
+set search_path = public as $$
+  select p_owner_id = auth.uid()
+    or exists (
+      select 1
+      from boards b
+      join board_members bm on bm.board_id = b.id
+      where b.owner_id = p_owner_id
+        and bm.user_id = auth.uid()
+    );
+$$;
+
+create policy pictograms_select on pictograms
+  for select using (is_owner_shared_with_me(owner_id));
+
+create policy kids_select on kids
+  for select using (is_owner_shared_with_me(owner_id));

--- a/supabase/tests/pictograms_kids_share_rls_test.sql
+++ b/supabase/tests/pictograms_kids_share_rls_test.sql
@@ -1,0 +1,196 @@
+-- Regression test for pictograms / kids RLS shared-board access.
+--
+-- Parallel to storage_share_rls_test.sql but for the data-plane policies
+-- (`pictograms_select`, `kids_select`) that gate the rows whose
+-- `image_path` / `audio_path` columns the storage policies then gate
+-- bytes for. The two layers must agree: a member should see both the
+-- row and the bytes; a non-member should see neither.
+--
+-- Four users with the same shape as the storage test (Alice owner;
+-- Bob member of Alice; Charlie unrelated; Dana cross-owner member of
+-- Charlie's board, NOT Alice's). Asserts:
+--
+--   helper layer  — `is_owner_shared_with_me(uuid)` returns the right
+--                   answer for owner / member / non-member /
+--                   cross-owner-member.
+--   policy layer  — SELECT through `pictograms_select` and
+--                   `kids_select` returns the owner's rows for the
+--                   owner and the member; zero rows for the
+--                   non-member and the cross-owner-member.
+--   write floor   — a member cannot UPDATE the owner's pictograms
+--                   (the existing `pictograms_owner_write` policy
+--                   still gates writes).
+--
+-- Run with: supabase test db
+BEGIN;
+SELECT plan(13);
+
+INSERT INTO auth.users (id, email)
+VALUES
+  ('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', 'alice@test.local'),
+  ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', 'bob@test.local'),
+  ('cccccccc-cccc-4ccc-8ccc-cccccccccccc', 'charlie@test.local'),
+  ('dddddddd-dddd-4ddd-8ddd-dddddddddddd', 'dana@test.local');
+
+INSERT INTO public.board_members (board_id, user_id, role)
+SELECT id, 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', 'viewer'
+  FROM public.boards
+ WHERE owner_id = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+ ORDER BY id LIMIT 1;
+
+INSERT INTO public.board_members (board_id, user_id, role)
+SELECT id, 'dddddddd-dddd-4ddd-8ddd-dddddddddddd', 'viewer'
+  FROM public.boards
+ WHERE owner_id = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+ ORDER BY id LIMIT 1;
+
+-- Capture Alice's row counts BEFORE role switching, while still postgres.
+-- Used as the expected count under owner + member sessions, so the test
+-- doesn't hardcode template_pictograms / template_boards numbers.
+-- The GRANT is needed because authenticated role doesn't get SELECT on
+-- temp tables by default; without it the post-role-switch reads fail.
+CREATE TEMP TABLE expected AS
+  SELECT
+    (SELECT count(*)::int FROM public.pictograms
+      WHERE owner_id = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa') AS pictograms,
+    (SELECT count(*)::int FROM public.kids
+      WHERE owner_id = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa') AS kids;
+GRANT SELECT ON expected TO authenticated;
+
+-- ── 1. Helper exists ───────────────────────────────────────────────────────
+
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public'
+       AND p.proname = 'is_owner_shared_with_me'
+       AND p.prosecdef = true
+  ),
+  'is_owner_shared_with_me exists in public schema as SECURITY DEFINER'
+);
+
+-- ── 2-5. Helper logic, four roles ──────────────────────────────────────────
+
+SET LOCAL ROLE authenticated;
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","role":"authenticated"}';
+SELECT ok(
+  is_owner_shared_with_me('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid),
+  'helper: owner shares with self'
+);
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb","role":"authenticated"}';
+SELECT ok(
+  is_owner_shared_with_me('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid),
+  'helper: board member sees owner data'
+);
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"cccccccc-cccc-4ccc-8ccc-cccccccccccc","role":"authenticated"}';
+SELECT ok(
+  NOT is_owner_shared_with_me('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid),
+  'helper: stranger does not see owner data'
+);
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","role":"authenticated"}';
+SELECT ok(
+  NOT is_owner_shared_with_me('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid),
+  'helper: cross-owner member (dana) does not see alice data (scoped-membership guard)'
+);
+
+-- ── 6-9. pictograms_select policy, four roles ──────────────────────────────
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","role":"authenticated"}';
+SELECT is(
+  (SELECT count(*)::int FROM public.pictograms
+    WHERE owner_id = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'),
+  (SELECT pictograms FROM expected),
+  'policy: owner sees full pictogram library'
+);
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb","role":"authenticated"}';
+SELECT is(
+  (SELECT count(*)::int FROM public.pictograms
+    WHERE owner_id = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'),
+  (SELECT pictograms FROM expected),
+  'policy: board member sees owner pictogram library'
+);
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"cccccccc-cccc-4ccc-8ccc-cccccccccccc","role":"authenticated"}';
+SELECT is(
+  (SELECT count(*)::int FROM public.pictograms
+    WHERE owner_id = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'),
+  0,
+  'policy: stranger sees zero of owner pictograms'
+);
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","role":"authenticated"}';
+SELECT is(
+  (SELECT count(*)::int FROM public.pictograms
+    WHERE owner_id = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'),
+  0,
+  'policy: cross-owner member sees zero of owner pictograms (scoped-membership guard)'
+);
+
+-- ── 10-12. kids_select policy, three roles ─────────────────────────────────
+-- Owner and member must see Alice's seeded kid; non-member and
+-- cross-owner-member must not. (Picking three of the four roles —
+-- owner/member/cross-owner — covers the same logic plane as pictograms;
+-- one row in `kids` per user means the owner+member case is the load-
+-- bearing one.)
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","role":"authenticated"}';
+SELECT is(
+  (SELECT count(*)::int FROM public.kids
+    WHERE owner_id = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'),
+  (SELECT kids FROM expected),
+  'policy: owner sees own kid'
+);
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb","role":"authenticated"}';
+SELECT is(
+  (SELECT count(*)::int FROM public.kids
+    WHERE owner_id = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'),
+  (SELECT kids FROM expected),
+  'policy: board member sees owner kid'
+);
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","role":"authenticated"}';
+SELECT is(
+  (SELECT count(*)::int FROM public.kids
+    WHERE owner_id = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'),
+  0,
+  'policy: cross-owner member sees zero of owner kids (scoped-membership guard)'
+);
+
+-- ── 13. Member cannot UPDATE owner pictograms ──────────────────────────────
+-- The widened SELECT must not have widened writes. The existing
+-- `pictograms_owner_write` policy keeps writes owner-only.
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb","role":"authenticated"}';
+
+WITH upd AS (
+  UPDATE public.pictograms SET label = label
+   WHERE owner_id = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+   RETURNING 1
+)
+SELECT is(
+  (SELECT count(*)::int FROM upd),
+  0,
+  'policy: member cannot UPDATE owner pictograms (RLS-filtered)'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/storage_share_rls_test.sql
+++ b/supabase/tests/storage_share_rls_test.sql
@@ -1,0 +1,251 @@
+-- Regression test for storage RLS shared-board access (issue #37).
+--
+-- Four users:
+--   Alice   — owns the board + storage we're sharing.
+--   Bob     — viewer on one of Alice's boards. Should see her storage.
+--   Charlie — no membership anywhere. Should see nothing.
+--   Dana    — viewer on one of Charlie's boards but NOT Alice's. Catches
+--             a regression where the predicate loosens from "member of
+--             this owner" to "member anywhere".
+--
+-- The test exercises the actual policies under role-switched sessions
+-- and asserts:
+--
+--   helper layer  — `is_pictogram_storage_visible(path)` returns
+--                   true for the owner, true for a member, false for
+--                   a stranger or a cross-owner member.
+--   policy layer  — SELECT through `pictogram_audio_select` and
+--                   `pictogram_images_select` returns 1/1/0/0 rows
+--                   for owner/member/non-member/cross-owner-member.
+--   write floor   — a member cannot UPDATE or INSERT into the owner's
+--                   prefix; the existing owner-only write policies
+--                   still gate writes. (DELETE on storage.objects is
+--                   blocked by a supabase `protect_delete` trigger
+--                   that fires before RLS, so DELETE isn't testable
+--                   from SQL — the storage API enforces it.)
+--
+-- The "member sees 1 row" assertions are the specific guards against
+-- the shadowing bug fixed in 20260425020000. Any future regression
+-- that re-breaks the member branch (column shadow, missing helper,
+-- bad cast) will land on these.
+--
+-- Run with: supabase test db
+BEGIN;
+SELECT plan(17);
+
+-- Four users. handle_new_user() seeds a starter library for each on
+-- INSERT, so Alice and Charlie each end up owning a few boards.
+INSERT INTO auth.users (id, email)
+VALUES
+  ('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', 'alice@test.local'),
+  ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', 'bob@test.local'),
+  ('cccccccc-cccc-4ccc-8ccc-cccccccccccc', 'charlie@test.local'),
+  ('dddddddd-dddd-4ddd-8ddd-dddddddddddd', 'dana@test.local');
+
+-- Bob is a viewer on Alice's first seeded board.
+INSERT INTO public.board_members (board_id, user_id, role)
+SELECT id, 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', 'viewer'
+  FROM public.boards
+ WHERE owner_id = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+ ORDER BY id LIMIT 1;
+
+-- Dana is a viewer on Charlie's first seeded board (NOT Alice's). She
+-- is a member-somewhere but not of Alice's data.
+INSERT INTO public.board_members (board_id, user_id, role)
+SELECT id, 'dddddddd-dddd-4ddd-8ddd-dddddddddddd', 'viewer'
+  FROM public.boards
+ WHERE owner_id = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+ ORDER BY id LIMIT 1;
+
+-- Precondition pinning: confirm both viewer rows actually got inserted.
+-- If a future migration adds a constraint that prevents these inserts,
+-- the rest of the test would silently pass against an empty fixture.
+SELECT is(
+  (SELECT count(*)::int FROM public.board_members
+    WHERE user_id = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'),
+  1,
+  'fixture: bob is a viewer on exactly one board (alice''s)'
+);
+SELECT is(
+  (SELECT count(*)::int FROM public.board_members
+    WHERE user_id = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'),
+  1,
+  'fixture: dana is a viewer on exactly one board (charlie''s, not alice''s)'
+);
+
+-- One fake storage object per bucket under Alice's prefix.
+-- Path shape matches what the client uploader writes.
+INSERT INTO storage.objects (bucket_id, name, owner) VALUES
+  ('pictogram-audio',
+   'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/wakeup.webm',
+   'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid),
+  ('pictogram-images',
+   'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/wakeup.jpg',
+   'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid);
+
+-- ── 1. Helper exists with the right shape ──────────────────────────────────
+
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public'
+       AND p.proname = 'is_pictogram_storage_visible'
+       AND p.prosecdef = true
+  ),
+  'is_pictogram_storage_visible exists in public schema as SECURITY DEFINER'
+);
+
+-- ── 2-4. Helper logic, three roles ─────────────────────────────────────────
+-- SET LOCAL applies for the rest of the transaction; subsequent SET LOCALs
+-- replace previous values. ROLLBACK at the end discards everything.
+
+SET LOCAL ROLE authenticated;
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","role":"authenticated"}';
+SELECT ok(
+  is_pictogram_storage_visible('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/wakeup.webm'),
+  'helper: owner sees own audio path'
+);
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb","role":"authenticated"}';
+SELECT ok(
+  is_pictogram_storage_visible('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/wakeup.webm'),
+  'helper: board member sees owner audio path (#37 regression guard)'
+);
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"cccccccc-cccc-4ccc-8ccc-cccccccccccc","role":"authenticated"}';
+SELECT ok(
+  NOT is_pictogram_storage_visible('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/wakeup.webm'),
+  'helper: non-member does not see owner audio path'
+);
+
+-- Dana is a member of CHARLIE's board, not Alice's. She must not see
+-- Alice's storage. Catches a regression where the predicate loosens
+-- from "scoped to this owner's boards" to "any membership anywhere".
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","role":"authenticated"}';
+SELECT ok(
+  NOT is_pictogram_storage_visible('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/wakeup.webm'),
+  'helper: cross-owner member (dana) does not see alice audio path'
+);
+
+-- ── Policy through SELECT, four roles, audio ───────────────────────────────
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","role":"authenticated"}';
+SELECT is(
+  (SELECT count(*)::int FROM storage.objects
+    WHERE bucket_id = 'pictogram-audio'
+      AND name = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/wakeup.webm'),
+  1,
+  'policy: owner SELECT returns 1 audio row'
+);
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb","role":"authenticated"}';
+SELECT is(
+  (SELECT count(*)::int FROM storage.objects
+    WHERE bucket_id = 'pictogram-audio'
+      AND name = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/wakeup.webm'),
+  1,
+  'policy: board member SELECT returns 1 audio row (#37 regression guard)'
+);
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"cccccccc-cccc-4ccc-8ccc-cccccccccccc","role":"authenticated"}';
+SELECT is(
+  (SELECT count(*)::int FROM storage.objects
+    WHERE bucket_id = 'pictogram-audio'
+      AND name = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/wakeup.webm'),
+  0,
+  'policy: non-member SELECT returns 0 audio rows'
+);
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","role":"authenticated"}';
+SELECT is(
+  (SELECT count(*)::int FROM storage.objects
+    WHERE bucket_id = 'pictogram-audio'
+      AND name = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/wakeup.webm'),
+  0,
+  'policy: cross-owner member SELECT returns 0 audio rows (scoped-membership guard)'
+);
+
+-- ── Policy through SELECT, four roles, images ──────────────────────────────
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","role":"authenticated"}';
+SELECT is(
+  (SELECT count(*)::int FROM storage.objects
+    WHERE bucket_id = 'pictogram-images'
+      AND name = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/wakeup.jpg'),
+  1,
+  'policy: owner SELECT returns 1 image row'
+);
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb","role":"authenticated"}';
+SELECT is(
+  (SELECT count(*)::int FROM storage.objects
+    WHERE bucket_id = 'pictogram-images'
+      AND name = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/wakeup.jpg'),
+  1,
+  'policy: board member SELECT returns 1 image row'
+);
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"cccccccc-cccc-4ccc-8ccc-cccccccccccc","role":"authenticated"}';
+SELECT is(
+  (SELECT count(*)::int FROM storage.objects
+    WHERE bucket_id = 'pictogram-images'
+      AND name = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/wakeup.jpg'),
+  0,
+  'policy: non-member SELECT returns 0 image rows'
+);
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","role":"authenticated"}';
+SELECT is(
+  (SELECT count(*)::int FROM storage.objects
+    WHERE bucket_id = 'pictogram-images'
+      AND name = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/wakeup.jpg'),
+  0,
+  'policy: cross-owner member SELECT returns 0 image rows (scoped-membership guard)'
+);
+
+-- ── Member cannot write to owner's prefix ──────────────────────────────────
+-- The widened SELECT must not have widened writes. UPDATE is RLS-filtered
+-- to 0 rows by the existing owner-only UPDATE policy; INSERT is rejected
+-- outright by the existing path-prefix-gated INSERT policy.
+
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb","role":"authenticated"}';
+
+WITH upd AS (
+  UPDATE storage.objects SET name = name
+   WHERE bucket_id = 'pictogram-audio'
+     AND name = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/wakeup.webm'
+   RETURNING 1
+)
+SELECT is(
+  (SELECT count(*)::int FROM upd),
+  0,
+  'policy: member cannot UPDATE owner audio (RLS-filtered)'
+);
+
+SELECT throws_ok(
+  $$ INSERT INTO storage.objects (bucket_id, name, owner)
+     VALUES ('pictogram-audio',
+             'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/bob-tried.webm',
+             'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'::uuid) $$,
+  '42501',
+  NULL,
+  'policy: member cannot INSERT into owner prefix'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Closes #37 and structurally closes the same pattern divergence on three RLS surfaces, not just one.

## What changed

The Phase 5 migration (20260425010000) inlined a `boards × board_members` join inside four policy USING clauses: `pictograms_select`, `kids_select`, and the two `pictogram_*_member_select` storage policies. The storage variants tripped a column-shadowing bug (unqualified `name` resolved to `boards.name` instead of `storage.objects.name`); the data-plane variants happened to be safe by accident (table-qualified inner predicates) but were the same landmine.

The bug was reachable only because Phase 5 broke the project's helper-function RLS pattern (`is_board_owner`, `is_board_member`, `is_board_editor`). This PR restores it across all four sharing policies.

### Structural fix

**`supabase/migrations/20260425020000_storage_rls_helper.sql`** — `is_pictogram_storage_visible(p_object_name text)` SECURITY DEFINER. Takes the object name as a *function parameter*, not a column reference, so column shadowing is structurally impossible inside the body. Replaces the buggy `pictogram_*_member_select` policies with clean one-line `pictogram_*_select` predicates.

**`supabase/migrations/20260425030000_owner_share_helper.sql`** — `is_owner_shared_with_me(p_owner_id uuid)` SECURITY DEFINER. Centralizes the visibility predicate for every owner-scoped table the project shares via `board_members`. `pictograms_select` and `kids_select` become one-line predicates that call it.

```sql
create policy pictograms_select on pictograms
  for select using (is_owner_shared_with_me(owner_id));
create policy kids_select on kids
  for select using (is_owner_shared_with_me(owner_id));
create policy pictogram_audio_select on storage.objects
  for select using (bucket_id = 'pictogram-audio' and is_pictogram_storage_visible(name));
create policy pictogram_images_select on storage.objects
  for select using (bucket_id = 'pictogram-images' and is_pictogram_storage_visible(name));
```

### Regression tests

Both run via the existing `npm run test:db` (pgTAP). Same four-role matrix: Alice (owner) / Bob (member of Alice) / Charlie (no membership) / Dana (member of Charlie's board, NOT Alice's).

**`supabase/tests/storage_share_rls_test.sql`** — 17 assertions covering helper layer, policy layer (audio + images), write floor (UPDATE filtered, INSERT rejected with 42501), plus fixture preconditions.

**`supabase/tests/pictograms_kids_share_rls_test.sql`** — 13 assertions covering helper layer (`is_owner_shared_with_me`) and policy layer (`pictograms_select`, `kids_select`) under the same four roles, plus a member-cannot-write assertion.

The **cross-owner member case** (Dana) is the load-bearing addition: it catches a regression where the predicate loosens from "scoped to this owner's boards" to "any membership anywhere". The "member sees N rows" assertions in both files are the explicit guards against the shadowing class — column shadow, missing `security definer`, bad cast, scope loosening, or any future RLS regression in this area lands on them immediately.

## Verification

- [x] `supabase db reset` applies all migrations clean
- [x] `npm run test:db` → 44/44 (14 existing trigger tests + 17 storage RLS + 13 pictograms/kids RLS)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (`--max-warnings 0`)
- [x] `npm test -- --run` 152/152 green
- [x] Chrome DevTools two-profile end-to-end: Alice uploads audio + shares with Bob; Bob taps pictogram in kid mode; sign POST returns 200, asset GET returns 206, `Audio.play` receives the signed URL. Pre-fix this returned 404.

## Test plan

- [ ] Run `supabase db reset && npm run test:db` on a clean checkout
- [ ] Two browser profiles: A records real audio, shares board with B; B opens shared kid mode and hears the recording
- [ ] Confirm an unrelated third user still sees nothing (RLS isolation)