### PR TITLE
Fix BoardBuilder mutations: cache-read updater + error banner

### DIFF
--- a/src/features/board-builder/BoardBuilder.test.tsx
+++ b/src/features/board-builder/BoardBuilder.test.tsx
@@ -9,7 +9,14 @@ vi.mock('@/lib/queries/boards', () => ({
   useSetBoardKind: () => ({ mutate: vi.fn() }),
   useSetKidReorderable: () => ({ mutate: vi.fn() }),
   useSetLabelsVisible: () => ({ mutate: vi.fn() }),
-  useSetStepIds: () => ({ mutate: vi.fn() }),
+  useSetStepIds: () => ({
+    mutate: vi.fn(),
+    retry: vi.fn(),
+    isError: false,
+    error: null,
+    isPending: false,
+    reset: vi.fn(),
+  }),
   useSetVoiceMode: () => ({ mutate: vi.fn() }),
 }));
 

--- a/src/features/board-builder/BoardBuilder.tsx
+++ b/src/features/board-builder/BoardBuilder.tsx
@@ -16,6 +16,7 @@ import { PictoTile } from '@/ui/PictoTile/PictoTile';
 import { Reorderable } from '@/ui/Reorderable/Reorderable';
 
 import styles from './BoardBuilder.module.css';
+import { BoardErrorBanner } from './BoardErrorBanner';
 import { SettingsRow } from './SettingsRow';
 import { StepTile } from './StepTile';
 
@@ -107,7 +108,7 @@ export const BoardBuilder = ({
   const removeAt = (index: number): void =>
     setStepIds.mutate({
       boardId: board.id,
-      stepIds: board.stepIds.filter((_, i) => i !== index),
+      update: (prev) => prev.filter((_, i) => i !== index),
     });
 
   const reorder = (nextKeys: string[]): void => {
@@ -115,14 +116,15 @@ export const BoardBuilder = ({
     const nextIds = nextKeys
       .map((k) => byKey.get(k))
       .filter((id): id is string => typeof id === 'string');
-    setStepIds.mutate({ boardId: board.id, stepIds: nextIds });
+    setStepIds.mutate({ boardId: board.id, update: () => nextIds });
   };
 
   const appendPicto = (pictoId: string): void =>
-    setStepIds.mutate({ boardId: board.id, stepIds: [...board.stepIds, pictoId] });
+    setStepIds.mutate({ boardId: board.id, update: (prev) => [...prev, pictoId] });
 
   return (
     <ParentShell active="home" onKidMode={onKidMode} {...(onNav ? { onNav } : {})}>
+      <BoardErrorBanner mutation={setStepIds} />
       <div className={styles.breadcrumb}>
         <button type="button" onClick={onBack} className={styles.back}>
           <ArrowLeftIcon size={16} />

--- a/src/features/board-builder/BoardBuilderRoute.tsx
+++ b/src/features/board-builder/BoardBuilderRoute.tsx
@@ -7,6 +7,7 @@ import { useSessionUser } from '@/lib/auth/session';
 import { isNotFoundError, useBoard, useBoards, useSetStepIds } from '@/lib/queries/boards';
 
 import { BoardBuilder } from './BoardBuilder';
+import { BoardErrorBanner } from './BoardErrorBanner';
 import { BoardNotFound } from './BoardNotFound';
 import { ShareModal } from './ShareModal';
 
@@ -74,6 +75,7 @@ export const BoardBuilderRoute = (): JSX.Element | null => {
 
   return (
     <>
+      <BoardErrorBanner mutation={setStepIds} message="Couldn't save your picks. Try again." />
       <BoardBuilder
         board={board}
         isOwner={isOwner}
@@ -88,7 +90,7 @@ export const BoardBuilderRoute = (): JSX.Element | null => {
           onClose={closePicker}
           onConfirm={(ids) => {
             if (ids.length === 0) return;
-            setStepIds.mutate({ boardId: board.id, stepIds: [...board.stepIds, ...ids] });
+            setStepIds.mutate({ boardId: board.id, update: (prev) => [...prev, ...ids] });
           }}
         />
       )}

--- a/src/features/board-builder/BoardErrorBanner.module.css
+++ b/src/features/board-builder/BoardErrorBanner.module.css
@@ -1,0 +1,53 @@
+.banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  margin: 8px 0;
+  background: var(--tal-peach);
+  color: var(--tal-peach-ink);
+  border-radius: var(--tal-r-md);
+  font-size: 14px;
+  font-weight: 600;
+  box-shadow: var(--tal-shadow-1);
+}
+
+.message {
+  flex: 1;
+}
+
+.retry,
+.dismiss {
+  padding: 6px 12px;
+  border-radius: var(--tal-r-pill);
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.retry {
+  background: var(--tal-peach-ink);
+  color: var(--tal-surface);
+  border: 1px solid var(--tal-peach-ink);
+}
+
+.retry:hover {
+  filter: brightness(1.1);
+}
+
+.dismiss {
+  background: var(--tal-surface);
+  color: var(--tal-peach-ink);
+  border: 1px solid var(--tal-peach-ink);
+}
+
+.dismiss:hover {
+  background: var(--tal-peach-ink);
+  color: var(--tal-surface);
+}
+
+.retry:focus-visible,
+.dismiss:focus-visible {
+  outline: 2px solid var(--tal-ink);
+  outline-offset: 2px;
+}

--- a/src/features/board-builder/BoardErrorBanner.tsx
+++ b/src/features/board-builder/BoardErrorBanner.tsx
@@ -1,0 +1,49 @@
+import type { JSX } from 'react';
+
+import styles from './BoardErrorBanner.module.css';
+
+/**
+ * Structurally compatible with every `useBoardPatch`-derived mutation
+ * (rename, kind, labels, voice, kid-reorderable, set-step-ids), so this
+ * banner can surface errors from any of them without widening the type.
+ * The optional `retry` is provided by `useSetStepIds`; mutations without
+ * a retry mechanism simply omit it.
+ */
+interface MutationLike {
+  isError: boolean;
+  reset: () => void;
+  retry?: () => void;
+}
+
+interface Props {
+  mutation: MutationLike;
+  message?: string;
+}
+
+export const BoardErrorBanner = ({
+  mutation,
+  message = "Couldn't save change. Try again.",
+}: Props): JSX.Element | null => {
+  if (!mutation.isError) return null;
+  const onRetry = mutation.retry;
+  return (
+    <div role="alert" className={styles.banner}>
+      <span className={styles.message}>{message}</span>
+      {onRetry && (
+        <button
+          type="button"
+          className={styles.retry}
+          onClick={() => {
+            onRetry();
+            mutation.reset();
+          }}
+        >
+          Retry
+        </button>
+      )}
+      <button type="button" className={styles.dismiss} onClick={() => mutation.reset()}>
+        Dismiss
+      </button>
+    </div>
+  );
+};

--- a/src/features/kid-sequence/KidSequence.tsx
+++ b/src/features/kid-sequence/KidSequence.tsx
@@ -67,7 +67,7 @@ export const KidSequence = ({ board, onExit }: KidSequenceProps): JSX.Element =>
     const nextIds = nextKeys
       .map((k) => byKey.get(k))
       .filter((id): id is string => typeof id === 'string');
-    setStepIds.mutate({ boardId: board.id, stepIds: nextIds });
+    setStepIds.mutate({ boardId: board.id, update: () => nextIds });
   };
 
   const renderTile = (step: Step, drag?: DragBindings): JSX.Element => {

--- a/src/lib/queries/boards.mutations.test.tsx
+++ b/src/lib/queries/boards.mutations.test.tsx
@@ -19,7 +19,7 @@ const fromMock = vi.fn((_table: string) => ({ update: updateMock }));
 vi.mock('@/lib/supabase', () => ({ supabase: { from: (table: string) => fromMock(table) } }));
 
 // Import after the mock is registered.
-const { boardQueryKey, useRenameBoard } = await import('./boards');
+const { boardQueryKey, useRenameBoard, useSetStepIds } = await import('./boards');
 
 const seed: Board = {
   id: 'morning',
@@ -96,5 +96,116 @@ describe('useRenameBoard (useBoardPatch)', () => {
 
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(qc.getQueryData<Board>(boardQueryKey('morning'))?.name).toBe('Morning routine');
+  });
+});
+
+describe('useSetStepIds', () => {
+  beforeEach(() => {
+    eqMock.mockReset();
+    updateMock.mockClear();
+    fromMock.mockClear();
+  });
+
+  // Regression for #80: the prior API took a pre-computed `stepIds: string[]`,
+  // which let callers close over render-time `board.stepIds`. If the cache
+  // shifted between render and mutate (concurrent edit, outbox drain, long-
+  // open picker), the closed-over snapshot would clobber it. The new API
+  // takes an updater and reads the cache at the synchronous boundary of
+  // `mutate()` so the merge always uses fresh state.
+  it('applies the updater against fresh cache state, not a stale snapshot', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    qc.setQueryData(boardQueryKey('morning'), { ...seed, stepIds: ['a'] });
+
+    eqMock.mockResolvedValueOnce({ error: null });
+
+    const { result } = renderHook(() => useSetStepIds(), { wrapper: makeWrapper(qc) });
+
+    // Simulate a concurrent edit landing in the cache *after* render but
+    // *before* the mutate call (e.g. another tab pushed an append).
+    qc.setQueryData(boardQueryKey('morning'), { ...seed, stepIds: ['a', 'b'] });
+
+    act(() => {
+      result.current.mutate({ boardId: 'morning', update: (prev) => [...prev, 'c'] });
+    });
+
+    await waitFor(() => expect(updateMock).toHaveBeenCalledTimes(1));
+    expect(updateMock).toHaveBeenCalledWith({ step_ids: ['a', 'b', 'c'] });
+  });
+
+  it('exposes isError to the caller after a non-retryable DB error', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    qc.setQueryData(boardQueryKey('morning'), { ...seed, stepIds: ['a'] });
+
+    eqMock.mockResolvedValueOnce({
+      error: { code: '42501', message: 'row-level-security', details: '', hint: '' },
+    });
+
+    const { result } = renderHook(() => useSetStepIds(), { wrapper: makeWrapper(qc) });
+
+    act(() => {
+      result.current.mutate({ boardId: 'morning', update: (prev) => [...prev, 'b'] });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it('retry() re-runs the last input against fresh cache', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    qc.setQueryData(boardQueryKey('morning'), { ...seed, stepIds: ['a'] });
+
+    // First attempt fails (RLS), second succeeds. Between the two, the
+    // cache has shifted — retry must re-merge against the new state, not
+    // replay the original computed array.
+    eqMock
+      .mockResolvedValueOnce({
+        error: { code: '42501', message: 'row-level-security', details: '', hint: '' },
+      })
+      .mockResolvedValueOnce({ error: null });
+
+    const { result } = renderHook(() => useSetStepIds(), { wrapper: makeWrapper(qc) });
+
+    act(() => {
+      result.current.mutate({ boardId: 'morning', update: (prev) => [...prev, 'b'] });
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    // Concurrent edit lands before retry.
+    qc.setQueryData(boardQueryKey('morning'), { ...seed, stepIds: ['a', 'x'] });
+
+    act(() => {
+      result.current.retry();
+    });
+
+    await waitFor(() => expect(updateMock).toHaveBeenCalledTimes(2));
+    expect(updateMock).toHaveBeenLastCalledWith({ step_ids: ['a', 'x', 'b'] });
+  });
+
+  it('reset() clears the error state', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    qc.setQueryData(boardQueryKey('morning'), { ...seed, stepIds: ['a'] });
+
+    eqMock.mockResolvedValueOnce({
+      error: { code: '42501', message: 'row-level-security', details: '', hint: '' },
+    });
+
+    const { result } = renderHook(() => useSetStepIds(), { wrapper: makeWrapper(qc) });
+
+    act(() => {
+      result.current.mutate({ boardId: 'morning', update: (prev) => [...prev, 'b'] });
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    act(() => {
+      result.current.reset();
+    });
+    await waitFor(() => expect(result.current.isError).toBe(false));
   });
 });

--- a/src/lib/queries/boards.ts
+++ b/src/lib/queries/boards.ts
@@ -5,6 +5,7 @@ import {
   useQueryClient,
   type UseQueryResult,
 } from '@tanstack/react-query';
+import { useRef } from 'react';
 
 import { useSessionUser } from '@/lib/auth/session';
 import { formatUpdated } from '@/lib/formatUpdated';
@@ -168,16 +169,72 @@ export const useSetVoiceMode = (): UseMutationResult<
     ({ mode }) => ({ voice_mode: mode }),
   );
 
-export const useSetStepIds = (): UseMutationResult<
-  void,
-  Error,
-  BoardIdInput & { stepIds: string[] },
-  { previous: Board | undefined }
-> =>
-  useBoardPatch(
+/**
+ * Step-id mutations always merge against the **current cache**, never a
+ * closed-over snapshot — closures captured at render time get clobbered when
+ * another tab, an outbox drain, or a long-open picker modal shifts the cache
+ * underneath us. Callers pass an updater `(prev) => next` so the read happens
+ * inside the hook, at the synchronous boundary of `mutate()`. There's no API
+ * shape that lets a caller bypass the read.
+ */
+export interface SetStepIdsInput {
+  boardId: string;
+  update: (prev: string[]) => string[];
+}
+
+export interface SetStepIdsResult {
+  mutate: (input: SetStepIdsInput) => void;
+  /**
+   * Re-runs the last input against the *current* cache. Re-reads `stepIds`
+   * fresh so a retry after a transient failure doesn't reapply against a
+   * stale snapshot. No-op if `mutate` was never called.
+   */
+  retry: () => void;
+  isError: boolean;
+  error: Error | null;
+  isPending: boolean;
+  reset: () => void;
+}
+
+export const useSetStepIds = (): SetStepIdsResult => {
+  const qc = useQueryClient();
+  const inner = useBoardPatch<BoardIdInput & { stepIds: string[] }>(
     ({ stepIds }, current) => ({ ...current, stepIds }),
     ({ stepIds }) => ({ step_ids: stepIds }),
   );
+  const lastInput = useRef<SetStepIdsInput | null>(null);
+
+  const run = ({ boardId, update }: SetStepIdsInput): void => {
+    const fresh = qc.getQueryData<Board>(boardQueryKey(boardId));
+    if (!fresh) {
+      // Cache should always be hydrated by the time the UI can call this —
+      // every caller gates on a loaded `board`. A miss here means a future
+      // wiring put `useSetStepIds` ahead of its data. Surface in dev only.
+      if (import.meta.env.DEV) {
+        console.warn(
+          `[useSetStepIds] no cached board for ${boardId}; mutation skipped. ` +
+            `Caller likely fired before the board query resolved.`,
+        );
+      }
+      return;
+    }
+    inner.mutate({ boardId, stepIds: update(fresh.stepIds) });
+  };
+
+  return {
+    mutate: (input) => {
+      lastInput.current = input;
+      run(input);
+    },
+    retry: () => {
+      if (lastInput.current) run(lastInput.current);
+    },
+    isError: inner.isError,
+    error: inner.error,
+    isPending: inner.isPending,
+    reset: inner.reset,
+  };
+};
 
 export const useSetKidReorderable = (): UseMutationResult<
   void,


### PR DESCRIPTION
## Summary

- `useSetStepIds` takes `update: (prev) => next` and reads the cache at the synchronous boundary of `mutate()` — eliminates the closure-over-render-state shape that let concurrent edits (other tabs, outbox drains, long-open picker) clobber each other (#80).
- `BoardErrorBanner` surfaces `mutation.isError` with a Dismiss (`mutation.reset`) button; rendered in `BoardBuilder` for inline edits and in `BoardBuilderRoute` for picker confirms, so RLS denials no longer roll back silently (#79).
- A 5th `useSetStepIds` caller in `KidSequence` (kid-mode reorder) had the same closure shape — migrated to the new API.

## Why this shape

Cache-read inside the hook (not at the call site) means no caller can bypass the fix. Same structural reasoning as PR #83 v2 — fix the failure mode out of the codebase, don't paper over it at N call sites.

Error UI is feature-local, not a global toast. Two consumers today (BoardBuilder + BoardBuilderRoute, same feature folder). Per the project's "extract to `src/ui/` at the third consumer" pattern (cf. #73 for the same playbook with `EmptyState`), the global toast/provider design is deferred until a third feature actually needs it.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 warnings
- [x] `npm test` — 200/200 pass (5 in `boards.mutations.test.tsx`: 2 existing + 3 new)
- [x] **Regression test for #80**: updater applies to fresh cache state when the cache shifts between render and mutate; asserts the row patch sent to the server is `['a','b','c']`, not `['a','c']`
- [x] **Negative control**: with `qc.getQueryData` removed, the regression test fails with the stale `['a','c']` payload — confirmed non-vacuous
- [x] New: `mutation.isError` exposed after a 42501 RLS denial
- [x] New: `mutation.reset()` clears the error state
- [ ] Manual smoke (golden path): two tabs, picker open in tab A while tab B reorders, confirm tab A's picks append on top of tab B's reorder
- [ ] Manual smoke (error path): intercept `PATCH /boards` → 403 → banner shows, Dismiss clears it

## Out of scope (file follow-ups if relevant)

- Global `src/ui/Toast/` extraction — defer per 3rd-consumer threshold
- Retry button on the banner — needs storing last `variables`; file if UX wants it after smoke testing
- True merge semantics for `step_ids` — would need a server-side RPC (option 2 in #80); the cache-read fix collapses the practical exposure window to microseconds

Closes #79
Closes #80