### PR TITLE
Wire PictoPicker onConfirm to append picks to board

### DIFF
--- a/src/features/board-builder/BoardBuilderRoute.tsx
+++ b/src/features/board-builder/BoardBuilderRoute.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { PictoPicker } from '@/features/pictogram-picker/PictoPicker';
 import { useParentNav } from '@/layouts/useParentNav';
 import { useSessionUser } from '@/lib/auth/session';
-import { isNotFoundError, useBoard, useBoards } from '@/lib/queries/boards';
+import { isNotFoundError, useBoard, useBoards, useSetStepIds } from '@/lib/queries/boards';
 
 import { BoardBuilder } from './BoardBuilder';
 import { BoardNotFound } from './BoardNotFound';
@@ -14,6 +14,7 @@ export const BoardBuilderRoute = (): JSX.Element | null => {
   const { boardId = '' } = useParams();
   const boardQuery = useBoard(boardId);
   const boardsQuery = useBoards();
+  const setStepIds = useSetStepIds();
   const board = boardQuery.data;
   const navigate = useNavigate();
   const onNav = useParentNav();
@@ -82,7 +83,15 @@ export const BoardBuilderRoute = (): JSX.Element | null => {
         onKidMode={() => navigate(`/kid/${board.kind}/${board.id}`)}
         onNav={onNav}
       />
-      {pickerOpen && <PictoPicker onClose={closePicker} />}
+      {pickerOpen && (
+        <PictoPicker
+          onClose={closePicker}
+          onConfirm={(ids) => {
+            if (ids.length === 0) return;
+            setStepIds.mutate({ boardId: board.id, stepIds: [...board.stepIds, ...ids] });
+          }}
+        />
+      )}
       {shareOpen && <ShareModal boardId={board.id} isOwner={isOwner} onClose={closeShare} />}
     </>
   );


### PR DESCRIPTION
## Summary
- `BoardBuilderRoute` was rendering `<PictoPicker onClose={closePicker} />` without an `onConfirm`. The picker treats `onConfirm` as optional and just closes, so clicking "Add to board" did nothing.
- Wires `onConfirm` through `useSetStepIds` to append the selected pictogram ids to `board.stepIds` — the same mutation drag/drop and remove already use.

## Test plan
- [x] Local: opened board → picker → selected 2 library pictograms → "Add 2 to board" → tiles appear in builder grid; confirmed Supabase `boards.step_ids` updated.
- [x] No-op when user confirms with zero selections.
- [x] `tsc -b` clean.