### PR TITLE
Wire Library route + See all CTA (PR 4/5 of #61)

### DIFF
--- a/src/features/library/Library.module.css
+++ b/src/features/library/Library.module.css
@@ -1,0 +1,35 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 20px;
+  margin-top: 8px;
+}
+
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 14px;
+  padding: 60px 32px;
+  margin-top: 8px;
+  border: 2px dashed var(--tal-line);
+  border-radius: var(--tal-r-lg);
+  background: var(--tal-surface-alt);
+}
+
+.emptyTitle {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--tal-ink);
+}
+
+.emptyBody {
+  margin: 0;
+  max-width: 420px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--tal-ink-soft);
+}

--- a/src/features/library/Library.test.tsx
+++ b/src/features/library/Library.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Pictogram } from '@/types/domain';
+
+const usePictogramsMock = vi.fn<() => { data: Pictogram[] | undefined; isPending: boolean }>();
+
+vi.mock('@/lib/queries/pictograms', () => ({
+  usePictograms: () => usePictogramsMock(),
+}));
+
+const { Library } = await import('./Library');
+
+const PICTOS: Pictogram[] = [
+  { id: 'p1', label: 'Apple', style: 'illus', glyph: 'apple', tint: '#ff0000' },
+  { id: 'p2', label: 'Book', style: 'illus', glyph: 'book', tint: '#00ff00' },
+];
+
+describe('Library', () => {
+  it('renders every pictogram from the cache', () => {
+    usePictogramsMock.mockReturnValue({ data: PICTOS, isPending: false });
+    render(<Library />);
+    expect(screen.getByText('Apple')).toBeInTheDocument();
+    expect(screen.getByText('Book')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when no pictograms exist', () => {
+    usePictogramsMock.mockReturnValue({ data: [], isPending: false });
+    render(<Library />);
+    expect(screen.getByRole('heading', { name: /no pictograms yet/i })).toBeInTheDocument();
+  });
+});

--- a/src/features/library/Library.tsx
+++ b/src/features/library/Library.tsx
@@ -10,7 +10,7 @@ export const Library = (): JSX.Element => {
 
   if (pictograms.length === 0) {
     return (
-      <div className={styles.emptyState}>
+      <div className={styles.emptyState} role="status">
         <h2 className={styles.emptyTitle}>No pictograms yet</h2>
         <p className={styles.emptyBody}>
           Pictograms you upload, generate, or pick from the library will show up here.

--- a/src/features/library/Library.tsx
+++ b/src/features/library/Library.tsx
@@ -1,0 +1,29 @@
+import type { JSX } from 'react';
+
+import { usePictograms } from '@/lib/queries/pictograms';
+import { PictoCard } from '@/ui/PictoTile/PictoCard';
+
+import styles from './Library.module.css';
+
+export const Library = (): JSX.Element => {
+  const { data: pictograms = [] } = usePictograms();
+
+  if (pictograms.length === 0) {
+    return (
+      <div className={styles.emptyState}>
+        <h2 className={styles.emptyTitle}>No pictograms yet</h2>
+        <p className={styles.emptyBody}>
+          Pictograms you upload, generate, or pick from the library will show up here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.grid}>
+      {pictograms.map((p) => (
+        <PictoCard key={p.id} picto={p} size={120} />
+      ))}
+    </div>
+  );
+};

--- a/src/features/library/LibraryRoute.test.tsx
+++ b/src/features/library/LibraryRoute.test.tsx
@@ -3,6 +3,14 @@ import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 
 import { TestSessionProvider } from '@/lib/auth/session.test-utils';
+import type { Pictogram } from '@/types/domain';
+
+vi.mock('@/lib/queries/pictograms', () => ({
+  usePictograms: (): { data: Pictogram[]; isPending: boolean } => ({
+    data: [{ id: 'p1', label: 'Apple', style: 'illus', glyph: 'apple', tint: '#ff0000' }],
+    isPending: false,
+  }),
+}));
 
 vi.mock('@/lib/supabase', () => ({
   supabase: {
@@ -17,7 +25,7 @@ vi.mock('@/lib/supabase', () => ({
 const { LibraryRoute } = await import('./LibraryRoute');
 
 describe('LibraryRoute', () => {
-  it('renders the Library header and a coming-soon body', () => {
+  it('renders the Library shell with pictograms from the cache', () => {
     render(
       <TestSessionProvider>
         <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
@@ -26,6 +34,6 @@ describe('LibraryRoute', () => {
       </TestSessionProvider>,
     );
     expect(screen.getByRole('heading', { name: 'Library' })).toBeInTheDocument();
-    expect(screen.getByText(/coming in a future release/i)).toBeInTheDocument();
+    expect(screen.getByText('Apple')).toBeInTheDocument();
   });
 });

--- a/src/features/library/LibraryRoute.tsx
+++ b/src/features/library/LibraryRoute.tsx
@@ -2,13 +2,19 @@ import type { JSX } from 'react';
 
 import { ParentShell } from '@/layouts/ParentShell';
 import { useParentNav } from '@/layouts/useParentNav';
-import { ComingSoon } from '@/ui/ComingSoon/ComingSoon';
+
+import { Library } from './Library';
 
 export const LibraryRoute = (): JSX.Element => {
   const onNav = useParentNav();
   return (
-    <ParentShell active="library" onNav={onNav} title="Library" subtitle="Coming soon">
-      <ComingSoon body="Browse and manage every pictogram across your boards. Coming in a future release." />
+    <ParentShell
+      active="library"
+      onNav={onNav}
+      title="Library"
+      subtitle="Every pictogram across your boards"
+    >
+      <Library />
     </ParentShell>
   );
 };

--- a/src/features/parent-home/ParentHome.tsx
+++ b/src/features/parent-home/ParentHome.tsx
@@ -26,6 +26,7 @@ interface ParentHomeProps {
    * passes a no-op or omits the prop while waiting on the kids query).
    */
   onNewBlankBoard?: () => void;
+  onSeeAll?: () => void;
   newBlankPending?: boolean;
 }
 
@@ -37,6 +38,7 @@ export const ParentHome = ({
   onNewKid,
   onNewBoard,
   onNewBlankBoard,
+  onSeeAll,
   newBlankPending = false,
 }: ParentHomeProps): JSX.Element => {
   const boardsQuery = useBoards();
@@ -95,7 +97,7 @@ export const ParentHome = ({
       <section className={styles.recent}>
         <div className={styles.recentHeader}>
           <h2 className={styles.recentHeading}>Recently added pictograms</h2>
-          <button type="button" className={styles.seeAll}>
+          <button type="button" className={styles.seeAll} onClick={onSeeAll}>
             See all
           </button>
         </div>

--- a/src/features/parent-home/ParentHomeRoute.test.tsx
+++ b/src/features/parent-home/ParentHomeRoute.test.tsx
@@ -238,6 +238,16 @@ describe('ParentHomeRoute create flows', () => {
     expect(screen.getByTestId(testid)).toBeInTheDocument();
   });
 
+  it('clicking See all navigates to /library', async () => {
+    const Wrap = makeWrap('/');
+    render(<Wrap />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /see all/i }));
+
+    expect(screen.getByTestId('library-route')).toBeInTheDocument();
+  });
+
   it('saving the New board modal navigates to the new board edit route', async () => {
     createBoardMutateMock.mockImplementation(
       (_input: unknown, opts?: { onSuccess?: (b: Partial<Board>) => void }) => {

--- a/src/features/parent-home/ParentHomeRoute.tsx
+++ b/src/features/parent-home/ParentHomeRoute.tsx
@@ -70,6 +70,7 @@ export const ParentHomeRoute = (): JSX.Element => {
         onNewKid={() => setNewKidOpen(true)}
         onNewBoard={() => setNewBoardOpen(true)}
         onNewBlankBoard={onNewBlankBoard}
+        onSeeAll={() => navigate('/library')}
         newBlankPending={createBoard.isPending}
       />
       {newKidOpen && <NewKidModal onClose={() => setNewKidOpen(false)} />}


### PR DESCRIPTION
## Summary
- Replace the `/library` stub from PR 3 with a real route rendering every pictogram via `usePictograms`, plus an explicit empty state.
- Wire the **See all** button in ParentHome's "Recently added pictograms" strip to navigate to `/library` — was previously a dead click.
- New `Library` is a feature-local presentational component (`PictoCard` grid); the route wraps it in `ParentShell` with `useParentNav`.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (193/193 passing)
- [x] New unit tests: `Library.test.tsx` (cache → tiles, empty → heading)
- [x] New integration: `LibraryRoute.test.tsx` (shell + Library compose)
- [x] New integration: `ParentHomeRoute.test.tsx` "clicking See all navigates to /library"
- [ ] Manual: dev server, sign in, click sidebar Library / See all → grid renders / empty state on fresh account

Part of #61. PR 5 (Kids route + extract `NewKidModal`) follows.