### PR TITLE
Grant authenticated CRUD on app tables

### DIFF
--- a/supabase/migrations/20260426180000_grant_authenticated.sql
+++ b/supabase/migrations/20260426180000_grant_authenticated.sql
@@ -1,0 +1,18 @@
+-- Cloud project's postgres-owned default ACL on schema public grants only
+-- Dxtm (truncate/references/trigger/maintain) to anon/authenticated/service_role.
+-- Tables created by `supabase db push` (running as postgres) inherit that ACL
+-- and lack arwd, so PostgREST returns 42501 "permission denied" before RLS
+-- runs. Grant CRUD to authenticated for existing app tables and set the
+-- schema default so future migrations stay safe.
+
+grant select, insert, update, delete on
+  public.kids,
+  public.boards,
+  public.pictograms,
+  public.board_members,
+  public.template_pictograms,
+  public.template_boards
+to authenticated;
+
+alter default privileges in schema public
+  grant select, insert, update, delete on tables to authenticated;


### PR DESCRIPTION
## Summary
- Cloud project's postgres-owned default ACL on schema `public` only grants `Dxtm` (truncate/references/trigger/maintain) to `authenticated` — no `arwd`. PostgREST returned 42501 "permission denied" on every SPA fetch before RLS even ran.
- Adds `supabase/migrations/20260426180000_grant_authenticated.sql` granting `select/insert/update/delete` to `authenticated` on the six app tables, and updates default privileges so future migrations inherit safe defaults.
- RLS remains the actual access gate.

## Test plan
- [x] `supabase db push --linked` applied cleanly
- [x] Manual: signed in to SPA against cloud, added a kid via `/kids` → 201 (was 42501 before)
- [x] Verified `information_schema.role_table_grants` shows `authenticated` now has SELECT/INSERT/UPDATE/DELETE on `kids`