### PR TITLE
Wire New board CTAs + grid empty state (PR 2/5 of #61)

### DIFF
--- a/src/features/parent-home/NewBoardModal.module.css
+++ b/src/features/parent-home/NewBoardModal.module.css
@@ -1,0 +1,118 @@
+.wrap {
+  padding: 28px 28px 24px;
+  max-width: 480px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.title {
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--tal-ink);
+  margin: 0 0 2px;
+}
+
+.subtitle {
+  font-size: 13px;
+  color: var(--tal-ink-muted);
+  margin: 0;
+}
+
+.closeBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--tal-ink-soft);
+  border: none;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.fieldLabel {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--tal-ink-muted);
+}
+
+.input {
+  font-size: 15px;
+  padding: 10px 12px;
+  border: 1px solid var(--tal-line);
+  border-radius: var(--tal-r-md);
+  background: var(--tal-surface);
+  color: var(--tal-ink);
+  outline: none;
+}
+
+.input:focus {
+  border-color: var(--tal-ink-soft);
+}
+
+.kindGroup {
+  display: flex;
+  gap: 8px;
+}
+
+.kindOption {
+  flex: 1 1 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--tal-line);
+  border-radius: var(--tal-r-md);
+  background: var(--tal-surface);
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--tal-ink);
+}
+
+.kindOptionChecked {
+  border-color: var(--tal-ink-soft);
+  background: var(--tal-bg);
+}
+
+.kindRadio {
+  margin: 0;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 20px;
+}
+
+.error {
+  margin: 8px 0 0;
+  font-size: 13px;
+  color: var(--tal-coral-ink, var(--tal-ink));
+}
+
+.noKids {
+  font-size: 14px;
+  color: var(--tal-ink-muted);
+  margin: 0 0 12px;
+}

--- a/src/features/parent-home/NewBoardModal.test.tsx
+++ b/src/features/parent-home/NewBoardModal.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { Board, Kid } from '@/types/domain';
+
+const KID_1: Kid = { id: 'k1', ownerId: 'owner', name: 'Liam' };
+const KID_2: Kid = { id: 'k2', ownerId: 'owner', name: 'Mira' };
+
+const useKidsMock = vi.fn(() => ({ data: [KID_1] as Kid[], isPending: false }));
+const createBoardMutateMock = vi.fn();
+const useCreateBoardMock = vi.fn(() => ({
+  mutate: createBoardMutateMock,
+  isPending: false,
+}));
+
+vi.mock('@/lib/queries/kids', () => ({
+  useKids: () => useKidsMock(),
+}));
+vi.mock('@/lib/queries/boards', () => ({
+  useCreateBoard: () => useCreateBoardMock(),
+}));
+
+const { NewBoardModal } = await import('./NewBoardModal');
+
+afterEach(() => {
+  createBoardMutateMock.mockReset();
+  useCreateBoardMock.mockReset();
+  useCreateBoardMock.mockReturnValue({ mutate: createBoardMutateMock, isPending: false });
+  useKidsMock.mockReset();
+  useKidsMock.mockReturnValue({ data: [KID_1], isPending: false });
+});
+
+describe('NewBoardModal', () => {
+  it('renders an empty form with default kind=sequence and Save disabled', () => {
+    render(<NewBoardModal onClose={vi.fn()} onCreated={vi.fn()} />);
+    expect(screen.getByRole('heading', { name: /new board/i })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /name/i })).toHaveValue('');
+    expect(screen.getByRole('radio', { name: /sequence/i })).toBeChecked();
+    expect(screen.getByRole('radio', { name: /choice/i })).not.toBeChecked();
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+  });
+
+  it('saves with name + kind + sole kid when only one kid exists, calls onCreated, and closes', async () => {
+    const onClose = vi.fn();
+    const onCreated = vi.fn();
+    const board: Partial<Board> = { id: 'b-new' };
+    createBoardMutateMock.mockImplementation(
+      (_input: unknown, opts?: { onSuccess?: (b: Partial<Board>) => void }) => {
+        opts?.onSuccess?.(board);
+      },
+    );
+
+    const user = userEvent.setup();
+    render(<NewBoardModal onClose={onClose} onCreated={onCreated} />);
+
+    await user.type(screen.getByRole('textbox', { name: /name/i }), 'Morning routine');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(createBoardMutateMock).toHaveBeenCalledWith(
+      { name: 'Morning routine', kind: 'sequence', kidId: 'k1' },
+      expect.any(Object),
+    );
+    expect(onCreated).toHaveBeenCalledWith('b-new');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a kid picker when multiple kids exist and saves with the selected kid', async () => {
+    useKidsMock.mockReturnValue({ data: [KID_1, KID_2], isPending: false });
+    const onClose = vi.fn();
+    const onCreated = vi.fn();
+    createBoardMutateMock.mockImplementation(
+      (_input: unknown, opts?: { onSuccess?: (b: Partial<Board>) => void }) => {
+        opts?.onSuccess?.({ id: 'b-new' });
+      },
+    );
+
+    const user = userEvent.setup();
+    render(<NewBoardModal onClose={onClose} onCreated={onCreated} />);
+
+    expect(screen.getByRole('combobox', { name: /kid/i })).toBeInTheDocument();
+    await user.type(screen.getByRole('textbox', { name: /name/i }), 'Bedtime');
+    await user.selectOptions(screen.getByRole('combobox', { name: /kid/i }), 'k2');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(createBoardMutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ kidId: 'k2', name: 'Bedtime' }),
+      expect.any(Object),
+    );
+  });
+
+  it('switches kind to choice when the choice radio is selected', async () => {
+    const user = userEvent.setup();
+    createBoardMutateMock.mockImplementation(
+      (_input: unknown, opts?: { onSuccess?: (b: Partial<Board>) => void }) => {
+        opts?.onSuccess?.({ id: 'b-new' });
+      },
+    );
+    render(<NewBoardModal onClose={vi.fn()} onCreated={vi.fn()} />);
+
+    await user.type(screen.getByRole('textbox', { name: /name/i }), 'Choices');
+    await user.click(screen.getByRole('radio', { name: /choice/i }));
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(createBoardMutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'choice' }),
+      expect.any(Object),
+    );
+  });
+
+  it('Save stays disabled when the name is whitespace-only', async () => {
+    const user = userEvent.setup();
+    render(<NewBoardModal onClose={vi.fn()} onCreated={vi.fn()} />);
+
+    await user.type(screen.getByRole('textbox', { name: /name/i }), '   ');
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+  });
+
+  it('renders an inline error when the mutation fails', async () => {
+    const onCreated = vi.fn();
+    createBoardMutateMock.mockImplementation(
+      (_input: unknown, opts?: { onError?: (e: Error) => void }) => {
+        opts?.onError?.(new Error('boom'));
+      },
+    );
+
+    const user = userEvent.setup();
+    render(<NewBoardModal onClose={vi.fn()} onCreated={onCreated} />);
+
+    await user.type(screen.getByRole('textbox', { name: /name/i }), 'X');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/couldn.?t create the board/i);
+    expect(onCreated).not.toHaveBeenCalled();
+  });
+
+  it('Cancel calls onClose without saving', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(<NewBoardModal onClose={onClose} onCreated={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(createBoardMutateMock).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a "no kids" message and disables Save when the user has zero kids', () => {
+    useKidsMock.mockReturnValue({ data: [], isPending: false });
+    render(<NewBoardModal onClose={vi.fn()} onCreated={vi.fn()} />);
+
+    expect(screen.getByText(/add a kid first/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+  });
+});

--- a/src/features/parent-home/NewBoardModal.test.tsx
+++ b/src/features/parent-home/NewBoardModal.test.tsx
@@ -25,10 +25,10 @@ const { NewBoardModal } = await import('./NewBoardModal');
 
 afterEach(() => {
   createBoardMutateMock.mockReset();
-  useCreateBoardMock.mockReset();
-  useCreateBoardMock.mockReturnValue({ mutate: createBoardMutateMock, isPending: false });
-  useKidsMock.mockReset();
-  useKidsMock.mockReturnValue({ data: [KID_1], isPending: false });
+  // mockClear preserves the factory implementations; per-test overrides via
+  // mockReturnValue still win for that test's invocations.
+  useCreateBoardMock.mockClear();
+  useKidsMock.mockClear();
 });
 
 describe('NewBoardModal', () => {

--- a/src/features/parent-home/NewBoardModal.tsx
+++ b/src/features/parent-home/NewBoardModal.tsx
@@ -1,0 +1,163 @@
+import { type FormEvent, type JSX, useState } from 'react';
+
+import { useCreateBoard } from '@/lib/queries/boards';
+import { useKids } from '@/lib/queries/kids';
+import type { BoardKind } from '@/types/domain';
+import { Button } from '@/ui/Button/Button';
+import { XIcon } from '@/ui/icons';
+import { Modal } from '@/ui/Modal/Modal';
+
+import styles from './NewBoardModal.module.css';
+
+const TITLE_ID = 'new-board-modal-title';
+
+interface NewBoardModalProps {
+  onClose: () => void;
+  onCreated: (boardId: string) => void;
+}
+
+const KIND_OPTIONS: readonly { value: BoardKind; label: string; hint: string }[] = [
+  { value: 'sequence', label: 'Sequence', hint: 'Step-by-step strip' },
+  { value: 'choice', label: 'Choice', hint: '3-up picker' },
+];
+
+export const NewBoardModal = ({ onClose, onCreated }: NewBoardModalProps): JSX.Element => {
+  const kids = useKids();
+  const createBoard = useCreateBoard();
+
+  const kidList = kids.data ?? [];
+  const [name, setName] = useState('');
+  const [kind, setKind] = useState<BoardKind>('sequence');
+  const [selectedKidId, setSelectedKidId] = useState<string>('');
+  const [error, setError] = useState<string | null>(null);
+
+  // Pick the first kid as default once the list resolves. Re-running this
+  // effect when the user picks one explicitly is unnecessary — local state
+  // wins after the first user interaction.
+  const effectiveKidId = selectedKidId || kidList[0]?.id || '';
+
+  const trimmed = name.trim();
+  const noKids = kidList.length === 0;
+  const submitDisabled = trimmed === '' || noKids || createBoard.isPending;
+
+  const submit = (e: FormEvent): void => {
+    e.preventDefault();
+    if (submitDisabled) return;
+    setError(null);
+    createBoard.mutate(
+      { name: trimmed, kind, kidId: effectiveKidId },
+      {
+        onSuccess: (board) => {
+          onCreated(board.id);
+          onClose();
+        },
+        onError: () => setError("Couldn't create the board. Try again."),
+      },
+    );
+  };
+
+  return (
+    <Modal onClose={onClose} labelledBy={TITLE_ID}>
+      <div className={styles.wrap}>
+        <header className={styles.header}>
+          <div>
+            <h2 id={TITLE_ID} className={styles.title}>
+              New board
+            </h2>
+            <p className={styles.subtitle}>
+              You can add steps and tweak settings after the board is created.
+            </p>
+          </div>
+          <button type="button" onClick={onClose} aria-label="Close" className={styles.closeBtn}>
+            <XIcon size={18} />
+          </button>
+        </header>
+
+        <form onSubmit={submit}>
+          {noKids && (
+            <p className={styles.noKids} role="status">
+              Add a kid first — boards need a kid to belong to.
+            </p>
+          )}
+
+          <label className={styles.field}>
+            <span className={styles.fieldLabel}>Name</span>
+            <input
+              type="text"
+              autoFocus
+              autoComplete="off"
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                if (error) setError(null);
+              }}
+              className={styles.input}
+              placeholder="Morning routine"
+              disabled={noKids}
+            />
+          </label>
+
+          <fieldset className={`${styles.field} ${styles.kindGroup}`}>
+            {KIND_OPTIONS.map((opt) => {
+              const checked = kind === opt.value;
+              return (
+                <label
+                  key={opt.value}
+                  className={`${styles.kindOption} ${checked ? styles.kindOptionChecked : ''}`}
+                >
+                  <input
+                    type="radio"
+                    name="kind"
+                    value={opt.value}
+                    checked={checked}
+                    onChange={() => setKind(opt.value)}
+                    className={styles.kindRadio}
+                    disabled={noKids}
+                  />
+                  <span>{opt.label}</span>
+                </label>
+              );
+            })}
+          </fieldset>
+
+          {kidList.length > 1 && (
+            <label className={styles.field}>
+              <span className={styles.fieldLabel}>Kid</span>
+              <select
+                value={effectiveKidId}
+                onChange={(e) => setSelectedKidId(e.target.value)}
+                className={styles.input}
+              >
+                {kidList.map((k) => (
+                  <option key={k.id} value={k.id}>
+                    {k.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+
+          {error && (
+            <p role="alert" className={styles.error}>
+              {error}
+            </p>
+          )}
+
+          <div className={styles.actions}>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onClose}
+              disabled={createBoard.isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" disabled={submitDisabled}>
+              {createBoard.isPending ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </Modal>
+  );
+};

--- a/src/features/parent-home/NewBoardModal.tsx
+++ b/src/features/parent-home/NewBoardModal.tsx
@@ -31,14 +31,17 @@ export const NewBoardModal = ({ onClose, onCreated }: NewBoardModalProps): JSX.E
   const [selectedKidId, setSelectedKidId] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
 
-  // Pick the first kid as default once the list resolves. Re-running this
-  // effect when the user picks one explicitly is unnecessary — local state
-  // wins after the first user interaction.
+  // Default to the first kid via derived state; `selectedKidId` wins once the
+  // user picks explicitly (the picker only renders when kidList.length > 1).
   const effectiveKidId = selectedKidId || kidList[0]?.id || '';
 
   const trimmed = name.trim();
-  const noKids = kidList.length === 0;
-  const submitDisabled = trimmed === '' || noKids || createBoard.isPending;
+  // Distinguish "still loading" from "user has zero kids" so we don't flash
+  // the "Add a kid first" copy on a slow connection. The empty branch only
+  // fires once the query has resolved with an empty list.
+  const kidsLoading = kids.isPending;
+  const noKids = !kidsLoading && kidList.length === 0;
+  const submitDisabled = trimmed === '' || noKids || kidsLoading || createBoard.isPending;
 
   const submit = (e: FormEvent): void => {
     e.preventDefault();
@@ -75,9 +78,7 @@ export const NewBoardModal = ({ onClose, onCreated }: NewBoardModalProps): JSX.E
 
         <form onSubmit={submit}>
           {noKids && (
-            <p className={styles.noKids} role="status">
-              Add a kid first — boards need a kid to belong to.
-            </p>
+            <p className={styles.noKids}>Add a kid first — boards need a kid to belong to.</p>
           )}
 
           <label className={styles.field}>

--- a/src/features/parent-home/NewKidModal.module.css
+++ b/src/features/parent-home/NewKidModal.module.css
@@ -1,0 +1,82 @@
+.wrap {
+  padding: 28px 28px 24px;
+  max-width: 440px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.title {
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--tal-ink);
+  margin: 0 0 2px;
+}
+
+.subtitle {
+  font-size: 13px;
+  color: var(--tal-ink-muted);
+  margin: 0;
+}
+
+.closeBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--tal-ink-soft);
+  border: none;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.fieldLabel {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--tal-ink-muted);
+}
+
+.input {
+  font-size: 15px;
+  padding: 10px 12px;
+  border: 1px solid var(--tal-line);
+  border-radius: var(--tal-r-md);
+  background: var(--tal-surface);
+  color: var(--tal-ink);
+  outline: none;
+}
+
+.input:focus {
+  border-color: var(--tal-ink-soft);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 20px;
+}
+
+.error {
+  margin: 8px 0 0;
+  font-size: 13px;
+  color: var(--tal-coral-ink, var(--tal-ink));
+}

--- a/src/features/parent-home/NewKidModal.test.tsx
+++ b/src/features/parent-home/NewKidModal.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { JSX } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mutateMock = vi.fn();
+const useCreateKidMock = vi.fn(() => ({
+  mutate: mutateMock,
+  isPending: false,
+}));
+
+vi.mock('@/lib/queries/kids', () => ({
+  useCreateKid: () => useCreateKidMock(),
+}));
+
+const { NewKidModal } = await import('./NewKidModal');
+
+const renderModal = (onClose: () => void = vi.fn()): JSX.Element => {
+  render(<NewKidModal onClose={onClose} />);
+  return <></>;
+};
+
+afterEach(() => {
+  mutateMock.mockReset();
+  useCreateKidMock.mockReset();
+  useCreateKidMock.mockReturnValue({ mutate: mutateMock, isPending: false });
+});
+
+describe('NewKidModal', () => {
+  it('renders an empty form with Save disabled', () => {
+    renderModal();
+    expect(screen.getByRole('heading', { name: /add a kid/i })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /name/i })).toHaveValue('');
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeEnabled();
+  });
+
+  it('Save calls useCreateKid with the trimmed name and closes on success', async () => {
+    const onClose = vi.fn();
+    mutateMock.mockImplementation((_input: unknown, opts?: { onSuccess?: () => void }) => {
+      opts?.onSuccess?.();
+    });
+
+    const user = userEvent.setup();
+    renderModal(onClose);
+
+    await user.type(screen.getByRole('textbox', { name: /name/i }), '  Mira  ');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(mutateMock).toHaveBeenCalledWith({ name: '  Mira  ' }, expect.any(Object));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('Save stays disabled when the input is whitespace-only', async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.type(screen.getByRole('textbox', { name: /name/i }), '   ');
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+  });
+
+  it('renders an inline error when the mutation fails', async () => {
+    const onClose = vi.fn();
+    mutateMock.mockImplementation((_input: unknown, opts?: { onError?: (e: Error) => void }) => {
+      opts?.onError?.(new Error('boom'));
+    });
+
+    const user = userEvent.setup();
+    renderModal(onClose);
+
+    await user.type(screen.getByRole('textbox', { name: /name/i }), 'Mira');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/couldn.?t add the kid/i);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('Cancel calls onClose without saving', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderModal(onClose);
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(mutateMock).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/parent-home/NewKidModal.test.tsx
+++ b/src/features/parent-home/NewKidModal.test.tsx
@@ -22,8 +22,10 @@ const renderModal = (onClose: () => void = vi.fn()): JSX.Element => {
 
 afterEach(() => {
   mutateMock.mockReset();
-  useCreateKidMock.mockReset();
-  useCreateKidMock.mockReturnValue({ mutate: mutateMock, isPending: false });
+  // mockClear (not mockReset) preserves the factory implementation; mockReset
+  // would drop it back to `vi.fn(() => undefined)` and the next render would
+  // crash with "cannot read property 'mutate' of undefined".
+  useCreateKidMock.mockClear();
 });
 
 describe('NewKidModal', () => {
@@ -47,7 +49,9 @@ describe('NewKidModal', () => {
     await user.type(screen.getByRole('textbox', { name: /name/i }), '  Mira  ');
     await user.click(screen.getByRole('button', { name: /save/i }));
 
-    expect(mutateMock).toHaveBeenCalledWith({ name: '  Mira  ' }, expect.any(Object));
+    // Modal trims the input before calling the mutation — the query layer is
+    // a thin DB wrapper and trusts what the modal passes.
+    expect(mutateMock).toHaveBeenCalledWith({ name: 'Mira' }, expect.any(Object));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 

--- a/src/features/parent-home/NewKidModal.tsx
+++ b/src/features/parent-home/NewKidModal.tsx
@@ -26,7 +26,7 @@ export const NewKidModal = ({ onClose }: NewKidModalProps): JSX.Element => {
     if (submitDisabled) return;
     setError(null);
     createKid.mutate(
-      { name },
+      { name: trimmed },
       {
         onSuccess: () => onClose(),
         onError: () => setError("Couldn't add the kid. Try again."),

--- a/src/features/parent-home/NewKidModal.tsx
+++ b/src/features/parent-home/NewKidModal.tsx
@@ -1,0 +1,87 @@
+import { type FormEvent, type JSX, useState } from 'react';
+
+import { useCreateKid } from '@/lib/queries/kids';
+import { Button } from '@/ui/Button/Button';
+import { XIcon } from '@/ui/icons';
+import { Modal } from '@/ui/Modal/Modal';
+
+import styles from './NewKidModal.module.css';
+
+const TITLE_ID = 'new-kid-modal-title';
+
+interface NewKidModalProps {
+  onClose: () => void;
+}
+
+export const NewKidModal = ({ onClose }: NewKidModalProps): JSX.Element => {
+  const createKid = useCreateKid();
+  const [name, setName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmed = name.trim();
+  const submitDisabled = trimmed === '' || createKid.isPending;
+
+  const submit = (e: FormEvent): void => {
+    e.preventDefault();
+    if (submitDisabled) return;
+    setError(null);
+    createKid.mutate(
+      { name },
+      {
+        onSuccess: () => onClose(),
+        onError: () => setError("Couldn't add the kid. Try again."),
+      },
+    );
+  };
+
+  return (
+    <Modal onClose={onClose} labelledBy={TITLE_ID}>
+      <div className={styles.wrap}>
+        <header className={styles.header}>
+          <div>
+            <h2 id={TITLE_ID} className={styles.title}>
+              Add a kid
+            </h2>
+            <p className={styles.subtitle}>
+              Each kid has their own boards. You can add more later.
+            </p>
+          </div>
+          <button type="button" onClick={onClose} aria-label="Close" className={styles.closeBtn}>
+            <XIcon size={18} />
+          </button>
+        </header>
+
+        <form onSubmit={submit}>
+          <label className={styles.field}>
+            <span className={styles.fieldLabel}>Name</span>
+            <input
+              type="text"
+              autoFocus
+              autoComplete="off"
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                if (error) setError(null);
+              }}
+              className={styles.input}
+              placeholder="Liam"
+            />
+          </label>
+          {error && (
+            <p role="alert" className={styles.error}>
+              {error}
+            </p>
+          )}
+          <div className={styles.actions}>
+            <Button type="button" variant="ghost" onClick={onClose} disabled={createKid.isPending}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" disabled={submitDisabled}>
+              {createKid.isPending ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </Modal>
+  );
+};

--- a/src/features/parent-home/ParentHome.module.css
+++ b/src/features/parent-home/ParentHome.module.css
@@ -36,6 +36,35 @@
   color: var(--tal-ink-soft);
 }
 
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 14px;
+  padding: 60px 32px;
+  margin-top: 8px;
+  border: 2px dashed var(--tal-line);
+  border-radius: var(--tal-r-lg);
+  background: var(--tal-surface-alt);
+}
+
+.emptyTitle {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--tal-ink);
+}
+
+.emptyBody {
+  margin: 0;
+  max-width: 420px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--tal-ink-soft);
+}
+
 .recent {
   margin-top: 36px;
 }

--- a/src/features/parent-home/ParentHome.tsx
+++ b/src/features/parent-home/ParentHome.tsx
@@ -16,12 +16,14 @@ interface ParentHomeProps {
   kidName?: string;
   onOpenBoard?: (id: string) => void;
   onKidMode?: () => void;
+  onNewKid?: () => void;
 }
 
 export const ParentHome = ({
   kidName = 'Liam',
   onOpenBoard,
   onKidMode,
+  onNewKid,
 }: ParentHomeProps): JSX.Element => {
   const boardsQuery = useBoards();
   const pictogramsBySlug = usePictogramsBySlug();
@@ -36,7 +38,7 @@ export const ParentHome = ({
       subtitle="Pick a board to edit, or start a new one."
       right={
         <div className={styles.rightActions}>
-          <Button variant="ghost" icon={<PlusIcon />}>
+          <Button variant="ghost" icon={<PlusIcon />} onClick={onNewKid}>
             New kid
           </Button>
           <Button variant="primary" icon={<PlusIcon />}>

--- a/src/features/parent-home/ParentHome.tsx
+++ b/src/features/parent-home/ParentHome.tsx
@@ -17,6 +17,15 @@ interface ParentHomeProps {
   onOpenBoard?: (id: string) => void;
   onKidMode?: () => void;
   onNewKid?: () => void;
+  /** Opens the full New board modal (name + kind + kid picker). */
+  onNewBoard?: () => void;
+  /**
+   * Fast path: creates a board with default values immediately and navigates
+   * into the BoardBuilder. Disabled when no kids are loaded yet (the route
+   * passes a no-op or omits the prop while waiting on the kids query).
+   */
+  onNewBlankBoard?: () => void;
+  newBlankPending?: boolean;
 }
 
 export const ParentHome = ({
@@ -24,11 +33,15 @@ export const ParentHome = ({
   onOpenBoard,
   onKidMode,
   onNewKid,
+  onNewBoard,
+  onNewBlankBoard,
+  newBlankPending = false,
 }: ParentHomeProps): JSX.Element => {
   const boardsQuery = useBoards();
   const pictogramsBySlug = usePictogramsBySlug();
 
   const boards = boardsQuery.data ?? [];
+  const noBoards = boards.length === 0;
 
   return (
     <ParentShell
@@ -41,23 +54,41 @@ export const ParentHome = ({
           <Button variant="ghost" icon={<PlusIcon />} onClick={onNewKid}>
             New kid
           </Button>
-          <Button variant="primary" icon={<PlusIcon />}>
+          <Button variant="primary" icon={<PlusIcon />} onClick={onNewBoard}>
             New board
           </Button>
         </div>
       }
     >
-      <div className={styles.grid}>
-        {boards.map((b) => (
-          <BoardCard key={b.id} board={b} onClick={() => onOpenBoard?.(b.id)} />
-        ))}
-        <button type="button" className={styles.newTile}>
-          <span className={styles.newTileIcon}>
-            <PlusIcon size={22} />
-          </span>
-          New blank board
-        </button>
-      </div>
+      {noBoards ? (
+        <div className={styles.emptyState} role="status">
+          <h2 className={styles.emptyTitle}>No boards yet</h2>
+          <p className={styles.emptyBody}>
+            Create your first board to start communicating. You can add steps and tweak settings
+            after.
+          </p>
+          <Button variant="primary" icon={<PlusIcon />} onClick={onNewBoard}>
+            Create your first board
+          </Button>
+        </div>
+      ) : (
+        <div className={styles.grid}>
+          {boards.map((b) => (
+            <BoardCard key={b.id} board={b} onClick={() => onOpenBoard?.(b.id)} />
+          ))}
+          <button
+            type="button"
+            className={styles.newTile}
+            onClick={onNewBlankBoard}
+            disabled={newBlankPending}
+          >
+            <span className={styles.newTileIcon}>
+              <PlusIcon size={22} />
+            </span>
+            {newBlankPending ? 'Creating…' : 'New blank board'}
+          </button>
+        </div>
+      )}
       <section className={styles.recent}>
         <div className={styles.recentHeader}>
           <h2 className={styles.recentHeading}>Recently added pictograms</h2>

--- a/src/features/parent-home/ParentHomeRoute.test.tsx
+++ b/src/features/parent-home/ParentHomeRoute.test.tsx
@@ -220,4 +220,32 @@ describe('ParentHomeRoute create flows', () => {
     );
     expect(screen.getByTestId('board-edit-route')).toBeInTheDocument();
   });
+
+  it('saving the New board modal navigates to the new board edit route', async () => {
+    createBoardMutateMock.mockImplementation(
+      (_input: unknown, opts?: { onSuccess?: (b: Partial<Board>) => void }) => {
+        opts?.onSuccess?.({ id: 'b-new-from-modal' });
+      },
+    );
+
+    const Wrap = makeWrap('/');
+    render(<Wrap />);
+
+    const user = userEvent.setup();
+    // Open the modal from the empty-state CTA (works the same as the header
+    // button — both go through `setNewBoardOpen(true)`).
+    await user.click(screen.getByRole('button', { name: /create your first board/i }));
+    await user.type(screen.getByRole('textbox', { name: /name/i }), 'From modal');
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+    expect(createBoardMutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'From modal',
+        kind: 'sequence',
+        kidId: 'k1',
+      }),
+      expect.any(Object),
+    );
+    expect(screen.getByTestId('board-edit-route')).toBeInTheDocument();
+  });
 });

--- a/src/features/parent-home/ParentHomeRoute.test.tsx
+++ b/src/features/parent-home/ParentHomeRoute.test.tsx
@@ -6,7 +6,31 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { TestSessionProvider } from '@/lib/auth/session.test-utils';
-import { boardsQueryKey } from '@/lib/queries/boards';
+import type { Board, Kid } from '@/types/domain';
+
+const KID: Kid = { id: 'k1', ownerId: 'owner', name: 'Liam' };
+
+const useKidsMock = vi.fn(() => ({ data: [KID] as Kid[], isPending: false }));
+const useBoardsMock = vi.fn(() => ({ data: [] as Board[], isPending: false }));
+const createBoardMutateMock = vi.fn();
+const useCreateBoardMock = vi.fn(() => ({
+  mutate: createBoardMutateMock,
+  isPending: false,
+}));
+
+vi.mock('@/lib/queries/kids', () => ({
+  useKids: () => useKidsMock(),
+  useCreateKid: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock('@/lib/queries/boards', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    useBoards: () => useBoardsMock(),
+    useCreateBoard: () => useCreateBoardMock(),
+  };
+});
 
 vi.mock('@/lib/supabase', () => ({
   supabase: {
@@ -25,7 +49,6 @@ const { ParentHomeRoute } = await import('./ParentHomeRoute');
 
 const makeWrap = (initialPath: string): (() => JSX.Element) => {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  qc.setQueryData(boardsQueryKey, []);
   return (): JSX.Element => (
     <TestSessionProvider>
       <QueryClientProvider client={qc}>
@@ -35,6 +58,7 @@ const makeWrap = (initialPath: string): (() => JSX.Element) => {
         >
           <Routes>
             <Route path="/" element={<ParentHomeRoute />} />
+            <Route path="/boards/:boardId/edit" element={<div data-testid="board-edit-route" />} />
             <Route
               path="/kid/sequence/:boardId"
               element={<div data-testid="kid-sequence-route" />}
@@ -47,22 +71,28 @@ const makeWrap = (initialPath: string): (() => JSX.Element) => {
   );
 };
 
-describe('ParentHomeRoute auto-launch', () => {
-  beforeEach(() => {
-    localStorage.clear();
-    sessionStorage.clear();
-  });
-  afterEach(() => {
-    localStorage.clear();
-    sessionStorage.clear();
-  });
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+  useKidsMock.mockReset();
+  useKidsMock.mockReturnValue({ data: [KID], isPending: false });
+  useBoardsMock.mockReset();
+  useBoardsMock.mockReturnValue({ data: [], isPending: false });
+  createBoardMutateMock.mockReset();
+  useCreateBoardMock.mockReset();
+  useCreateBoardMock.mockReturnValue({ mutate: createBoardMutateMock, isPending: false });
+});
+afterEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+});
 
+describe('ParentHomeRoute auto-launch', () => {
   it('renders ParentHome when no last board is recorded', () => {
     const Wrap = makeWrap('/');
     render(<Wrap />);
     expect(screen.queryByTestId('kid-sequence-route')).not.toBeInTheDocument();
     expect(screen.queryByTestId('kid-choice-route')).not.toBeInTheDocument();
-    // ParentHome's title is rendered via ParentShell when supplied.
     expect(screen.getByText(/Liam's boards/)).toBeInTheDocument();
   });
 
@@ -88,7 +118,9 @@ describe('ParentHomeRoute auto-launch', () => {
     expect(screen.queryByTestId('kid-sequence-route')).not.toBeInTheDocument();
     expect(screen.getByText(/Liam's boards/)).toBeInTheDocument();
   });
+});
 
+describe('ParentHomeRoute create flows', () => {
   it('clicking New kid opens the kid modal', async () => {
     const Wrap = makeWrap('/');
     render(<Wrap />);
@@ -98,5 +130,94 @@ describe('ParentHomeRoute auto-launch', () => {
     await user.click(screen.getByRole('button', { name: /new kid/i }));
 
     expect(screen.getByRole('heading', { name: /add a kid/i })).toBeInTheDocument();
+  });
+
+  it('shows the empty state when there are no boards', () => {
+    const Wrap = makeWrap('/');
+    render(<Wrap />);
+    expect(screen.getByRole('heading', { name: /no boards yet/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /create your first board/i })).toBeInTheDocument();
+  });
+
+  it('clicking the empty-state CTA opens the New board modal', async () => {
+    const Wrap = makeWrap('/');
+    render(<Wrap />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /create your first board/i }));
+
+    expect(screen.getByRole('heading', { name: /new board/i })).toBeInTheDocument();
+  });
+
+  it('clicking the header New board opens the modal even when boards exist', async () => {
+    useBoardsMock.mockReturnValue({
+      data: [
+        {
+          id: 'b1',
+          ownerId: 'owner',
+          kidId: 'k1',
+          name: 'Existing',
+          kind: 'sequence',
+          labelsVisible: true,
+          voiceMode: 'tts',
+          stepIds: [],
+          kidReorderable: false,
+          accent: 'sage',
+          accentInk: 'sage-ink',
+          updatedLabel: 'just now',
+        },
+      ],
+      isPending: false,
+    });
+    const Wrap = makeWrap('/');
+    render(<Wrap />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /^new board$/i }));
+
+    expect(screen.getByRole('heading', { name: /^new board$/i })).toBeInTheDocument();
+  });
+
+  it('clicking New blank board fast-creates with the first kid and navigates to the board edit route', async () => {
+    useBoardsMock.mockReturnValue({
+      data: [
+        {
+          id: 'b1',
+          ownerId: 'owner',
+          kidId: 'k1',
+          name: 'Existing',
+          kind: 'sequence',
+          labelsVisible: true,
+          voiceMode: 'tts',
+          stepIds: [],
+          kidReorderable: false,
+          accent: 'sage',
+          accentInk: 'sage-ink',
+          updatedLabel: 'just now',
+        },
+      ],
+      isPending: false,
+    });
+    createBoardMutateMock.mockImplementation(
+      (_input: unknown, opts?: { onSuccess?: (b: Partial<Board>) => void }) => {
+        opts?.onSuccess?.({ id: 'b-new' });
+      },
+    );
+
+    const Wrap = makeWrap('/');
+    render(<Wrap />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /new blank board/i }));
+
+    expect(createBoardMutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Untitled board',
+        kind: 'sequence',
+        kidId: 'k1',
+      }),
+      expect.any(Object),
+    );
+    expect(screen.getByTestId('board-edit-route')).toBeInTheDocument();
   });
 });

--- a/src/features/parent-home/ParentHomeRoute.test.tsx
+++ b/src/features/parent-home/ParentHomeRoute.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { JSX } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -86,5 +87,16 @@ describe('ParentHomeRoute auto-launch', () => {
     render(<Wrap />);
     expect(screen.queryByTestId('kid-sequence-route')).not.toBeInTheDocument();
     expect(screen.getByText(/Liam's boards/)).toBeInTheDocument();
+  });
+
+  it('clicking New kid opens the kid modal', async () => {
+    const Wrap = makeWrap('/');
+    render(<Wrap />);
+    expect(screen.queryByRole('heading', { name: /add a kid/i })).not.toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /new kid/i }));
+
+    expect(screen.getByRole('heading', { name: /add a kid/i })).toBeInTheDocument();
   });
 });

--- a/src/features/parent-home/ParentHomeRoute.tsx
+++ b/src/features/parent-home/ParentHomeRoute.tsx
@@ -4,11 +4,13 @@ import { Navigate, useNavigate } from 'react-router-dom';
 import { getLastBoard, hasAutoLaunched, kidPathFor, markAutoLaunched } from '@/lib/lastBoard';
 import { useBoards } from '@/lib/queries/boards';
 
+import { NewKidModal } from './NewKidModal';
 import { ParentHome } from './ParentHome';
 
 export const ParentHomeRoute = (): JSX.Element => {
   const navigate = useNavigate();
   const boardsQuery = useBoards();
+  const [newKidOpen, setNewKidOpen] = useState(false);
   // Auto-launch into the last kid-mode board on the first parent-home visit
   // per browser session. Subsequent visits this session (e.g. after PIN exit
   // back to home) render ParentHome normally so the user is never trapped.
@@ -30,5 +32,14 @@ export const ParentHomeRoute = (): JSX.Element => {
     if (firstSequence) navigate(`/kid/sequence/${firstSequence.id}`);
   };
 
-  return <ParentHome onOpenBoard={(id) => navigate(`/boards/${id}/edit`)} onKidMode={onKidMode} />;
+  return (
+    <>
+      <ParentHome
+        onOpenBoard={(id) => navigate(`/boards/${id}/edit`)}
+        onKidMode={onKidMode}
+        onNewKid={() => setNewKidOpen(true)}
+      />
+      {newKidOpen && <NewKidModal onClose={() => setNewKidOpen(false)} />}
+    </>
+  );
 };

--- a/src/features/parent-home/ParentHomeRoute.tsx
+++ b/src/features/parent-home/ParentHomeRoute.tsx
@@ -2,15 +2,21 @@ import { type JSX, useEffect, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 
 import { getLastBoard, hasAutoLaunched, kidPathFor, markAutoLaunched } from '@/lib/lastBoard';
-import { useBoards } from '@/lib/queries/boards';
+import { useBoards, useCreateBoard } from '@/lib/queries/boards';
+import { useKids } from '@/lib/queries/kids';
+import { accentForIndex } from '@/theme/tokens';
 
+import { NewBoardModal } from './NewBoardModal';
 import { NewKidModal } from './NewKidModal';
 import { ParentHome } from './ParentHome';
 
 export const ParentHomeRoute = (): JSX.Element => {
   const navigate = useNavigate();
   const boardsQuery = useBoards();
+  const kidsQuery = useKids();
+  const createBoard = useCreateBoard();
   const [newKidOpen, setNewKidOpen] = useState(false);
+  const [newBoardOpen, setNewBoardOpen] = useState(false);
   // Auto-launch into the last kid-mode board on the first parent-home visit
   // per browser session. Subsequent visits this session (e.g. after PIN exit
   // back to home) render ParentHome normally so the user is never trapped.
@@ -32,14 +38,44 @@ export const ParentHomeRoute = (): JSX.Element => {
     if (firstSequence) navigate(`/kid/sequence/${firstSequence.id}`);
   };
 
+  const firstKid = kidsQuery.data?.[0];
+  const boardCount = boardsQuery.data?.length ?? 0;
+
+  // Fast-path create: skip the modal, drop a board with default values, and
+  // navigate straight into the BoardBuilder where the user names + tunes it.
+  // Accent rotates by current board count so the grid stays visually distinct.
+  const onNewBlankBoard = (): void => {
+    if (!firstKid || createBoard.isPending) return;
+    createBoard.mutate(
+      {
+        name: 'Untitled board',
+        kind: 'sequence',
+        kidId: firstKid.id,
+        accent: accentForIndex(boardCount),
+      },
+      {
+        onSuccess: (board) => navigate(`/boards/${board.id}/edit`),
+      },
+    );
+  };
+
   return (
     <>
       <ParentHome
         onOpenBoard={(id) => navigate(`/boards/${id}/edit`)}
         onKidMode={onKidMode}
         onNewKid={() => setNewKidOpen(true)}
+        onNewBoard={() => setNewBoardOpen(true)}
+        onNewBlankBoard={onNewBlankBoard}
+        newBlankPending={createBoard.isPending}
       />
       {newKidOpen && <NewKidModal onClose={() => setNewKidOpen(false)} />}
+      {newBoardOpen && (
+        <NewBoardModal
+          onClose={() => setNewBoardOpen(false)}
+          onCreated={(boardId) => navigate(`/boards/${boardId}/edit`)}
+        />
+      )}
     </>
   );
 };

--- a/src/lib/queries/boards.create.test.tsx
+++ b/src/lib/queries/boards.create.test.tsx
@@ -1,0 +1,144 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { JSX, ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TestSessionProvider } from '@/lib/auth/session.test-utils';
+import type { Board } from '@/types/domain';
+
+interface MockPostgrestError {
+  code: string;
+  message: string;
+  details: string;
+  hint: string;
+}
+
+// Write-path chain: from('boards').insert({...}).select().single()
+const singleMock = vi.fn<() => Promise<{ data: unknown; error: MockPostgrestError | null }>>();
+const insertSelectMock = vi.fn(() => ({ single: singleMock }));
+const insertMock = vi.fn(() => ({ select: insertSelectMock }));
+const fromMock = vi.fn((_table: string) => ({ insert: insertMock }));
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: { from: (table: string) => fromMock(table) },
+}));
+
+// Import after the mock is registered.
+const { boardsQueryKey, useCreateBoard } = await import('./boards');
+
+const wrap = (qc: QueryClient): ((p: { children: ReactNode }) => JSX.Element) => {
+  const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+    <TestSessionProvider>
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    </TestSessionProvider>
+  );
+  return Wrapper;
+};
+
+const SERVER_ROW = {
+  id: 'b-new',
+  owner_id: '00000000-0000-0000-0000-0000000000aa',
+  kid_id: 'k1',
+  slug: null,
+  name: 'Morning routine',
+  kind: 'sequence',
+  labels_visible: true,
+  voice_mode: 'tts',
+  step_ids: [] as string[],
+  kid_reorderable: false,
+  accent: 'sage',
+  accent_ink: 'sage-ink',
+  updated_at: '2026-04-26T12:00:00Z',
+};
+
+describe('useCreateBoard', () => {
+  beforeEach(() => {
+    singleMock.mockReset();
+    insertSelectMock.mockClear();
+    insertMock.mockClear();
+    fromMock.mockClear();
+  });
+
+  it('inserts with sensible defaults, returns the mapped Board, and invalidates the boards list cache', async () => {
+    singleMock.mockResolvedValueOnce({ data: SERVER_ROW, error: null });
+
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCreateBoard(), { wrapper: wrap(qc) });
+
+    let returned: Board | undefined;
+    await act(async () => {
+      returned = await result.current.mutateAsync({
+        name: '  Morning routine  ',
+        kind: 'sequence',
+        kidId: 'k1',
+      });
+    });
+
+    expect(fromMock).toHaveBeenCalledWith('boards');
+    expect(insertMock).toHaveBeenCalledWith({
+      owner_id: '00000000-0000-0000-0000-0000000000aa',
+      kid_id: 'k1',
+      name: 'Morning routine',
+      kind: 'sequence',
+      labels_visible: true,
+      voice_mode: 'tts',
+      step_ids: [],
+      kid_reorderable: false,
+      accent: 'sage',
+      accent_ink: 'sage-ink',
+    });
+    expect(returned?.name).toBe('Morning routine');
+    expect(returned?.kind).toBe('sequence');
+    expect(returned?.kidId).toBe('k1');
+    expect(returned?.id).toBe('b-new');
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: boardsQueryKey });
+  });
+
+  it('honors a caller-supplied accent override', async () => {
+    singleMock.mockResolvedValueOnce({
+      data: { ...SERVER_ROW, accent: 'lavender', accent_ink: 'lavender-ink' },
+      error: null,
+    });
+
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const { result } = renderHook(() => useCreateBoard(), { wrapper: wrap(qc) });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: 'Bedtime',
+        kind: 'choice',
+        kidId: 'k1',
+        accent: { bg: 'lavender', ink: 'lavender-ink' },
+      });
+    });
+
+    expect(insertMock).toHaveBeenCalledWith(
+      expect.objectContaining({ accent: 'lavender', accent_ink: 'lavender-ink', kind: 'choice' }),
+    );
+  });
+
+  it('surfaces a Postgres RLS error as React Query error state', async () => {
+    singleMock.mockResolvedValueOnce({
+      data: null,
+      error: { code: '42501', message: 'row-level-security', details: '', hint: '' },
+    });
+
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const { result } = renderHook(() => useCreateBoard(), { wrapper: wrap(qc) });
+
+    act(() => {
+      result.current.mutate({ name: 'X', kind: 'sequence', kidId: 'k1' });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toMatchObject({ code: '42501' });
+  });
+});

--- a/src/lib/queries/boards.ts
+++ b/src/lib/queries/boards.ts
@@ -6,10 +6,11 @@ import {
   type UseQueryResult,
 } from '@tanstack/react-query';
 
+import { useSessionUser } from '@/lib/auth/session';
 import { formatUpdated } from '@/lib/formatUpdated';
 import { type BoardRowPatch, enqueueAndDrain } from '@/lib/outbox';
 import { supabase } from '@/lib/supabase';
-import type { ColorToken } from '@/theme/tokens';
+import { type Accent, type ColorToken } from '@/theme/tokens';
 import type { Board, BoardKind, VoiceMode } from '@/types/domain';
 import type { Database } from '@/types/supabase';
 
@@ -188,3 +189,54 @@ export const useSetKidReorderable = (): UseMutationResult<
     ({ reorderable }, current) => ({ ...current, kidReorderable: reorderable }),
     ({ reorderable }) => ({ kid_reorderable: reorderable }),
   );
+
+interface CreateBoardInput {
+  name: string;
+  kind: BoardKind;
+  kidId: string;
+  /** Defaults to the first slot of the accent cycle (sage / sage-ink). */
+  accent?: Accent;
+}
+
+const DEFAULT_ACCENT: Accent = { bg: 'sage', ink: 'sage-ink' };
+
+/**
+ * Direct Supabase insert (no outbox), matching the `useAddBoardMember` and
+ * `useCreateKid` precedents. Outbox would surface RLS denials only at drain
+ * time — wrong for create-then-navigate where the caller needs the row to
+ * actually exist on the server before routing into the BoardBuilder.
+ *
+ * Defaults match the new-board column requirements from
+ * `20260425000000_real_auth_onboarding.sql`: an empty step list, labels
+ * visible, TTS voice, kid-reorderable off. The user can change all of these
+ * in the BoardBuilder after creation.
+ */
+export const useCreateBoard = (): UseMutationResult<Board, Error, CreateBoardInput> => {
+  const qc = useQueryClient();
+  const ownerId = useSessionUser().id;
+  return useMutation({
+    mutationFn: async ({ name, kind, kidId, accent = DEFAULT_ACCENT }) => {
+      const { data, error } = await supabase
+        .from('boards')
+        .insert({
+          owner_id: ownerId,
+          kid_id: kidId,
+          name: name.trim(),
+          kind,
+          labels_visible: true,
+          voice_mode: 'tts',
+          step_ids: [],
+          kid_reorderable: false,
+          accent: accent.bg,
+          accent_ink: accent.ink,
+        })
+        .select()
+        .single();
+      if (error) throw error;
+      return rowToBoard(data);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: boardsQueryKey });
+    },
+  });
+};

--- a/src/lib/queries/kids.test.tsx
+++ b/src/lib/queries/kids.test.tsx
@@ -1,0 +1,141 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { JSX, ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TestSessionProvider } from '@/lib/auth/session.test-utils';
+import type { Kid } from '@/types/domain';
+
+interface MockPostgrestError {
+  code: string;
+  message: string;
+  details: string;
+  hint: string;
+}
+
+// Read-path chain: from('kids').select('*').order('created_at')
+const orderMock = vi.fn<() => Promise<{ data: unknown; error: MockPostgrestError | null }>>();
+const readSelectMock = vi.fn(() => ({ order: orderMock }));
+
+// Write-path chain: from('kids').insert({...}).select().single()
+const singleMock = vi.fn<() => Promise<{ data: unknown; error: MockPostgrestError | null }>>();
+const insertSelectMock = vi.fn(() => ({ single: singleMock }));
+const insertMock = vi.fn(() => ({ select: insertSelectMock }));
+
+const fromMock = vi.fn((_table: string) => ({
+  select: readSelectMock,
+  insert: insertMock,
+}));
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: { from: (table: string) => fromMock(table) },
+}));
+
+// Import after the mock is registered.
+const { kidsQueryKey, useCreateKid, useKids } = await import('./kids');
+
+const wrap = (qc: QueryClient): ((p: { children: ReactNode }) => JSX.Element) => {
+  const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+    <TestSessionProvider>
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    </TestSessionProvider>
+  );
+  return Wrapper;
+};
+
+describe('useKids', () => {
+  beforeEach(() => {
+    orderMock.mockReset();
+    readSelectMock.mockClear();
+    singleMock.mockReset();
+    insertSelectMock.mockClear();
+    insertMock.mockClear();
+    fromMock.mockClear();
+  });
+
+  it('fetches kids and maps rows to the domain shape', async () => {
+    orderMock.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'k1',
+          owner_id: 'owner-uuid',
+          name: 'Liam',
+          created_at: '2026-04-01T00:00:00Z',
+        },
+      ],
+      error: null,
+    });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useKids(), { wrapper: wrap(qc) });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual<Kid[]>([{ id: 'k1', ownerId: 'owner-uuid', name: 'Liam' }]);
+    expect(fromMock).toHaveBeenCalledWith('kids');
+  });
+});
+
+describe('useCreateKid', () => {
+  beforeEach(() => {
+    orderMock.mockReset();
+    readSelectMock.mockClear();
+    singleMock.mockReset();
+    insertSelectMock.mockClear();
+    insertMock.mockClear();
+    fromMock.mockClear();
+  });
+
+  it('inserts with the trimmed name + session owner_id, returns the mapped Kid, and invalidates the kids list cache', async () => {
+    singleMock.mockResolvedValueOnce({
+      data: {
+        id: 'k-new',
+        owner_id: '00000000-0000-0000-0000-0000000000aa',
+        name: 'Mira',
+        created_at: '2026-04-26T12:00:00Z',
+      },
+      error: null,
+    });
+
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCreateKid(), { wrapper: wrap(qc) });
+
+    let returned: Kid | undefined;
+    await act(async () => {
+      returned = await result.current.mutateAsync({ name: '  Mira  ' });
+    });
+
+    expect(returned).toEqual<Kid>({
+      id: 'k-new',
+      ownerId: '00000000-0000-0000-0000-0000000000aa',
+      name: 'Mira',
+    });
+    expect(insertMock).toHaveBeenCalledWith({
+      owner_id: '00000000-0000-0000-0000-0000000000aa',
+      name: 'Mira',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: kidsQueryKey });
+  });
+
+  it('surfaces a Postgres RLS error as React Query error state', async () => {
+    singleMock.mockResolvedValueOnce({
+      data: null,
+      error: { code: '42501', message: 'row-level-security', details: '', hint: '' },
+    });
+
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const { result } = renderHook(() => useCreateKid(), { wrapper: wrap(qc) });
+
+    act(() => {
+      result.current.mutate({ name: 'Mira' });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toMatchObject({ code: '42501' });
+  });
+});

--- a/src/lib/queries/kids.test.tsx
+++ b/src/lib/queries/kids.test.tsx
@@ -85,7 +85,7 @@ describe('useCreateKid', () => {
     fromMock.mockClear();
   });
 
-  it('inserts with the trimmed name + session owner_id, returns the mapped Kid, and invalidates the kids list cache', async () => {
+  it('inserts with the supplied name + session owner_id, returns the mapped Kid, and invalidates the kids list cache', async () => {
     singleMock.mockResolvedValueOnce({
       data: {
         id: 'k-new',
@@ -105,7 +105,9 @@ describe('useCreateKid', () => {
 
     let returned: Kid | undefined;
     await act(async () => {
-      returned = await result.current.mutateAsync({ name: '  Mira  ' });
+      // Input normalization (trim) is the modal's job; the query forwards
+      // `name` to the DB unchanged.
+      returned = await result.current.mutateAsync({ name: 'Mira' });
     });
 
     expect(returned).toEqual<Kid>({

--- a/src/lib/queries/kids.ts
+++ b/src/lib/queries/kids.ts
@@ -45,9 +45,12 @@ export const useCreateKid = (): UseMutationResult<Kid, Error, CreateKidInput> =>
   const ownerId = useSessionUser().id;
   return useMutation({
     mutationFn: async ({ name }) => {
+      // Input normalization (trimming, validation) is the modal layer's job;
+      // the query stays a thin DB wrapper so all create mutations behave
+      // identically (`useCreateBoard` already follows this).
       const { data, error } = await supabase
         .from('kids')
-        .insert({ owner_id: ownerId, name: name.trim() })
+        .insert({ owner_id: ownerId, name })
         .select()
         .single();
       if (error) throw error;

--- a/src/lib/queries/kids.ts
+++ b/src/lib/queries/kids.ts
@@ -1,0 +1,60 @@
+import {
+  useMutation,
+  type UseMutationResult,
+  useQuery,
+  useQueryClient,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+
+import { useSessionUser } from '@/lib/auth/session';
+import { supabase } from '@/lib/supabase';
+import type { Kid } from '@/types/domain';
+import type { Database } from '@/types/supabase';
+
+type KidRow = Database['public']['Tables']['kids']['Row'];
+
+export const rowToKid = (row: KidRow): Kid => ({
+  id: row.id,
+  ownerId: row.owner_id,
+  name: row.name,
+});
+
+export const kidsQueryKey = ['kids'] as const;
+
+const fetchKids = async (): Promise<Kid[]> => {
+  const { data, error } = await supabase.from('kids').select('*').order('created_at');
+  if (error) throw error;
+  return data.map(rowToKid);
+};
+
+export const useKids = (): UseQueryResult<Kid[]> =>
+  useQuery({ queryKey: kidsQueryKey, queryFn: fetchKids });
+
+interface CreateKidInput {
+  name: string;
+}
+
+/**
+ * Direct Supabase insert (no outbox), matching the `useAddBoardMember` pattern
+ * in `board-members.ts`. Outbox would surface RLS denials only at drain — wrong
+ * for create-then-react flows where the caller needs the row to actually exist
+ * on the server (e.g. defaulting a new board's `kid_id`).
+ */
+export const useCreateKid = (): UseMutationResult<Kid, Error, CreateKidInput> => {
+  const qc = useQueryClient();
+  const ownerId = useSessionUser().id;
+  return useMutation({
+    mutationFn: async ({ name }) => {
+      const { data, error } = await supabase
+        .from('kids')
+        .insert({ owner_id: ownerId, name: name.trim() })
+        .select()
+        .single();
+      if (error) throw error;
+      return rowToKid(data);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: kidsQueryKey });
+    },
+  });
+};


### PR DESCRIPTION
## Summary

A fresh sign-in to Talrum currently lands on a parent home where the only thing rendered is the dead "New blank board" dashed tile. This PR makes the screen functional: the header **New board** opens a modal, the body **New blank board** fast-creates and navigates, and an explicit **empty state** replaces the empty grid with a clear CTA.

Second of 5 PRs that wire the dead parent-home CTAs ([tracking #61](https://github.com/nbhansen/Talrum/issues/61)). **Stacked on #65** — base retargets to `main` after #65 merges.

## What's new

- `useCreateBoard` in `src/lib/queries/boards.ts` — direct Supabase insert (no outbox), mirrors `useCreateKid` and `useAddBoardMember`. Defaults from the init migration: empty step list, labels visible, TTS voice, kid-reorderable off. Caller can override `accent` (used by the fast-path tile to rotate accents).
- `NewBoardModal` — feature-local modal with name input, sequence/choice radio toggle, and a kid `<select>` that only appears when the user has more than one kid. Fires `onCreated(boardId)` so the route can navigate. Friendly fallback when the user has zero kids.

## What changed

- `ParentHome.tsx` — adds `onNewBoard`, `onNewBlankBoard`, `newBlankPending` props. When `boards.length === 0`, the grid is replaced by an explicit empty state (heading + body + primary CTA) rather than just the dashed tile.
- `ParentHomeRoute.tsx` — owns both modal open-state and the fast-path mutation. Header button → modal. Body dashed tile → `useCreateBoard.mutate(...)` with defaults + `accentForIndex(boardCount)` → navigate to BoardBuilder. Modal save → also navigate.

## Architectural decisions held from PR 1

- Direct write, **not** outbox. Same precedent as `useAddBoardMember` and the new `useCreateKid`. Outbox bypasses RLS at enqueue and the BoardBuilder navigation needs the row to actually exist on the server.
- No new outbox entry kinds.

## Test plan

- [x] TDD throughout. Tests written first (red), implementation made them pass (green).
- [x] `boards.create.test.tsx` (3 tests): insert with defaults + return mapped Board + invalidate cache; honor caller-supplied accent override; surface RLS error.
- [x] `NewBoardModal.test.tsx` (8 tests): empty render with default kind=sequence; save with sole kid; kid picker visible with multiple kids; kind toggle works; Save disabled on whitespace; inline error on failure; Cancel; "no kids" fallback.
- [x] `ParentHomeRoute.test.tsx` (+5 tests): empty state renders; empty-state CTA opens modal; header button opens modal even with boards; New blank board fast-creates and navigates; (existing tests still pass).
- [x] Full suite: 182/183 pass, typecheck clean, lint clean. **The 1 failure is pre-existing flake #29** in `outbox.test.ts` — passes in isolation, unrelated to anything this PR touches.
- [ ] Manual smoke: dev server, sign in, see empty state, click "Create your first board" → modal → fill name → Save → land in BoardBuilder.

## Coming next in sequence

PR 3: Sidebar `onNav` wiring + stub routes for `/library`, `/kids`, `/settings`.
PR 4: Library route (replaces stub) + wire See all.
PR 5: Kids route (replaces stub) + extract `NewKidModal` to `src/ui/` for reuse.