### PR TITLE
Tighten grant-layer contract + pin with pgTAP test (#78, #81)

### DIFF
--- a/supabase/migrations/20260427000000_tighten_grants.sql
+++ b/supabase/migrations/20260427000000_tighten_grants.sql
@@ -1,0 +1,60 @@
+-- Tighten the grant-layer contract added in 20260426180000_grant_authenticated.sql.
+-- That migration over-granted IUD on read-only-by-design template tables
+-- (template_pictograms, template_boards) and only set schema defaults for
+-- authenticated, leaving service_role and anon dependent on platform-default
+-- ACLs that differ between local Supabase (open) and cloud (locked down).
+--
+-- This migration pins the contract explicitly per (role, table) so behavior
+-- is identical regardless of starting ACL.
+--
+--   authenticated -> CRUD on app tables, SELECT-only on template tables
+--   service_role  -> CRUD on ALL six tables (explicit; do not rely on platform
+--                    defaults — pinning makes the contract survive future
+--                    Supabase changes and shows up in the pgTAP test)
+--   anon          -> revoked from all six tables and from schema defaults
+--                    (this app has no anon-readable surface)
+
+-- authenticated: tighten templates to SELECT-only.
+revoke insert, update, delete on
+  public.template_pictograms,
+  public.template_boards
+from authenticated;
+
+-- service_role: explicit CRUD on every existing table. No platform-default
+-- reliance. If Supabase ever changes service_role's default grants, this
+-- migration plus the pgTAP test catch it.
+grant select, insert, update, delete on
+  public.kids,
+  public.boards,
+  public.pictograms,
+  public.board_members,
+  public.template_pictograms,
+  public.template_boards
+to service_role;
+
+-- anon: revoke everything from existing tables.
+revoke all on
+  public.kids,
+  public.boards,
+  public.pictograms,
+  public.board_members,
+  public.template_pictograms,
+  public.template_boards
+from anon;
+
+-- Schema defaults for future tables.
+--   service_role -> CRUD (new). Without this, future tables created via
+--                   supabase db push leave service_role on the cloud's
+--                   broken Dxtm-only default — admin tooling and edge
+--                   functions hit 42501 the same way the SPA did before
+--                   20260426180000 fixed it for authenticated.
+--   anon         -> revoked. Note: ALTER DEFAULT PRIVILEGES is grantor-
+--                   scoped — this only cancels grants the executing role
+--                   would otherwise extend. All migrations run as postgres,
+--                   and postgres' default ACL on schema public is the one
+--                   that grants anon access on local Supabase, so this
+--                   revoke is effective for tables created by our migrations.
+alter default privileges in schema public
+  grant select, insert, update, delete on tables to service_role;
+alter default privileges in schema public
+  revoke all on tables from anon;

--- a/supabase/tests/grants_test.sql
+++ b/supabase/tests/grants_test.sql
@@ -1,0 +1,86 @@
+-- Regression test pinning the grant-layer contract from
+-- 20260426180000_grant_authenticated.sql + 20260427000000_tighten_grants.sql.
+-- Without this, a future migration could silently revoke or over-grant and
+-- the regression would only surface as a 42501 in production.
+--
+-- Run with: supabase test db
+BEGIN;
+SELECT plan(54);
+
+-- 1–16: authenticated has full CRUD on the four real app tables.
+SELECT ok(has_table_privilege('authenticated', 'public.kids',          'SELECT'), 'authenticated can SELECT kids');
+SELECT ok(has_table_privilege('authenticated', 'public.kids',          'INSERT'), 'authenticated can INSERT kids');
+SELECT ok(has_table_privilege('authenticated', 'public.kids',          'UPDATE'), 'authenticated can UPDATE kids');
+SELECT ok(has_table_privilege('authenticated', 'public.kids',          'DELETE'), 'authenticated can DELETE kids');
+
+SELECT ok(has_table_privilege('authenticated', 'public.boards',        'SELECT'), 'authenticated can SELECT boards');
+SELECT ok(has_table_privilege('authenticated', 'public.boards',        'INSERT'), 'authenticated can INSERT boards');
+SELECT ok(has_table_privilege('authenticated', 'public.boards',        'UPDATE'), 'authenticated can UPDATE boards');
+SELECT ok(has_table_privilege('authenticated', 'public.boards',        'DELETE'), 'authenticated can DELETE boards');
+
+SELECT ok(has_table_privilege('authenticated', 'public.pictograms',    'SELECT'), 'authenticated can SELECT pictograms');
+SELECT ok(has_table_privilege('authenticated', 'public.pictograms',    'INSERT'), 'authenticated can INSERT pictograms');
+SELECT ok(has_table_privilege('authenticated', 'public.pictograms',    'UPDATE'), 'authenticated can UPDATE pictograms');
+SELECT ok(has_table_privilege('authenticated', 'public.pictograms',    'DELETE'), 'authenticated can DELETE pictograms');
+
+SELECT ok(has_table_privilege('authenticated', 'public.board_members', 'SELECT'), 'authenticated can SELECT board_members');
+SELECT ok(has_table_privilege('authenticated', 'public.board_members', 'INSERT'), 'authenticated can INSERT board_members');
+SELECT ok(has_table_privilege('authenticated', 'public.board_members', 'UPDATE'), 'authenticated can UPDATE board_members');
+SELECT ok(has_table_privilege('authenticated', 'public.board_members', 'DELETE'), 'authenticated can DELETE board_members');
+
+-- 17–18: authenticated can SELECT templates (read-only by design).
+SELECT ok(has_table_privilege('authenticated', 'public.template_pictograms', 'SELECT'), 'authenticated can SELECT template_pictograms');
+SELECT ok(has_table_privilege('authenticated', 'public.template_boards',     'SELECT'), 'authenticated can SELECT template_boards');
+
+-- 19–24: authenticated CANNOT mutate templates. Load-bearing for #78 — these
+-- assertions fail loudly if a future migration re-over-grants.
+SELECT ok(NOT has_table_privilege('authenticated', 'public.template_pictograms', 'INSERT'), 'authenticated cannot INSERT template_pictograms');
+SELECT ok(NOT has_table_privilege('authenticated', 'public.template_pictograms', 'UPDATE'), 'authenticated cannot UPDATE template_pictograms');
+SELECT ok(NOT has_table_privilege('authenticated', 'public.template_pictograms', 'DELETE'), 'authenticated cannot DELETE template_pictograms');
+SELECT ok(NOT has_table_privilege('authenticated', 'public.template_boards',     'INSERT'), 'authenticated cannot INSERT template_boards');
+SELECT ok(NOT has_table_privilege('authenticated', 'public.template_boards',     'UPDATE'), 'authenticated cannot UPDATE template_boards');
+SELECT ok(NOT has_table_privilege('authenticated', 'public.template_boards',     'DELETE'), 'authenticated cannot DELETE template_boards');
+
+-- 25–48: service_role has full CRUD on all six tables. Pins the explicit
+-- grants from 20260427000000 — does not rely on Supabase platform defaults.
+SELECT ok(has_table_privilege('service_role', 'public.kids',                'SELECT'), 'service_role can SELECT kids');
+SELECT ok(has_table_privilege('service_role', 'public.kids',                'INSERT'), 'service_role can INSERT kids');
+SELECT ok(has_table_privilege('service_role', 'public.kids',                'UPDATE'), 'service_role can UPDATE kids');
+SELECT ok(has_table_privilege('service_role', 'public.kids',                'DELETE'), 'service_role can DELETE kids');
+
+SELECT ok(has_table_privilege('service_role', 'public.boards',              'SELECT'), 'service_role can SELECT boards');
+SELECT ok(has_table_privilege('service_role', 'public.boards',              'INSERT'), 'service_role can INSERT boards');
+SELECT ok(has_table_privilege('service_role', 'public.boards',              'UPDATE'), 'service_role can UPDATE boards');
+SELECT ok(has_table_privilege('service_role', 'public.boards',              'DELETE'), 'service_role can DELETE boards');
+
+SELECT ok(has_table_privilege('service_role', 'public.pictograms',          'SELECT'), 'service_role can SELECT pictograms');
+SELECT ok(has_table_privilege('service_role', 'public.pictograms',          'INSERT'), 'service_role can INSERT pictograms');
+SELECT ok(has_table_privilege('service_role', 'public.pictograms',          'UPDATE'), 'service_role can UPDATE pictograms');
+SELECT ok(has_table_privilege('service_role', 'public.pictograms',          'DELETE'), 'service_role can DELETE pictograms');
+
+SELECT ok(has_table_privilege('service_role', 'public.board_members',       'SELECT'), 'service_role can SELECT board_members');
+SELECT ok(has_table_privilege('service_role', 'public.board_members',       'INSERT'), 'service_role can INSERT board_members');
+SELECT ok(has_table_privilege('service_role', 'public.board_members',       'UPDATE'), 'service_role can UPDATE board_members');
+SELECT ok(has_table_privilege('service_role', 'public.board_members',       'DELETE'), 'service_role can DELETE board_members');
+
+SELECT ok(has_table_privilege('service_role', 'public.template_pictograms', 'SELECT'), 'service_role can SELECT template_pictograms');
+SELECT ok(has_table_privilege('service_role', 'public.template_pictograms', 'INSERT'), 'service_role can INSERT template_pictograms');
+SELECT ok(has_table_privilege('service_role', 'public.template_pictograms', 'UPDATE'), 'service_role can UPDATE template_pictograms');
+SELECT ok(has_table_privilege('service_role', 'public.template_pictograms', 'DELETE'), 'service_role can DELETE template_pictograms');
+
+SELECT ok(has_table_privilege('service_role', 'public.template_boards',     'SELECT'), 'service_role can SELECT template_boards');
+SELECT ok(has_table_privilege('service_role', 'public.template_boards',     'INSERT'), 'service_role can INSERT template_boards');
+SELECT ok(has_table_privilege('service_role', 'public.template_boards',     'UPDATE'), 'service_role can UPDATE template_boards');
+SELECT ok(has_table_privilege('service_role', 'public.template_boards',     'DELETE'), 'service_role can DELETE template_boards');
+
+-- 49–54: anon has no SELECT on any app or template table. Pins the
+-- "this app has no anon-readable surface" decision.
+SELECT ok(NOT has_table_privilege('anon', 'public.kids',               'SELECT'), 'anon cannot SELECT kids');
+SELECT ok(NOT has_table_privilege('anon', 'public.boards',             'SELECT'), 'anon cannot SELECT boards');
+SELECT ok(NOT has_table_privilege('anon', 'public.pictograms',         'SELECT'), 'anon cannot SELECT pictograms');
+SELECT ok(NOT has_table_privilege('anon', 'public.board_members',      'SELECT'), 'anon cannot SELECT board_members');
+SELECT ok(NOT has_table_privilege('anon', 'public.template_pictograms','SELECT'), 'anon cannot SELECT template_pictograms');
+SELECT ok(NOT has_table_privilege('anon', 'public.template_boards',    'SELECT'), 'anon cannot SELECT template_boards');
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary

Tighten the grant-layer contract from PR #76 and pin it with a pgTAP regression test.

**Approach (revised after code review):** instead of editing the already-applied migration (which `supabase db push --linked` would silently skip on cloud, since the timestamp is already in `schema_migrations`), this PR adds a new migration `20260427000000_tighten_grants.sql` carrying only the deltas. The original `20260426180000_grant_authenticated.sql` is restored byte-identical to what's already stamped on cloud.

The new migration is idempotent and explicit per (role, table) — no reliance on platform defaults that differ between local Supabase and cloud:

- **authenticated**: revoke `IUD` on `template_pictograms` / `template_boards` (read-only-by-design per RLS in `20260425000000:156-189`); `SELECT` grant from #76 remains.
- **service_role**: explicit `CRUD` on all six tables, plus extended schema default so future tables don't 42501 for admin tooling. No reliance on platform defaults.
- **anon**: revoked from every existing table and from schema defaults. This app has no anon-readable surface.

`supabase/tests/grants_test.sql` is `plan(54)`: 16 authenticated CRUD + 2 template SELECT + 6 negative template-write + 24 service_role CRUD + 6 negative anon SELECT.

Closes #78
Closes #81

## Test plan

- [x] `supabase db reset` applies all migrations cleanly (incl. new `20260427000000`)
- [x] `npm run test:db` — 98/98 pass (54 new + 44 existing)
- [x] Negative control 1: revoked `INSERT on template_pictograms FROM service_role`, confirmed test #42 failed
- [x] Negative control 2: re-granted `INSERT on template_pictograms TO authenticated`, confirmed test #19 failed
- [x] Restored via `supabase db reset`, all 98 tests pass again
- [ ] After merge: CI's `supabase db push --linked` should pick up only the new `20260427000000` (the unchanged `20260426180000` stays stamped); confirm advisor warnings unchanged on cloud