### PR TITLE
Drop dead @/data guard, fix stale README + auth.md docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ supabase db reset                    # applies migrations + seeds 4 demo boards
 npm run dev
 ```
 
-Open the URL Vite prints (usually `http://localhost:5173`). The app signs in
-automatically as the seeded stub user — no login screen. Supabase Studio is at
+Open the URL Vite prints (usually `http://localhost:5173`). You'll get a login
+screen — enter any email, then grab the 6-digit OTP from Mailpit at
+`http://127.0.0.1:54324` (Supabase ships Mailpit as the local SMTP catch-all).
+See `docs/auth.md` for the full flow. Supabase Studio is at
 `http://127.0.0.1:54323` if you want to poke around the DB.
 
 ## Day-to-day commands
@@ -117,10 +119,10 @@ shared (lib, ui, theme, types, glyphs, layouts)  →  features  →  app
   shell, PIN gate, modal/picker) belongs in `layouts/` or `ui/`, not
   `features/`.
 
-**Currently enforced by ESLint:** `no-restricted-imports` blocks `@/data/*`
-from `features/`. **TODO:** add `import/no-restricted-paths` to block sibling
-`features/X` ↔ `features/Y` imports and reverse imports from `lib/* | ui/* |
-layouts/* → app/*`.
+**TODO:** add `import/no-restricted-paths` to block sibling `features/X` ↔
+`features/Y` imports, reverse imports from `lib/* | ui/* | layouts/* → app/*`,
+and direct `supabase.from(...)` calls from `features/*` (the real "single read
+path through `lib/queries/*`" guard). Tracked in #39.
 
 ### Per-feature scope
 
@@ -141,7 +143,6 @@ Vite tree-shaking prefers it.
 - `src/types/supabase.ts` is generated and only read inside
   `lib/queries/*` row-to-domain mappers. Everything else sees clean domain
   types from `src/types/domain.ts`.
-- Feature code MUST NOT import from `@/data/*` (seed-only).
 
 ### State
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -84,12 +84,3 @@ where bucket_id in ('pictogram-audio', 'pictogram-images')
 
 For local dev this is a non-issue because `supabase db reset` clears
 storage.objects alongside the schema.
-
-## What got deleted
-
-- `src/lib/localAuth.ts` and `LOCAL_PARENT_ID` / `LOCAL_KID_ID` constants.
-- `ensureStubSession`, `STUB_EMAIL`, `STUB_PASSWORD` in `src/lib/supabase.ts`.
-- The `auth.users` / `auth.identities` seed block in
-  `scripts/gen-seed.ts` — no dev-password rows in `seed.sql`.
-- `slugifyLabel` in `src/lib/image.ts` — photo-pictogram ids are now
-  uuids generated via `crypto.randomUUID()`.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,21 +39,4 @@ export default tseslint.config(
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
     },
   },
-  {
-    files: ['src/features/**/*.{ts,tsx}'],
-    rules: {
-      'no-restricted-imports': [
-        'error',
-        {
-          patterns: [
-            {
-              group: ['@/data/*'],
-              message:
-                'Feature code must read through @/lib/queries/* (Phase 2 DRY boundary). @/data/* is the seed source of truth for the DB only.',
-            },
-          ],
-        },
-      ],
-    },
-  },
 );


### PR DESCRIPTION
## Summary

Three small doc/config drift fixes flagged during the #41/#42 work.

- **#51** — `eslint.config.js` had a `no-restricted-imports` block on `@/data/*`, but `src/data/` was deleted in `e4e6fca`. The rule guards a path nothing could resolve to. Removed; also dropped the two stale README references and rephrased the layering TODO around the *real* rule we want (single read path through `lib/queries/*`, tracked under #39).
- **#52** — README first-time setup said the app "signs in automatically as the seeded stub user." That stopped being true in Phase 3 (commit `85f8f9e`). New contributors hit a login screen with no idea where to find the OTP. Now points at Mailpit (`127.0.0.1:54324`, cross-checked against `supabase status`).
- **#50** — `docs/auth.md` had a "What got deleted" changelog section listing files that have themselves since been deleted (`localAuth.ts`, `gen-seed.ts`). Removed — `git log` is the authoritative changelog.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (confirms no code actually relied on the removed @/data rule)
- [x] `npm run test` — 152/152 passing
- [x] `grep -rn '@/data\\|src/data'` returns nothing
- [x] Mailpit URL cross-checked against `supabase status` output

Closes #50, #51, #52.