### PR TITLE
Flush Prettier formatting drift across repo

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+coverage
+src/types/supabase.ts

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ docs/
 
 - If the app boots blank or the network tab shows Supabase 500s, run
   `supabase status` to confirm the stack is up. `supabase stop` + `supabase
-  start` is the restart path.
+start` is the restart path.
 - After any migration edit, run `supabase db reset` (applies migrations +
   seed) and `npm run types:db` (regenerates DB types). Commit both the
   migration and the updated `src/types/supabase.ts`.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -56,7 +56,7 @@ can't be abused to mutate them.
 ## Schema notes
 
 - `kids.id`, `pictograms.id`, `boards.id` are all `uuid primary key default
-  gen_random_uuid()`.
+gen_random_uuid()`.
 - Text slugs ('apple', 'morning', 'liam') are preserved as an optional
   `slug text` column (with a `unique (owner_id, slug)` constraint on
   pictograms and boards). They're used by a handful of client-side lookup
@@ -64,7 +64,7 @@ can't be abused to mutate them.
   `GenerateTab.RESULT_SLUGS` — via `usePictogramsBySlug`.
 - `boards.kid_id uuid references kids(id) on delete cascade` — real FK.
 - `boards.step_ids uuid[]` — the trigger rewrites template `step_slugs
-  text[]` into per-user uuids at signup.
+text[]` into per-user uuids at signup.
 - `board_members.board_id uuid references boards(id)` — unchanged in shape.
 
 ## Storage cleanup caveat

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -36,7 +36,10 @@ export default tseslint.config(
       'simple-import-sort/imports': 'error',
       'simple-import-sort/exports': 'error',
       '@typescript-eslint/consistent-type-imports': ['error', { prefer: 'type-imports' }],
-      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
     },
   },
   {

--- a/src/app/AuthGate.tsx
+++ b/src/app/AuthGate.tsx
@@ -64,9 +64,7 @@ export const AuthGate = ({ children }: { children: ReactNode }): JSX.Element => 
 const AuthGateOfflineHint = (): JSX.Element | null => {
   const online = useOnline();
   if (online) return null;
-  return (
-    <p className={styles.errorBody}>You're offline — Retry once your connection is back.</p>
-  );
+  return <p className={styles.errorBody}>You're offline — Retry once your connection is back.</p>;
 };
 
 const HUNG_GETSESSION_HINT_MS = 5000;

--- a/src/features/login/Login.tsx
+++ b/src/features/login/Login.tsx
@@ -86,11 +86,7 @@ export const Login = (): JSX.Element => {
               />
             </label>
             {error && <div className={styles.error}>{error}</div>}
-            <Button
-              type="submit"
-              variant="primary"
-              disabled={busy || !email.trim() || !online}
-            >
+            <Button type="submit" variant="primary" disabled={busy || !email.trim() || !online}>
               {busy ? 'Sending…' : 'Send code'}
             </Button>
           </form>
@@ -130,11 +126,7 @@ export const Login = (): JSX.Element => {
               >
                 Back
               </Button>
-              <Button
-                type="submit"
-                variant="primary"
-                disabled={busy || code.length < 6 || !online}
-              >
+              <Button type="submit" variant="primary" disabled={busy || code.length < 6 || !online}>
                 {busy ? 'Verifying…' : 'Sign in'}
               </Button>
             </div>

--- a/src/features/parent-home/BoardCard.module.css
+++ b/src/features/parent-home/BoardCard.module.css
@@ -8,7 +8,9 @@
   flex-direction: column;
   gap: 14px;
   border: 1px solid var(--tal-line-soft);
-  transition: transform 0.15s, box-shadow 0.15s;
+  transition:
+    transform 0.15s,
+    box-shadow 0.15s;
   width: 100%;
   font-family: inherit;
   color: inherit;

--- a/src/features/parent-home/ParentHomeRoute.tsx
+++ b/src/features/parent-home/ParentHomeRoute.tsx
@@ -30,10 +30,5 @@ export const ParentHomeRoute = (): JSX.Element => {
     if (firstSequence) navigate(`/kid/sequence/${firstSequence.id}`);
   };
 
-  return (
-    <ParentHome
-      onOpenBoard={(id) => navigate(`/boards/${id}/edit`)}
-      onKidMode={onKidMode}
-    />
-  );
+  return <ParentHome onOpenBoard={(id) => navigate(`/boards/${id}/edit`)} onKidMode={onKidMode} />;
 };

--- a/src/features/pictogram-picker/PictoPicker.tsx
+++ b/src/features/pictogram-picker/PictoPicker.tsx
@@ -42,7 +42,7 @@ export const PictoPicker = ({ onClose, onConfirm }: PictoPickerProps): JSX.Eleme
   // Keep the dialog's pictogram in sync with the query cache so `audio_path`
   // updates (record → save, delete) flow through without remounting.
   const editingVoiceLive = editingVoice
-    ? pictograms.find((p) => p.id === editingVoice.id) ?? editingVoice
+    ? (pictograms.find((p) => p.id === editingVoice.id) ?? editingVoice)
     : null;
 
   const toggle = (id: string): void => {
@@ -66,9 +66,7 @@ export const PictoPicker = ({ onClose, onConfirm }: PictoPickerProps): JSX.Eleme
           <h2 id={TITLE_ID} className={styles.title}>
             Add pictograms
           </h2>
-          <p className={styles.subtitle}>
-            Pick from the library, upload a photo, or generate one.
-          </p>
+          <p className={styles.subtitle}>Pick from the library, upload a photo, or generate one.</p>
         </div>
         <button
           type="button"
@@ -123,10 +121,7 @@ export const PictoPicker = ({ onClose, onConfirm }: PictoPickerProps): JSX.Eleme
         </div>
       </footer>
       {editingVoiceLive && (
-        <VoiceRecorderDialog
-          picto={editingVoiceLive}
-          onClose={() => setEditingVoice(null)}
-        />
+        <VoiceRecorderDialog picto={editingVoiceLive} onClose={() => setEditingVoice(null)} />
       )}
     </Modal>
   );

--- a/src/features/pictogram-picker/VoiceRecorderDialog.module.css
+++ b/src/features/pictogram-picker/VoiceRecorderDialog.module.css
@@ -68,8 +68,13 @@
 }
 
 @keyframes tal-rec-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.3; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
 }
 
 .ok {

--- a/src/features/pictogram-picker/VoiceRecorderDialog.tsx
+++ b/src/features/pictogram-picker/VoiceRecorderDialog.tsx
@@ -1,10 +1,7 @@
 import { type JSX, useEffect, useState } from 'react';
 
 import { playPictogramAudio } from '@/lib/audio';
-import {
-  useClearPictogramAudio,
-  useSetPictogramAudio,
-} from '@/lib/queries/pictograms';
+import { useClearPictogramAudio, useSetPictogramAudio } from '@/lib/queries/pictograms';
 import {
   extensionForMime,
   isRecordingSupported,
@@ -109,8 +106,8 @@ export const VoiceRecorderDialog = ({ picto, onClose }: Props): JSX.Element => {
             Record voice
           </h2>
           <p className={styles.subtitle}>
-            This voice plays for <strong>{picto.label}</strong> when a board uses
-            &ldquo;Parent voice&rdquo;.
+            This voice plays for <strong>{picto.label}</strong> when a board uses &ldquo;Parent
+            voice&rdquo;.
           </p>
         </div>
         <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Close">

--- a/src/features/pictogram-picker/tabs/LibraryTab.tsx
+++ b/src/features/pictogram-picker/tabs/LibraryTab.tsx
@@ -63,9 +63,7 @@ export const LibraryTab = ({
                 onEditVoice(p);
               }}
               aria-label={
-                p.audioPath
-                  ? `Edit voice recording for ${p.label}`
-                  : `Record voice for ${p.label}`
+                p.audioPath ? `Edit voice recording for ${p.label}` : `Record voice for ${p.label}`
               }
               title={p.audioPath ? 'Edit recording' : 'Record voice'}
             >

--- a/src/features/pictogram-picker/tabs/UploadTab.module.css
+++ b/src/features/pictogram-picker/tabs/UploadTab.module.css
@@ -133,4 +133,3 @@
   gap: 14px;
   flex-wrap: wrap;
 }
-

--- a/src/layouts/TalrumLogo.tsx
+++ b/src/layouts/TalrumLogo.tsx
@@ -18,7 +18,12 @@ interface TalrumLogoProps {
   children?: ReactNode;
 }
 
-export const TalrumLogo = ({ size = 44, tile, tileInk, children }: TalrumLogoProps): JSX.Element => {
+export const TalrumLogo = ({
+  size = 44,
+  tile,
+  tileInk,
+  children,
+}: TalrumLogoProps): JSX.Element => {
   const override = tile !== undefined || children !== undefined;
   if (!override) return <TalrumMark size={size} />;
 

--- a/src/lib/outbox/outbox.test.ts
+++ b/src/lib/outbox/outbox.test.ts
@@ -18,9 +18,8 @@ vi.mock('@/lib/supabase', () => ({
 }));
 
 const { deleteEntry, listEntries, putEntry } = await import('./store');
-const { __test_resetOutbox, drain, getStatus, startOutbox, subscribeStatus } = await import(
-  './drain'
-);
+const { __test_resetOutbox, drain, getStatus, startOutbox, subscribeStatus } =
+  await import('./drain');
 const { enqueueAndDrain } = await import('./index');
 
 const baseEntry = (over: Partial<UpdateBoardEntry> = {}): UpdateBoardEntry => ({
@@ -95,7 +94,7 @@ describe('outbox drain', () => {
     await putEntry(baseEntry({ id: '01HZZA' }));
     await drain();
     expect(eqMock).not.toHaveBeenCalled();
-    expect((await listEntries())).toHaveLength(1);
+    expect(await listEntries()).toHaveLength(1);
   });
 
   it('marks an entry as failed after MAX_ATTEMPTS transient failures', async () => {

--- a/src/lib/outbox/store.ts
+++ b/src/lib/outbox/store.ts
@@ -9,8 +9,7 @@ import type { OutboxEntry } from './types';
  */
 const PREFIX = 'outbox:';
 const idbKey = (id: string): string => `${PREFIX}${id}`;
-const isOutboxKey = (k: IDBValidKey): k is string =>
-  typeof k === 'string' && k.startsWith(PREFIX);
+const isOutboxKey = (k: IDBValidKey): k is string => typeof k === 'string' && k.startsWith(PREFIX);
 
 export const putEntry = async (entry: OutboxEntry): Promise<void> => {
   await set(idbKey(entry.id), entry);

--- a/src/lib/queries/boards.mutations.test.tsx
+++ b/src/lib/queries/boards.mutations.test.tsx
@@ -75,7 +75,9 @@ describe('useRenameBoard (useBoardPatch)', () => {
   });
 
   it('rolls back the cache on a non-retryable DB error (RLS denial)', async () => {
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
     qc.setQueryData(boardQueryKey('morning'), seed);
 
     // The outbox classifies coded errors (Postgres / PostgREST) as

--- a/src/lib/speech.test.ts
+++ b/src/lib/speech.test.ts
@@ -44,16 +44,15 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  if (originalSynth) (globalThis as { speechSynthesis: SpeechSynthesis }).speechSynthesis = originalSynth;
+  if (originalSynth)
+    (globalThis as { speechSynthesis: SpeechSynthesis }).speechSynthesis = originalSynth;
   else delete (globalThis as { speechSynthesis?: SpeechSynthesis }).speechSynthesis;
   (globalThis as { SpeechSynthesisUtterance: unknown }).SpeechSynthesisUtterance = originalUtter;
 });
 
 describe('speak()', () => {
   it('cancels in-flight speech and speaks the requested text', () => {
-    const { synth, utters, cancel, speakFn } = makeFakeSynth([
-      { name: 'Samantha', lang: 'en-US' },
-    ]);
+    const { synth, utters, cancel, speakFn } = makeFakeSynth([{ name: 'Samantha', lang: 'en-US' }]);
     (globalThis as { speechSynthesis: unknown }).speechSynthesis = synth;
 
     speak('hello');

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -2,7 +2,10 @@ import { clear, set } from 'idb-keyval';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const createSignedUrlMock = vi.fn<
-  (path: string, expiresIn: number) => Promise<{
+  (
+    path: string,
+    expiresIn: number,
+  ) => Promise<{
     data: { signedUrl: string } | null;
     error: Error | null;
   }>

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -37,10 +37,7 @@ export const uploadBlob = async (bucket: string, path: string, blob: Blob): Prom
   if (error) throw error;
 };
 
-export const removeFromBucket = async (
-  bucket: string,
-  paths: readonly string[],
-): Promise<void> => {
+export const removeFromBucket = async (bucket: string, paths: readonly string[]): Promise<void> => {
   if (paths.length === 0) return;
   const { error } = await supabase.storage.from(bucket).remove([...paths]);
   if (error) throw error;

--- a/src/lib/useSignedUrl.ts
+++ b/src/lib/useSignedUrl.ts
@@ -7,10 +7,7 @@ import { signedUrlFor } from './storage';
  * on error (callers should render a placeholder in that state). Re-runs when
  * bucket/path change; cancelled updates if the component unmounts first.
  */
-export const useSignedUrl = (
-  bucket: string,
-  path: string | undefined,
-): string | null => {
+export const useSignedUrl = (bucket: string, path: string | undefined): string | null => {
   const [url, setUrl] = useState<string | null>(null);
   useEffect(() => {
     if (!path) {

--- a/src/ui/Button/Button.module.css
+++ b/src/ui/Button/Button.module.css
@@ -6,7 +6,10 @@
   font-size: 15px;
   font-weight: 700;
   line-height: 1;
-  transition: transform 0.15s, box-shadow 0.15s, background 0.15s;
+  transition:
+    transform 0.15s,
+    box-shadow 0.15s,
+    background 0.15s;
 }
 
 .button:disabled {

--- a/src/ui/OfflineIndicator/OfflineIndicator.module.css
+++ b/src/ui/OfflineIndicator/OfflineIndicator.module.css
@@ -65,6 +65,11 @@
 }
 
 @keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.35; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
 }

--- a/src/ui/PictoTile/PictogramMedia.module.css
+++ b/src/ui/PictoTile/PictogramMedia.module.css
@@ -6,11 +6,15 @@
   position: relative;
   border-radius: var(--tal-r-lg);
   box-shadow: var(--tal-shadow-1);
-  transition: box-shadow 0.15s, transform 0.15s;
+  transition:
+    box-shadow 0.15s,
+    transform 0.15s;
 }
 
 .selected {
-  box-shadow: 0 0 0 3px var(--tal-sky-ink), var(--tal-shadow-2);
+  box-shadow:
+    0 0 0 3px var(--tal-sky-ink),
+    var(--tal-shadow-2);
 }
 
 .photo {

--- a/src/ui/Reorderable/Reorderable.tsx
+++ b/src/ui/Reorderable/Reorderable.tsx
@@ -47,9 +47,7 @@ export const Reorderable = <T extends Identified>({
   keyFor,
 }: ReorderableProps<T>): JSX.Element => {
   const keys = items.map((item, i) => (keyFor ? keyFor(item, i) : item.id));
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
-  );
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
 
   const handleDragEnd = (event: DragEndEvent): void => {
     const { active, over } = event;

--- a/src/ui/Select/Select.tsx
+++ b/src/ui/Select/Select.tsx
@@ -24,11 +24,7 @@ export const Select = <V extends string>({
 }: SelectProps<V>): JSX.Element => (
   <label className={styles.wrapper}>
     <span className={styles.label}>{label}:</span>
-    <select
-      className={styles.native}
-      value={value}
-      onChange={(e) => onChange(e.target.value as V)}
-    >
+    <select className={styles.native} value={value} onChange={(e) => onChange(e.target.value as V)}>
       {options.map((o) => (
         <option key={o.value} value={o.value}>
           {o.label}


### PR DESCRIPTION
## Summary

Pre-existing files predate the husky/lint-staged install (PR #53) and weren't Prettier-clean. Touching any of them in a substantive PR drags unrelated formatting hunks into the diff — exactly what was flagged in #54's review. One pass of \`npm run format\` brings the whole tree into compliance so future PRs stay surgical.

Also adds \`.prettierignore\` so the generated \`src/types/supabase.ts\` isn't reformatted (regen via \`npm run types:db\` would just undo it).

No behavior changes. Pure formatting.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run typecheck\` clean
- [x] \`npm run test\` 152/152 pass