### PR TITLE
Wire sidebar nav + add stub routes (PR 3/5 of #61)

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -19,6 +19,15 @@ const KidSequenceRoute = lazy(() =>
 const KidChoiceRoute = lazy(() =>
   import('@/features/kid-choice/KidChoiceRoute').then((m) => ({ default: m.KidChoiceRoute })),
 );
+const LibraryRoute = lazy(() =>
+  import('@/features/library/LibraryRoute').then((m) => ({ default: m.LibraryRoute })),
+);
+const KidsRoute = lazy(() =>
+  import('@/features/kids/KidsRoute').then((m) => ({ default: m.KidsRoute })),
+);
+const SettingsRoute = lazy(() =>
+  import('@/features/settings/SettingsRoute').then((m) => ({ default: m.SettingsRoute })),
+);
 
 export const parentRouteFallback = (reset: () => void): ReactNode => (
   <div role="alert" className={styles.routeFallback}>
@@ -82,6 +91,9 @@ export const router = createBrowserRouter(
   [
     { path: '/', element: wrap(<ParentHomeRoute />, 'parent') },
     { path: '/boards/:boardId/edit', element: wrap(<BoardBuilderRoute />, 'parent') },
+    { path: '/library', element: wrap(<LibraryRoute />, 'parent') },
+    { path: '/kids', element: wrap(<KidsRoute />, 'parent') },
+    { path: '/settings', element: wrap(<SettingsRoute />, 'parent') },
     { path: '/kid/sequence/:boardId', element: wrap(<KidSequenceRoute />, 'kid') },
     { path: '/kid/choice/:boardId', element: wrap(<KidChoiceRoute />, 'kid') },
     { path: '*', element: <Navigate to="/" replace /> },

--- a/src/features/board-builder/BoardBuilder.tsx
+++ b/src/features/board-builder/BoardBuilder.tsx
@@ -1,6 +1,6 @@
 import { Fragment, type JSX, useEffect, useMemo, useRef, useState } from 'react';
 
-import { ParentShell } from '@/layouts/ParentShell';
+import { type ParentNavKey, ParentShell } from '@/layouts/ParentShell';
 import {
   useRenameBoard,
   useSetBoardKind,
@@ -30,6 +30,7 @@ interface BoardBuilderProps {
   onOpenPicker: () => void;
   onOpenShare: () => void;
   onKidMode: () => void;
+  onNav?: (id: ParentNavKey) => void;
 }
 
 interface Step {
@@ -57,6 +58,7 @@ export const BoardBuilder = ({
   onOpenPicker,
   onOpenShare,
   onKidMode,
+  onNav,
 }: BoardBuilderProps): JSX.Element => {
   const pictogramsById = usePictogramsById();
   const { data: allPictograms = [] } = usePictograms();
@@ -120,7 +122,7 @@ export const BoardBuilder = ({
     setStepIds.mutate({ boardId: board.id, stepIds: [...board.stepIds, pictoId] });
 
   return (
-    <ParentShell active="home" onKidMode={onKidMode}>
+    <ParentShell active="home" onKidMode={onKidMode} {...(onNav ? { onNav } : {})}>
       <div className={styles.breadcrumb}>
         <button type="button" onClick={onBack} className={styles.back}>
           <ArrowLeftIcon size={16} />

--- a/src/features/board-builder/BoardBuilderRoute.tsx
+++ b/src/features/board-builder/BoardBuilderRoute.tsx
@@ -2,6 +2,7 @@ import { type JSX, useCallback } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import { PictoPicker } from '@/features/pictogram-picker/PictoPicker';
+import { useParentNav } from '@/layouts/useParentNav';
 import { useSessionUser } from '@/lib/auth/session';
 import { isNotFoundError, useBoard, useBoards } from '@/lib/queries/boards';
 
@@ -15,6 +16,7 @@ export const BoardBuilderRoute = (): JSX.Element | null => {
   const boardsQuery = useBoards();
   const board = boardQuery.data;
   const navigate = useNavigate();
+  const onNav = useParentNav();
   const me = useSessionUser();
   const [searchParams, setSearchParams] = useSearchParams();
   const pickerOpen = searchParams.get('picker') === '1';
@@ -60,6 +62,7 @@ export const BoardBuilderRoute = (): JSX.Element | null => {
         onKidMode={() => {
           if (fallbackKid) navigate(`/kid/sequence/${fallbackKid.id}`);
         }}
+        onNav={onNav}
       />
     );
   }
@@ -77,6 +80,7 @@ export const BoardBuilderRoute = (): JSX.Element | null => {
         onOpenPicker={openPicker}
         onOpenShare={openShare}
         onKidMode={() => navigate(`/kid/${board.kind}/${board.id}`)}
+        onNav={onNav}
       />
       {pickerOpen && <PictoPicker onClose={closePicker} />}
       {shareOpen && <ShareModal boardId={board.id} isOwner={isOwner} onClose={closeShare} />}

--- a/src/features/board-builder/BoardNotFound.tsx
+++ b/src/features/board-builder/BoardNotFound.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'react';
 
-import { ParentShell } from '@/layouts/ParentShell';
+import { type ParentNavKey, ParentShell } from '@/layouts/ParentShell';
 import { Button } from '@/ui/Button/Button';
 
 import styles from './BoardNotFound.module.css';
@@ -12,6 +12,7 @@ interface BoardNotFoundProps {
   onBack: () => void;
   onRetry?: () => void;
   onKidMode: () => void;
+  onNav?: (id: ParentNavKey) => void;
 }
 
 const COPY: Record<BoardLoadFailureVariant, { title: string; body: string }> = {
@@ -30,10 +31,11 @@ export const BoardNotFound = ({
   onBack,
   onRetry,
   onKidMode,
+  onNav,
 }: BoardNotFoundProps): JSX.Element => {
   const { title, body } = COPY[variant];
   return (
-    <ParentShell active="home" onKidMode={onKidMode}>
+    <ParentShell active="home" onKidMode={onKidMode} {...(onNav ? { onNav } : {})}>
       <div className={styles.wrap}>
         <h1 className={styles.title}>{title}</h1>
         <p className={styles.body}>{body}</p>

--- a/src/features/kids/KidsRoute.test.tsx
+++ b/src/features/kids/KidsRoute.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TestSessionProvider } from '@/lib/auth/session.test-utils';
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      signOut: vi.fn(),
+      getSession: vi.fn(() => Promise.resolve({ data: { session: null } })),
+      onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+    },
+  },
+}));
+
+const { KidsRoute } = await import('./KidsRoute');
+
+describe('KidsRoute', () => {
+  it('renders the Kids header and a coming-soon body', () => {
+    render(
+      <TestSessionProvider>
+        <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+          <KidsRoute />
+        </MemoryRouter>
+      </TestSessionProvider>,
+    );
+    expect(screen.getByRole('heading', { name: 'Kids' })).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent(/coming in a future release/i);
+  });
+});

--- a/src/features/kids/KidsRoute.test.tsx
+++ b/src/features/kids/KidsRoute.test.tsx
@@ -26,6 +26,6 @@ describe('KidsRoute', () => {
       </TestSessionProvider>,
     );
     expect(screen.getByRole('heading', { name: 'Kids' })).toBeInTheDocument();
-    expect(screen.getByRole('status')).toHaveTextContent(/coming in a future release/i);
+    expect(screen.getByText(/coming in a future release/i)).toBeInTheDocument();
   });
 });

--- a/src/features/kids/KidsRoute.tsx
+++ b/src/features/kids/KidsRoute.tsx
@@ -1,0 +1,14 @@
+import type { JSX } from 'react';
+
+import { ParentShell } from '@/layouts/ParentShell';
+import { useParentNav } from '@/layouts/useParentNav';
+import { ComingSoon } from '@/ui/ComingSoon/ComingSoon';
+
+export const KidsRoute = (): JSX.Element => {
+  const onNav = useParentNav();
+  return (
+    <ParentShell active="kids" onNav={onNav} title="Kids" subtitle="Coming soon">
+      <ComingSoon body="Manage kid profiles and their boards from one place. Coming in a future release." />
+    </ParentShell>
+  );
+};

--- a/src/features/library/LibraryRoute.test.tsx
+++ b/src/features/library/LibraryRoute.test.tsx
@@ -26,6 +26,6 @@ describe('LibraryRoute', () => {
       </TestSessionProvider>,
     );
     expect(screen.getByRole('heading', { name: 'Library' })).toBeInTheDocument();
-    expect(screen.getByRole('status')).toHaveTextContent(/coming in a future release/i);
+    expect(screen.getByText(/coming in a future release/i)).toBeInTheDocument();
   });
 });

--- a/src/features/library/LibraryRoute.test.tsx
+++ b/src/features/library/LibraryRoute.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TestSessionProvider } from '@/lib/auth/session.test-utils';
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      signOut: vi.fn(),
+      getSession: vi.fn(() => Promise.resolve({ data: { session: null } })),
+      onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+    },
+  },
+}));
+
+const { LibraryRoute } = await import('./LibraryRoute');
+
+describe('LibraryRoute', () => {
+  it('renders the Library header and a coming-soon body', () => {
+    render(
+      <TestSessionProvider>
+        <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+          <LibraryRoute />
+        </MemoryRouter>
+      </TestSessionProvider>,
+    );
+    expect(screen.getByRole('heading', { name: 'Library' })).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent(/coming in a future release/i);
+  });
+});

--- a/src/features/library/LibraryRoute.tsx
+++ b/src/features/library/LibraryRoute.tsx
@@ -1,0 +1,14 @@
+import type { JSX } from 'react';
+
+import { ParentShell } from '@/layouts/ParentShell';
+import { useParentNav } from '@/layouts/useParentNav';
+import { ComingSoon } from '@/ui/ComingSoon/ComingSoon';
+
+export const LibraryRoute = (): JSX.Element => {
+  const onNav = useParentNav();
+  return (
+    <ParentShell active="library" onNav={onNav} title="Library" subtitle="Coming soon">
+      <ComingSoon body="Browse and manage every pictogram across your boards. Coming in a future release." />
+    </ParentShell>
+  );
+};

--- a/src/features/parent-home/ParentHome.tsx
+++ b/src/features/parent-home/ParentHome.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'react';
 
-import { ParentShell } from '@/layouts/ParentShell';
+import { type ParentNavKey, ParentShell } from '@/layouts/ParentShell';
 import { useBoards } from '@/lib/queries/boards';
 import { usePictogramsBySlug } from '@/lib/queries/pictograms';
 import { Button } from '@/ui/Button/Button';
@@ -16,6 +16,7 @@ interface ParentHomeProps {
   kidName?: string;
   onOpenBoard?: (id: string) => void;
   onKidMode?: () => void;
+  onNav?: (id: ParentNavKey) => void;
   onNewKid?: () => void;
   /** Opens the full New board modal (name + kind + kid picker). */
   onNewBoard?: () => void;
@@ -32,6 +33,7 @@ export const ParentHome = ({
   kidName = 'Liam',
   onOpenBoard,
   onKidMode,
+  onNav,
   onNewKid,
   onNewBoard,
   onNewBlankBoard,
@@ -46,6 +48,7 @@ export const ParentHome = ({
   return (
     <ParentShell
       active="home"
+      {...(onNav ? { onNav } : {})}
       {...(onKidMode ? { onKidMode } : {})}
       title={`${kidName}'s boards`}
       subtitle="Pick a board to edit, or start a new one."

--- a/src/features/parent-home/ParentHomeRoute.test.tsx
+++ b/src/features/parent-home/ParentHomeRoute.test.tsx
@@ -59,6 +59,9 @@ const makeWrap = (initialPath: string): (() => JSX.Element) => {
           <Routes>
             <Route path="/" element={<ParentHomeRoute />} />
             <Route path="/boards/:boardId/edit" element={<div data-testid="board-edit-route" />} />
+            <Route path="/library" element={<div data-testid="library-route" />} />
+            <Route path="/kids" element={<div data-testid="kids-route" />} />
+            <Route path="/settings" element={<div data-testid="settings-route" />} />
             <Route
               path="/kid/sequence/:boardId"
               element={<div data-testid="kid-sequence-route" />}
@@ -219,6 +222,20 @@ describe('ParentHomeRoute create flows', () => {
       expect.any(Object),
     );
     expect(screen.getByTestId('board-edit-route')).toBeInTheDocument();
+  });
+
+  it.each([
+    { label: /library/i, testid: 'library-route' },
+    { label: /kids/i, testid: 'kids-route' },
+    { label: /settings/i, testid: 'settings-route' },
+  ])('clicking sidebar $label navigates to its stub route', async ({ label, testid }) => {
+    const Wrap = makeWrap('/');
+    render(<Wrap />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: label }));
+
+    expect(screen.getByTestId(testid)).toBeInTheDocument();
   });
 
   it('saving the New board modal navigates to the new board edit route', async () => {

--- a/src/features/parent-home/ParentHomeRoute.tsx
+++ b/src/features/parent-home/ParentHomeRoute.tsx
@@ -1,6 +1,7 @@
 import { type JSX, useEffect, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 
+import { useParentNav } from '@/layouts/useParentNav';
 import { getLastBoard, hasAutoLaunched, kidPathFor, markAutoLaunched } from '@/lib/lastBoard';
 import { useBoards, useCreateBoard } from '@/lib/queries/boards';
 import { useKids } from '@/lib/queries/kids';
@@ -12,6 +13,7 @@ import { ParentHome } from './ParentHome';
 
 export const ParentHomeRoute = (): JSX.Element => {
   const navigate = useNavigate();
+  const onNav = useParentNav();
   const boardsQuery = useBoards();
   const kidsQuery = useKids();
   const createBoard = useCreateBoard();
@@ -64,6 +66,7 @@ export const ParentHomeRoute = (): JSX.Element => {
       <ParentHome
         onOpenBoard={(id) => navigate(`/boards/${id}/edit`)}
         onKidMode={onKidMode}
+        onNav={onNav}
         onNewKid={() => setNewKidOpen(true)}
         onNewBoard={() => setNewBoardOpen(true)}
         onNewBlankBoard={onNewBlankBoard}

--- a/src/features/settings/SettingsRoute.test.tsx
+++ b/src/features/settings/SettingsRoute.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TestSessionProvider } from '@/lib/auth/session.test-utils';
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      signOut: vi.fn(),
+      getSession: vi.fn(() => Promise.resolve({ data: { session: null } })),
+      onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+    },
+  },
+}));
+
+const { SettingsRoute } = await import('./SettingsRoute');
+
+describe('SettingsRoute', () => {
+  it('renders the Settings header and a coming-soon body', () => {
+    render(
+      <TestSessionProvider>
+        <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+          <SettingsRoute />
+        </MemoryRouter>
+      </TestSessionProvider>,
+    );
+    expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent(/coming in a future release/i);
+  });
+});

--- a/src/features/settings/SettingsRoute.test.tsx
+++ b/src/features/settings/SettingsRoute.test.tsx
@@ -26,6 +26,6 @@ describe('SettingsRoute', () => {
       </TestSessionProvider>,
     );
     expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
-    expect(screen.getByRole('status')).toHaveTextContent(/coming in a future release/i);
+    expect(screen.getByText(/coming in a future release/i)).toBeInTheDocument();
   });
 });

--- a/src/features/settings/SettingsRoute.tsx
+++ b/src/features/settings/SettingsRoute.tsx
@@ -1,0 +1,14 @@
+import type { JSX } from 'react';
+
+import { ParentShell } from '@/layouts/ParentShell';
+import { useParentNav } from '@/layouts/useParentNav';
+import { ComingSoon } from '@/ui/ComingSoon/ComingSoon';
+
+export const SettingsRoute = (): JSX.Element => {
+  const onNav = useParentNav();
+  return (
+    <ParentShell active="settings" onNav={onNav} title="Settings" subtitle="Coming soon">
+      <ComingSoon body="Account preferences, voice settings, and PIN management. Coming in a future release." />
+    </ParentShell>
+  );
+};

--- a/src/layouts/useParentNav.ts
+++ b/src/layouts/useParentNav.ts
@@ -1,0 +1,16 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import type { ParentNavKey } from './ParentShell';
+
+const PATHS: Record<ParentNavKey, string> = {
+  home: '/',
+  library: '/library',
+  kids: '/kids',
+  settings: '/settings',
+};
+
+export const useParentNav = (): ((id: ParentNavKey) => void) => {
+  const navigate = useNavigate();
+  return useCallback((id: ParentNavKey) => navigate(PATHS[id]), [navigate]);
+};

--- a/src/ui/ComingSoon/ComingSoon.module.css
+++ b/src/ui/ComingSoon/ComingSoon.module.css
@@ -1,0 +1,13 @@
+.wrap {
+  display: flex;
+  align-items: flex-start;
+  padding-top: 48px;
+  max-width: 520px;
+}
+
+.body {
+  font-size: 16px;
+  color: var(--tal-ink-soft);
+  margin: 0;
+  line-height: 1.5;
+}

--- a/src/ui/ComingSoon/ComingSoon.tsx
+++ b/src/ui/ComingSoon/ComingSoon.tsx
@@ -1,0 +1,13 @@
+import type { JSX } from 'react';
+
+import styles from './ComingSoon.module.css';
+
+interface ComingSoonProps {
+  body: string;
+}
+
+export const ComingSoon = ({ body }: ComingSoonProps): JSX.Element => (
+  <div className={styles.wrap} role="status">
+    <p className={styles.body}>{body}</p>
+  </div>
+);

--- a/src/ui/ComingSoon/ComingSoon.tsx
+++ b/src/ui/ComingSoon/ComingSoon.tsx
@@ -7,7 +7,7 @@ interface ComingSoonProps {
 }
 
 export const ComingSoon = ({ body }: ComingSoonProps): JSX.Element => (
-  <div className={styles.wrap} role="status">
+  <div className={styles.wrap}>
     <p className={styles.body}>{body}</p>
   </div>
 );


### PR DESCRIPTION
## Summary
- Sidebar Library/Kids/Settings buttons now navigate (previously dead).
- Adds three lazy-loaded stub routes: `/library`, `/kids`, `/settings`.
- New `useParentNav` hook centralises the nav-key → path mapping so every shell consumer wires up the same way.
- `ParentHome`, `BoardBuilder`, and `BoardNotFound` accept and forward `onNav` through to `ParentShell`.
- Shared `<ComingSoon>` UI primitive renders the body of each stub.

## PR sequence
This is PR 3 of 5 from the master plan in #61 wiring up dead parent-home CTAs. Stubs intentionally — PRs 4 and 5 will replace them with real Library and Kids routes. Branched off `main` (no stacked PRs).

## Plan deviations
- `useParentNav` returns just the callback rather than `{ active, onNav }` derived from `useLocation`. Each route hardcodes `active="library"` etc. — simpler, removes a runtime branch (`/boards/:id/edit` → `'home'`), keeps the hook a 3-line shim. Drop the speculative `active` derivation; can revisit when the route map gets non-trivial.
- No dedicated `useParentNav` unit test. Behavioural coverage from `ParentHomeRoute.test.tsx` (sidebar Library/Kids/Settings clicks land on the right test routes) is sufficient for a 3-line hook.

## Known follow-up
- KID button is a no-op on `/library`, `/kids`, `/settings` stub routes. Filed as #71. Library + Kids will be subsumed by PRs 4 and 5; Settings keeps the issue alive past that.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npx vitest run` all 190 passing (3 new smoke tests + 3 new nav-integration assertions)
- [x] Code review (superpowers:code-reviewer): `Ready to merge: Yes`. Acted on Minor #2 (a11y `role="status"` → text-content assertions) and Minor #4 (filed #71). Other Minor items either rejected by reviewer or naturally resolve in PRs 4–5.
- [ ] Manual: click each sidebar item from parent home, observe the right stub renders, sidebar active state moves
- [ ] Manual: from `/library`, click the home icon, lands back on `/`