### PR TITLE
Add ErrorBoundary at app-root and per-route layers (closes #43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,12 @@ Vite tree-shaking prefers it.
 ### Errors & boundaries
 
 - Network errors are surfaced through React Query state; never swallow them.
-- **TODO:** wrap each route component in a localized `<ErrorBoundary>` so a
-  render crash in one route doesn't blank the whole app.
-- **TODO:** add production error tracking (Sentry or similar).
+- Render-time crashes are caught by `<ErrorBoundary>` (`src/ui/ErrorBoundary/`)
+  at two layers: an app-root boundary around `<RouterProvider>` and a
+  per-route boundary inside `routes.tsx` with parent / kid fallback variants.
+  A crash in one route never blanks the whole app.
+- **TODO:** add production error tracking (Sentry or similar). When that
+  lands, hook `componentDidCatch` in `ErrorBoundary` to forward to it.
 
 ### Performance
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,17 +1,38 @@
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client';
+import type { JSX } from 'react';
 import { RouterProvider } from 'react-router-dom';
 
 import { persistOptions, queryClient } from '@/lib/queryClient';
+import { ErrorBoundary } from '@/ui/ErrorBoundary/ErrorBoundary';
+import styles from '@/ui/ErrorBoundary/ErrorBoundary.module.css';
 
 import { AuthGate } from './AuthGate';
 import { router } from './routes';
 import { SwUpdatePrompt } from './SwUpdatePrompt';
 
+// Last-resort fallback if anything escapes a route boundary or fires before
+// any route mounts. Lives outside RouterProvider so it can't use router hooks
+// — `window.location.reload()` is the only viable recovery.
+const AppRootFallback = (): JSX.Element => (
+  <div role="alert" className={styles.appRootFallback}>
+    <p className={styles.appRootFallbackTitle}>Something went wrong.</p>
+    <button
+      type="button"
+      className={`${styles.routeFallbackBtn} ${styles.routeFallbackBtnPrimary}`}
+      onClick={() => window.location.reload()}
+    >
+      Reload
+    </button>
+  </div>
+);
+
 export const App = (): React.JSX.Element => (
   <div className="tal">
     <PersistQueryClientProvider client={queryClient} persistOptions={persistOptions}>
       <AuthGate>
-        <RouterProvider router={router} future={{ v7_startTransition: true }} />
+        <ErrorBoundary fallback={() => <AppRootFallback />}>
+          <RouterProvider router={router} future={{ v7_startTransition: true }} />
+        </ErrorBoundary>
       </AuthGate>
       <SwUpdatePrompt />
     </PersistQueryClientProvider>

--- a/src/app/routes.test.tsx
+++ b/src/app/routes.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import { isValidElement, type JSX, type ReactElement } from 'react';
+import { MemoryRouter, type RouteObject } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ErrorBoundary } from '@/ui/ErrorBoundary/ErrorBoundary';
+
+import { kidRouteFallback, parentRouteFallback, router } from './routes';
+
+const Boom = (): JSX.Element => {
+  throw new Error('boom');
+};
+
+describe('routes — error boundary wiring', () => {
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    errSpy.mockRestore();
+  });
+
+  // Structural guard: if a future PR adds a route and forgets to wrap it,
+  // this test fails before any user sees a blank screen.
+  it('every non-wildcard route element is wrapped in <ErrorBoundary>', () => {
+    const routes = router.routes as RouteObject[];
+    const wrapped = routes.filter((r) => r.path !== '*');
+    expect(wrapped.length).toBeGreaterThan(0);
+    for (const r of wrapped) {
+      expect(isValidElement(r.element)).toBe(true);
+      expect((r.element as ReactElement).type).toBe(ErrorBoundary);
+    }
+  });
+
+  it('parent fallback shows Retry + Go home and surrounding tree stays mounted', () => {
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <div data-testid="shell">
+          <ErrorBoundary fallback={parentRouteFallback}>
+            <Boom />
+          </ErrorBoundary>
+        </div>
+      </MemoryRouter>,
+    );
+    // Boundary caught — outer shell still rendered.
+    expect(screen.getByTestId('shell')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent(/Couldn.?t load this screen/i);
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Go home' })).toHaveAttribute('href', '/');
+  });
+
+  it('kid fallback shows only "Tap to go back" — no Retry, no body copy', () => {
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <div data-testid="shell">
+          <ErrorBoundary fallback={kidRouteFallback}>
+            <Boom />
+          </ErrorBoundary>
+        </div>
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId('shell')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Tap to go back' })).toHaveAttribute('href', '/');
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+  });
+});

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,16 +1,62 @@
-import { createBrowserRouter, Navigate } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { createBrowserRouter, Link, Navigate } from 'react-router-dom';
 
 import { BoardBuilderRoute } from '@/features/board-builder/BoardBuilderRoute';
 import { KidChoiceRoute } from '@/features/kid-choice/KidChoiceRoute';
 import { KidSequenceRoute } from '@/features/kid-sequence/KidSequenceRoute';
 import { ParentHomeRoute } from '@/features/parent-home/ParentHomeRoute';
+import { queryClient } from '@/lib/queryClient';
+import { ErrorBoundary } from '@/ui/ErrorBoundary/ErrorBoundary';
+import styles from '@/ui/ErrorBoundary/ErrorBoundary.module.css';
+
+export const parentRouteFallback = (reset: () => void): ReactNode => (
+  <div role="alert" className={styles.routeFallback}>
+    <p className={styles.routeFallbackTitle}>Couldn&apos;t load this screen.</p>
+    <p className={styles.routeFallbackBody}>
+      Try again, or go back to the home screen. Your work is saved.
+    </p>
+    <div className={styles.routeFallbackActions}>
+      <button
+        type="button"
+        className={`${styles.routeFallbackBtn} ${styles.routeFallbackBtnPrimary}`}
+        onClick={() => {
+          // Flush any cached query that might have produced bad data, then
+          // clear the boundary's error so the subtree renders fresh.
+          void queryClient.invalidateQueries();
+          reset();
+        }}
+      >
+        Retry
+      </button>
+      <Link to="/" className={styles.routeFallbackBtn}>
+        Go home
+      </Link>
+    </div>
+  </div>
+);
+
+// Standalone JSX — intentionally NOT wrapped in KidModeLayout. If the original
+// crash came from KidModeLayout itself, re-rendering it would re-throw.
+export const kidRouteFallback = (): ReactNode => (
+  <div role="alert" className={styles.kidFallback}>
+    <Link to="/" className={styles.kidFallbackBtn}>
+      Tap to go back
+    </Link>
+  </div>
+);
+
+const wrap = (el: ReactNode, variant: 'parent' | 'kid'): ReactNode => (
+  <ErrorBoundary fallback={variant === 'kid' ? kidRouteFallback : parentRouteFallback}>
+    {el}
+  </ErrorBoundary>
+);
 
 export const router = createBrowserRouter(
   [
-    { path: '/', element: <ParentHomeRoute /> },
-    { path: '/boards/:boardId/edit', element: <BoardBuilderRoute /> },
-    { path: '/kid/sequence/:boardId', element: <KidSequenceRoute /> },
-    { path: '/kid/choice/:boardId', element: <KidChoiceRoute /> },
+    { path: '/', element: wrap(<ParentHomeRoute />, 'parent') },
+    { path: '/boards/:boardId/edit', element: wrap(<BoardBuilderRoute />, 'parent') },
+    { path: '/kid/sequence/:boardId', element: wrap(<KidSequenceRoute />, 'kid') },
+    { path: '/kid/choice/:boardId', element: wrap(<KidChoiceRoute />, 'kid') },
     { path: '*', element: <Navigate to="/" replace /> },
   ],
   {

--- a/src/ui/ErrorBoundary/ErrorBoundary.module.css
+++ b/src/ui/ErrorBoundary/ErrorBoundary.module.css
@@ -1,0 +1,101 @@
+.routeFallback {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 48px 24px;
+  text-align: center;
+  color: var(--tal-ink);
+}
+
+.routeFallbackTitle {
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.routeFallbackBody {
+  color: var(--tal-ink-soft);
+  font-size: 14px;
+  max-width: 36ch;
+}
+
+.routeFallbackActions {
+  display: inline-flex;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.routeFallbackBtn {
+  appearance: none;
+  border: 0;
+  background: var(--tal-surface);
+  color: var(--tal-ink);
+  font-size: 14px;
+  font-weight: 600;
+  padding: 10px 18px;
+  border-radius: var(--tal-r-pill);
+  border: 1px solid var(--tal-line);
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.routeFallbackBtnPrimary {
+  background: var(--tal-ink);
+  color: var(--tal-surface);
+  border-color: var(--tal-ink);
+}
+
+.routeFallbackBtn:focus-visible {
+  outline: 2px solid var(--tal-ink);
+  outline-offset: 2px;
+}
+
+.kidFallback {
+  position: fixed;
+  inset: 0;
+  background: #000;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.kidFallbackBtn {
+  appearance: none;
+  border: 4px solid #fff;
+  background: transparent;
+  color: #fff;
+  font-size: 28px;
+  font-weight: 800;
+  padding: 32px 48px;
+  border-radius: 24px;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.appRootFallback {
+  min-height: 100vh;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 24px;
+  text-align: center;
+  background: var(--tal-bg);
+  color: var(--tal-ink);
+}
+
+.appRootFallbackTitle {
+  font-size: 22px;
+  font-weight: 800;
+}

--- a/src/ui/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/ui/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { type JSX, useState } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ErrorBoundary } from './ErrorBoundary';
+
+const Boom = ({ msg = 'boom' }: { msg?: string }): JSX.Element => {
+  throw new Error(msg);
+};
+
+describe('ErrorBoundary', () => {
+  // React logs caught errors to console.error during render. Silence so the
+  // test output isn't polluted; restore so unrelated errors still surface.
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    errSpy.mockRestore();
+  });
+
+  it('renders children when no error', () => {
+    render(
+      <ErrorBoundary fallback={() => <span>fallback</span>}>
+        <span>child</span>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('child')).toBeInTheDocument();
+    expect(screen.queryByText('fallback')).not.toBeInTheDocument();
+  });
+
+  it('renders fallback when a child throws', () => {
+    render(
+      <ErrorBoundary fallback={() => <span>fallback</span>}>
+        <Boom />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('fallback')).toBeInTheDocument();
+  });
+
+  it('clears error state when reset() is called from the fallback', () => {
+    // Toggleable child: throws while toggle=true, renders normally otherwise.
+    // The fallback's button flips the toggle AND calls reset, so the next
+    // render finds clean children.
+    const Harness = (): JSX.Element => {
+      const [throwing, setThrowing] = useState(true);
+      return (
+        <ErrorBoundary
+          fallback={(reset) => (
+            <button
+              type="button"
+              onClick={() => {
+                setThrowing(false);
+                reset();
+              }}
+            >
+              retry
+            </button>
+          )}
+        >
+          {throwing ? <Boom /> : <span>recovered</span>}
+        </ErrorBoundary>
+      );
+    };
+    render(<Harness />);
+    expect(screen.getByRole('button', { name: 'retry' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'retry' }));
+    expect(screen.getByText('recovered')).toBeInTheDocument();
+  });
+
+  it('catches a second throw after reset (state is not latched)', () => {
+    // Reset clears the error, but a child that throws again on the next
+    // render must re-trigger the fallback rather than bubble out.
+    const Harness = (): JSX.Element => {
+      const [n, setN] = useState(0);
+      return (
+        <ErrorBoundary
+          fallback={(reset) => (
+            <button
+              type="button"
+              onClick={() => {
+                setN((x) => x + 1);
+                reset();
+              }}
+            >
+              retry-{n}
+            </button>
+          )}
+        >
+          <Boom msg={`boom-${n}`} />
+        </ErrorBoundary>
+      );
+    };
+    render(<Harness />);
+    fireEvent.click(screen.getByRole('button', { name: 'retry-0' }));
+    // Reset cleared, child re-rendered, child threw again → fallback again
+    // with the bumped counter visible.
+    expect(screen.getByRole('button', { name: 'retry-1' })).toBeInTheDocument();
+  });
+});

--- a/src/ui/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/ui/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,34 @@
+import { Component, type ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  fallback: (reset: () => void) => ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+/**
+ * The only class component in the repo — React's error-boundary API is
+ * class-only. Catches render-time exceptions in the descendant subtree and
+ * hands the consumer a `reset()` so the fallback can clear the error and
+ * retry. When #45 (production error tracking) lands, add
+ * `componentDidCatch(error, info)` here to forward to Sentry; until then
+ * React's own dev-mode console.error is the only signal we get.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  override state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  override render(): ReactNode {
+    return this.state.error ? this.props.fallback(this.reset) : this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `src/ui/ErrorBoundary/` — a 25-line class component (the only class in the repo, required by React's class-only error-boundary API) with a render-prop `fallback`.
- Wraps `<RouterProvider>` in `App.tsx` (last-resort: "Something went wrong" + Reload, since this boundary lives outside the router).
- Wraps every non-wildcard route in `routes.tsx` with one of two fallback variants:
  - **Parent** (`/`, `/boards/:boardId/edit`): "Couldn't load this screen" + Retry (invalidates queries, then resets) + "Go home" link.
  - **Kid** (`/kid/sequence`, `/kid/choice`): plain black full-screen page with one giant "Tap to go back" link. No retry — kid-mode crashes hand back to the parent. Intentionally not wrapped in `KidModeLayout` so a crash inside the layout itself doesn't re-throw.

The issue suggested a third boundary specifically around `<KidModeLayout>`; that collapses into the per-route kid fallback (same coverage, fewer files) since `KidModeLayout` already renders inside the per-route tree.

Sentry/runtime tracking (#45) is deferred; a comment in `ErrorBoundary.tsx` points at the `componentDidCatch` hook that wires it in.

## Test plan

- [x] Unit tests for the boundary class (4 cases: happy path, fallback, reset, re-throw).
- [x] Routes integration test asserts every non-wildcard route element is wrapped (structural guard so a future PR adding a route can't forget the boundary) and each fallback variant renders the right UI.
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npm run test` — 159 tests pass.
- [ ] Manual smoke: temporarily `throw new Error('boom')` inside `ParentHomeRoute` → see parent fallback; same in a kid route → see kid fallback.

## Acceptance (from #43)

- [x] `ErrorBoundary` component exists with a `fallback` render-prop
- [x] All four routes wrapped (parent variant for two, kid variant for two)
- [x] App-root boundary catches anything that escapes a route boundary
- [x] Test: throw inside a route component, asserts surrounding tree stays mounted and the fallback renders