### PR TITLE
Code-split routes with React.lazy + Suspense (#44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,9 @@ Vite tree-shaking prefers it.
 
 ### Performance
 
-- **TODO:** code-split routes with `React.lazy` + `<Suspense>`.
+- Each route in `src/app/routes.tsx` is loaded via `React.lazy` and wrapped
+  in `<Suspense>` (parent variant: small spinner; kid variant: empty
+  black-shell shell). Initial load only ships the route the user is on.
 - Memoize only when profiling shows it matters. Default to plain components.
 - Heavy work (image resizing, audio recording) lives in
   `src/lib/{image,audio,recording}.ts` so feature code stays render-fast.

--- a/src/app/routes.test.tsx
+++ b/src/app/routes.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { isValidElement, type JSX, type ReactElement } from 'react';
+import { isValidElement, type JSX, type ReactElement, Suspense } from 'react';
 import { MemoryRouter, type RouteObject } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -21,14 +21,18 @@ describe('routes — error boundary wiring', () => {
   });
 
   // Structural guard: if a future PR adds a route and forgets to wrap it,
-  // this test fails before any user sees a blank screen.
-  it('every non-wildcard route element is wrapped in <ErrorBoundary>', () => {
+  // this test fails before any user sees a blank screen — and before any
+  // route ships in the initial bundle (Suspense layer enforces lazy split).
+  it('every non-wildcard route is wrapped in <ErrorBoundary> with a <Suspense> child', () => {
     const routes = router.routes as RouteObject[];
     const wrapped = routes.filter((r) => r.path !== '*');
     expect(wrapped.length).toBeGreaterThan(0);
     for (const r of wrapped) {
       expect(isValidElement(r.element)).toBe(true);
-      expect((r.element as ReactElement).type).toBe(ErrorBoundary);
+      const outer = r.element as ReactElement<{ children: ReactElement }>;
+      expect(outer.type).toBe(ErrorBoundary);
+      expect(isValidElement(outer.props.children)).toBe(true);
+      expect(outer.props.children.type).toBe(Suspense);
     }
   });
 

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,13 +1,24 @@
-import type { ReactNode } from 'react';
+import { lazy, type ReactNode, Suspense } from 'react';
 import { createBrowserRouter, Link, Navigate } from 'react-router-dom';
 
-import { BoardBuilderRoute } from '@/features/board-builder/BoardBuilderRoute';
-import { KidChoiceRoute } from '@/features/kid-choice/KidChoiceRoute';
-import { KidSequenceRoute } from '@/features/kid-sequence/KidSequenceRoute';
-import { ParentHomeRoute } from '@/features/parent-home/ParentHomeRoute';
 import { queryClient } from '@/lib/queryClient';
 import { ErrorBoundary } from '@/ui/ErrorBoundary/ErrorBoundary';
 import styles from '@/ui/ErrorBoundary/ErrorBoundary.module.css';
+
+const ParentHomeRoute = lazy(() =>
+  import('@/features/parent-home/ParentHomeRoute').then((m) => ({ default: m.ParentHomeRoute })),
+);
+const BoardBuilderRoute = lazy(() =>
+  import('@/features/board-builder/BoardBuilderRoute').then((m) => ({
+    default: m.BoardBuilderRoute,
+  })),
+);
+const KidSequenceRoute = lazy(() =>
+  import('@/features/kid-sequence/KidSequenceRoute').then((m) => ({ default: m.KidSequenceRoute })),
+);
+const KidChoiceRoute = lazy(() =>
+  import('@/features/kid-choice/KidChoiceRoute').then((m) => ({ default: m.KidChoiceRoute })),
+);
 
 export const parentRouteFallback = (reset: () => void): ReactNode => (
   <div role="alert" className={styles.routeFallback}>
@@ -45,9 +56,25 @@ export const kidRouteFallback = (): ReactNode => (
   </div>
 );
 
+const parentSuspenseFallback = (
+  <div className={`tal ${styles.parentSuspense}`}>
+    <div className={styles.spinner} aria-hidden="true" />
+    <p className={styles.parentSuspenseBody}>Loading…</p>
+  </div>
+);
+
+// Empty kid-tinted shell — no spinner, no text. Kid-mode prefers a calm
+// static screen during the brief async wait while the route chunk loads.
+const kidSuspenseFallback = <div className={styles.kidFallback} aria-hidden="true" />;
+
+// ErrorBoundary wraps Suspense (not the other way around) so that a
+// chunk-load failure during the dynamic import lands in the route's own
+// error fallback (with Retry) instead of bubbling to the app-root fallback.
 const wrap = (el: ReactNode, variant: 'parent' | 'kid'): ReactNode => (
   <ErrorBoundary fallback={variant === 'kid' ? kidRouteFallback : parentRouteFallback}>
-    {el}
+    <Suspense fallback={variant === 'kid' ? kidSuspenseFallback : parentSuspenseFallback}>
+      {el}
+    </Suspense>
   </ErrorBoundary>
 );
 

--- a/src/ui/ErrorBoundary/ErrorBoundary.module.css
+++ b/src/ui/ErrorBoundary/ErrorBoundary.module.css
@@ -99,3 +99,39 @@
   font-size: 22px;
   font-weight: 800;
 }
+
+.parentSuspense {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  height: 100vh;
+}
+
+.parentSuspenseBody {
+  font-size: 15px;
+  color: var(--tal-ink-soft);
+  margin: 0;
+}
+
+.spinner {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 3px solid var(--tal-line);
+  border-top-color: var(--tal-sage);
+  animation: tal-route-spin 0.9s linear infinite;
+}
+
+@keyframes tal-route-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation-duration: 2.5s;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #44.

Convert each of the four route imports in `src/app/routes.tsx` to `React.lazy` and wrap each route element in `<Suspense>`. Compose with the existing `<ErrorBoundary>` as `ErrorBoundary > Suspense > LazyRoute` so a chunk-load failure during the dynamic import lands in the route's own error fallback (with Retry) instead of bubbling to the app-root fallback whose only recovery is a full reload.

Two Suspense fallback variants matching the parent/kid split:
- **Parent**: AuthGate-style centered spinner + "Loading…" label.
- **Kid**: empty full-screen black shell — keeps kid-mode visually calm during the brief async wait.

`routes.test.tsx` structural guard now asserts every non-wildcard route is wrapped in `<ErrorBoundary>` AND its child is `<Suspense>`, so a future PR that drops the lazy split fails the test before it ships.

## Build chunks (acceptance: ≥4)

Before: 1 large `index-*.js` (~460 kB).

After: 12 JS chunks including four per-route chunks:
- `ParentHomeRoute` — 3.11 kB
- `BoardBuilderRoute` — 26.73 kB
- `KidSequenceRoute` — 2.34 kB
- `KidChoiceRoute` — 2.38 kB

Plus shared splits (`PictogramMedia` 32.73 kB, `Reorderable` 44.90 kB) that are only pulled in by the routes that need them. Kid surfaces no longer ship BoardBuilder + PictogramMedia + Reorderable (~104 kB saved on cold-load for kid mode).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 159/159 pass (including the updated `routes.test.tsx` structural guard)
- [x] `npm run build` — clean, 4 named route chunks under `dist/assets/`
- [ ] Manual smoke (optional): hard-refresh `/`, observe network panel only loads home chunk; navigate to `/boards/:id/edit` and watch the builder chunk load on demand