### PR TITLE
Wire New kid CTA + add kids queries (PR 1/5 of #61)

### DIFF
--- a/src/features/parent-home/NewKidModal.module.css
+++ b/src/features/parent-home/NewKidModal.module.css
@@ -1,0 +1,82 @@
+.wrap {
+  padding: 28px 28px 24px;
+  max-width: 440px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.title {
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--tal-ink);
+  margin: 0 0 2px;
+}
+
+.subtitle {
+  font-size: 13px;
+  color: var(--tal-ink-muted);
+  margin: 0;
+}
+
+.closeBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--tal-ink-soft);
+  border: none;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.fieldLabel {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--tal-ink-muted);
+}
+
+.input {
+  font-size: 15px;
+  padding: 10px 12px;
+  border: 1px solid var(--tal-line);
+  border-radius: var(--tal-r-md);
+  background: var(--tal-surface);
+  color: var(--tal-ink);
+  outline: none;
+}
+
+.input:focus {
+  border-color: var(--tal-ink-soft);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 20px;
+}
+
+.error {
+  margin: 8px 0 0;
+  font-size: 13px;
+  color: var(--tal-coral-ink, var(--tal-ink));
+}

--- a/src/features/parent-home/NewKidModal.test.tsx
+++ b/src/features/parent-home/NewKidModal.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { JSX } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mutateMock = vi.fn();
+const useCreateKidMock = vi.fn(() => ({
+  mutate: mutateMock,
+  isPending: false,
+}));
+
+vi.mock('@/lib/queries/kids', () => ({
+  useCreateKid: () => useCreateKidMock(),
+}));
+
+const { NewKidModal } = await import('./NewKidModal');
+
+const renderModal = (onClose: () => void = vi.fn()): JSX.Element => {
+  render(<NewKidModal onClose={onClose} />);
+  return <></>;
+};
+
+afterEach(() => {
+  mutateMock.mockReset();
+  useCreateKidMock.mockReset();
+  useCreateKidMock.mockReturnValue({ mutate: mutateMock, isPending: false });
+});
+
+describe('NewKidModal', () => {
+  it('renders an empty form with Save disabled', () => {
+    renderModal();
+    expect(screen.getByRole('heading', { name: /add a kid/i })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /name/i })).toHaveValue('');
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeEnabled();
+  });
+
+  it('Save calls useCreateKid with the trimmed name and closes on success', async () => {
+    const onClose = vi.fn();
+    mutateMock.mockImplementation((_input: unknown, opts?: { onSuccess?: () => void }) => {
+      opts?.onSuccess?.();
+    });
+
+    const user = userEvent.setup();
+    renderModal(onClose);
+
+    await user.type(screen.getByRole('textbox', { name: /name/i }), '  Mira  ');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(mutateMock).toHaveBeenCalledWith({ name: '  Mira  ' }, expect.any(Object));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('Save stays disabled when the input is whitespace-only', async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.type(screen.getByRole('textbox', { name: /name/i }), '   ');
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+  });
+
+  it('renders an inline error when the mutation fails', async () => {
+    const onClose = vi.fn();
+    mutateMock.mockImplementation((_input: unknown, opts?: { onError?: (e: Error) => void }) => {
+      opts?.onError?.(new Error('boom'));
+    });
+
+    const user = userEvent.setup();
+    renderModal(onClose);
+
+    await user.type(screen.getByRole('textbox', { name: /name/i }), 'Mira');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/couldn.?t add the kid/i);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('Cancel calls onClose without saving', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderModal(onClose);
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(mutateMock).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/parent-home/NewKidModal.tsx
+++ b/src/features/parent-home/NewKidModal.tsx
@@ -1,0 +1,87 @@
+import { type FormEvent, type JSX, useState } from 'react';
+
+import { useCreateKid } from '@/lib/queries/kids';
+import { Button } from '@/ui/Button/Button';
+import { XIcon } from '@/ui/icons';
+import { Modal } from '@/ui/Modal/Modal';
+
+import styles from './NewKidModal.module.css';
+
+const TITLE_ID = 'new-kid-modal-title';
+
+interface NewKidModalProps {
+  onClose: () => void;
+}
+
+export const NewKidModal = ({ onClose }: NewKidModalProps): JSX.Element => {
+  const createKid = useCreateKid();
+  const [name, setName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmed = name.trim();
+  const submitDisabled = trimmed === '' || createKid.isPending;
+
+  const submit = (e: FormEvent): void => {
+    e.preventDefault();
+    if (submitDisabled) return;
+    setError(null);
+    createKid.mutate(
+      { name },
+      {
+        onSuccess: () => onClose(),
+        onError: () => setError("Couldn't add the kid. Try again."),
+      },
+    );
+  };
+
+  return (
+    <Modal onClose={onClose} labelledBy={TITLE_ID}>
+      <div className={styles.wrap}>
+        <header className={styles.header}>
+          <div>
+            <h2 id={TITLE_ID} className={styles.title}>
+              Add a kid
+            </h2>
+            <p className={styles.subtitle}>
+              Each kid has their own boards. You can add more later.
+            </p>
+          </div>
+          <button type="button" onClick={onClose} aria-label="Close" className={styles.closeBtn}>
+            <XIcon size={18} />
+          </button>
+        </header>
+
+        <form onSubmit={submit}>
+          <label className={styles.field}>
+            <span className={styles.fieldLabel}>Name</span>
+            <input
+              type="text"
+              autoFocus
+              autoComplete="off"
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                if (error) setError(null);
+              }}
+              className={styles.input}
+              placeholder="Liam"
+            />
+          </label>
+          {error && (
+            <p role="alert" className={styles.error}>
+              {error}
+            </p>
+          )}
+          <div className={styles.actions}>
+            <Button type="button" variant="ghost" onClick={onClose} disabled={createKid.isPending}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" disabled={submitDisabled}>
+              {createKid.isPending ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </Modal>
+  );
+};

--- a/src/features/parent-home/ParentHome.tsx
+++ b/src/features/parent-home/ParentHome.tsx
@@ -16,12 +16,14 @@ interface ParentHomeProps {
   kidName?: string;
   onOpenBoard?: (id: string) => void;
   onKidMode?: () => void;
+  onNewKid?: () => void;
 }
 
 export const ParentHome = ({
   kidName = 'Liam',
   onOpenBoard,
   onKidMode,
+  onNewKid,
 }: ParentHomeProps): JSX.Element => {
   const boardsQuery = useBoards();
   const pictogramsBySlug = usePictogramsBySlug();
@@ -36,7 +38,7 @@ export const ParentHome = ({
       subtitle="Pick a board to edit, or start a new one."
       right={
         <div className={styles.rightActions}>
-          <Button variant="ghost" icon={<PlusIcon />}>
+          <Button variant="ghost" icon={<PlusIcon />} onClick={onNewKid}>
             New kid
           </Button>
           <Button variant="primary" icon={<PlusIcon />}>

--- a/src/features/parent-home/ParentHomeRoute.test.tsx
+++ b/src/features/parent-home/ParentHomeRoute.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { JSX } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -86,5 +87,16 @@ describe('ParentHomeRoute auto-launch', () => {
     render(<Wrap />);
     expect(screen.queryByTestId('kid-sequence-route')).not.toBeInTheDocument();
     expect(screen.getByText(/Liam's boards/)).toBeInTheDocument();
+  });
+
+  it('clicking New kid opens the kid modal', async () => {
+    const Wrap = makeWrap('/');
+    render(<Wrap />);
+    expect(screen.queryByRole('heading', { name: /add a kid/i })).not.toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /new kid/i }));
+
+    expect(screen.getByRole('heading', { name: /add a kid/i })).toBeInTheDocument();
   });
 });

--- a/src/features/parent-home/ParentHomeRoute.tsx
+++ b/src/features/parent-home/ParentHomeRoute.tsx
@@ -4,11 +4,13 @@ import { Navigate, useNavigate } from 'react-router-dom';
 import { getLastBoard, hasAutoLaunched, kidPathFor, markAutoLaunched } from '@/lib/lastBoard';
 import { useBoards } from '@/lib/queries/boards';
 
+import { NewKidModal } from './NewKidModal';
 import { ParentHome } from './ParentHome';
 
 export const ParentHomeRoute = (): JSX.Element => {
   const navigate = useNavigate();
   const boardsQuery = useBoards();
+  const [newKidOpen, setNewKidOpen] = useState(false);
   // Auto-launch into the last kid-mode board on the first parent-home visit
   // per browser session. Subsequent visits this session (e.g. after PIN exit
   // back to home) render ParentHome normally so the user is never trapped.
@@ -30,5 +32,14 @@ export const ParentHomeRoute = (): JSX.Element => {
     if (firstSequence) navigate(`/kid/sequence/${firstSequence.id}`);
   };
 
-  return <ParentHome onOpenBoard={(id) => navigate(`/boards/${id}/edit`)} onKidMode={onKidMode} />;
+  return (
+    <>
+      <ParentHome
+        onOpenBoard={(id) => navigate(`/boards/${id}/edit`)}
+        onKidMode={onKidMode}
+        onNewKid={() => setNewKidOpen(true)}
+      />
+      {newKidOpen && <NewKidModal onClose={() => setNewKidOpen(false)} />}
+    </>
+  );
 };

--- a/src/lib/queries/kids.test.tsx
+++ b/src/lib/queries/kids.test.tsx
@@ -1,0 +1,141 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { JSX, ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TestSessionProvider } from '@/lib/auth/session.test-utils';
+import type { Kid } from '@/types/domain';
+
+interface MockPostgrestError {
+  code: string;
+  message: string;
+  details: string;
+  hint: string;
+}
+
+// Read-path chain: from('kids').select('*').order('created_at')
+const orderMock = vi.fn<() => Promise<{ data: unknown; error: MockPostgrestError | null }>>();
+const readSelectMock = vi.fn(() => ({ order: orderMock }));
+
+// Write-path chain: from('kids').insert({...}).select().single()
+const singleMock = vi.fn<() => Promise<{ data: unknown; error: MockPostgrestError | null }>>();
+const insertSelectMock = vi.fn(() => ({ single: singleMock }));
+const insertMock = vi.fn(() => ({ select: insertSelectMock }));
+
+const fromMock = vi.fn((_table: string) => ({
+  select: readSelectMock,
+  insert: insertMock,
+}));
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: { from: (table: string) => fromMock(table) },
+}));
+
+// Import after the mock is registered.
+const { kidsQueryKey, useCreateKid, useKids } = await import('./kids');
+
+const wrap = (qc: QueryClient): ((p: { children: ReactNode }) => JSX.Element) => {
+  const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+    <TestSessionProvider>
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    </TestSessionProvider>
+  );
+  return Wrapper;
+};
+
+describe('useKids', () => {
+  beforeEach(() => {
+    orderMock.mockReset();
+    readSelectMock.mockClear();
+    singleMock.mockReset();
+    insertSelectMock.mockClear();
+    insertMock.mockClear();
+    fromMock.mockClear();
+  });
+
+  it('fetches kids and maps rows to the domain shape', async () => {
+    orderMock.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'k1',
+          owner_id: 'owner-uuid',
+          name: 'Liam',
+          created_at: '2026-04-01T00:00:00Z',
+        },
+      ],
+      error: null,
+    });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useKids(), { wrapper: wrap(qc) });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual<Kid[]>([{ id: 'k1', ownerId: 'owner-uuid', name: 'Liam' }]);
+    expect(fromMock).toHaveBeenCalledWith('kids');
+  });
+});
+
+describe('useCreateKid', () => {
+  beforeEach(() => {
+    orderMock.mockReset();
+    readSelectMock.mockClear();
+    singleMock.mockReset();
+    insertSelectMock.mockClear();
+    insertMock.mockClear();
+    fromMock.mockClear();
+  });
+
+  it('inserts with the trimmed name + session owner_id, returns the mapped Kid, and invalidates the kids list cache', async () => {
+    singleMock.mockResolvedValueOnce({
+      data: {
+        id: 'k-new',
+        owner_id: '00000000-0000-0000-0000-0000000000aa',
+        name: 'Mira',
+        created_at: '2026-04-26T12:00:00Z',
+      },
+      error: null,
+    });
+
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCreateKid(), { wrapper: wrap(qc) });
+
+    let returned: Kid | undefined;
+    await act(async () => {
+      returned = await result.current.mutateAsync({ name: '  Mira  ' });
+    });
+
+    expect(returned).toEqual<Kid>({
+      id: 'k-new',
+      ownerId: '00000000-0000-0000-0000-0000000000aa',
+      name: 'Mira',
+    });
+    expect(insertMock).toHaveBeenCalledWith({
+      owner_id: '00000000-0000-0000-0000-0000000000aa',
+      name: 'Mira',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: kidsQueryKey });
+  });
+
+  it('surfaces a Postgres RLS error as React Query error state', async () => {
+    singleMock.mockResolvedValueOnce({
+      data: null,
+      error: { code: '42501', message: 'row-level-security', details: '', hint: '' },
+    });
+
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const { result } = renderHook(() => useCreateKid(), { wrapper: wrap(qc) });
+
+    act(() => {
+      result.current.mutate({ name: 'Mira' });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toMatchObject({ code: '42501' });
+  });
+});

--- a/src/lib/queries/kids.ts
+++ b/src/lib/queries/kids.ts
@@ -1,0 +1,60 @@
+import {
+  useMutation,
+  type UseMutationResult,
+  useQuery,
+  useQueryClient,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+
+import { useSessionUser } from '@/lib/auth/session';
+import { supabase } from '@/lib/supabase';
+import type { Kid } from '@/types/domain';
+import type { Database } from '@/types/supabase';
+
+type KidRow = Database['public']['Tables']['kids']['Row'];
+
+export const rowToKid = (row: KidRow): Kid => ({
+  id: row.id,
+  ownerId: row.owner_id,
+  name: row.name,
+});
+
+export const kidsQueryKey = ['kids'] as const;
+
+const fetchKids = async (): Promise<Kid[]> => {
+  const { data, error } = await supabase.from('kids').select('*').order('created_at');
+  if (error) throw error;
+  return data.map(rowToKid);
+};
+
+export const useKids = (): UseQueryResult<Kid[]> =>
+  useQuery({ queryKey: kidsQueryKey, queryFn: fetchKids });
+
+interface CreateKidInput {
+  name: string;
+}
+
+/**
+ * Direct Supabase insert (no outbox), matching the `useAddBoardMember` pattern
+ * in `board-members.ts`. Outbox would surface RLS denials only at drain — wrong
+ * for create-then-react flows where the caller needs the row to actually exist
+ * on the server (e.g. defaulting a new board's `kid_id`).
+ */
+export const useCreateKid = (): UseMutationResult<Kid, Error, CreateKidInput> => {
+  const qc = useQueryClient();
+  const ownerId = useSessionUser().id;
+  return useMutation({
+    mutationFn: async ({ name }) => {
+      const { data, error } = await supabase
+        .from('kids')
+        .insert({ owner_id: ownerId, name: name.trim() })
+        .select()
+        .single();
+      if (error) throw error;
+      return rowToKid(data);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: kidsQueryKey });
+    },
+  });
+};


### PR DESCRIPTION
## Summary

- The "New kid" header button on the parent home rendered with no `onClick` handler. This PR wires it end-to-end: a queries layer for kids and a feature-local modal that creates one.
- First of 5 PRs that wire up the dead parent-home CTAs ([tracking #61](https://github.com/nbhansen/Talrum/issues/61)). Sequenced first because subsequent PRs need `useKids()` to default a new board's `kid_id`.

## What's new

- `src/lib/queries/kids.ts` — `rowToKid`, `kidsQueryKey`, `useKids` (read), `useCreateKid` (direct Supabase write returning the created `Kid`).
- `src/features/parent-home/NewKidModal.tsx` (+ `.module.css`) — feature-local modal with name input, Save / Cancel, inline error on failure. Mirrors `ShareModal`'s structure.

## What changed

- `ParentHome.tsx` — adds `onNewKid?: () => void`, wires it to the existing button.
- `ParentHomeRoute.tsx` — owns modal open-state and renders `<NewKidModal />` when open.

## Architectural call: direct write, not the outbox

`useCreateKid` writes directly via `supabase.from('kids').insert(...)` rather than going through `enqueueAndDrain`. This mirrors the existing `useAddBoardMember` precedent in `lib/queries/board-members.ts:62-66` — outbox bypasses RLS at enqueue and only surfaces denials at drain time, which is wrong for create-then-react flows. Especially relevant since later PRs will default a new board's `kid_id` to the user's first kid via `useKids()`, and that flow needs the kid to actually exist on the server before navigating.

No new outbox entry kinds added.

## Test plan

- [x] TDD: tests written first, watched fail, then implementation made them pass.
- [x] `src/lib/queries/kids.test.tsx` (3 tests): fetch + map; insert with trimmed name + invalidate cache + return mapped Kid; surface RLS error.
- [x] `src/features/parent-home/NewKidModal.test.tsx` (5 tests): empty render; save calls hook + closes; Save disabled on whitespace; inline error on failure; Cancel closes without saving.
- [x] `ParentHomeRoute.test.tsx` (+1 test): clicking New kid opens the modal.
- [x] Full suite: 168/168 passing, typecheck clean, lint clean (zero warnings).
- [ ] Manual smoke: dev server pointed at cloud project, click New kid, type name, Save, verify kid appears in `kids` table via Supabase Studio.

## Stacked on

This PR is independent of the in-flight deployment PR #60 (no overlapping files). Either can merge first.

## Coming next in sequence

PR 2: `useCreateBoard` mutation + wire the New board / New blank board CTAs + grid empty state.
PR 3: Sidebar `onNav` wiring + stub routes for `/library`, `/kids`, `/settings`.
PR 4: Library route (replaces stub) + wire See all.
PR 5: Kids route (replaces stub) + extract NewKidModal to `src/ui/` for reuse.