### PR TITLE
Fix two flaky tests by waiting for async chains

### DIFF
--- a/src/lib/outbox/outbox.test.ts
+++ b/src/lib/outbox/outbox.test.ts
@@ -208,11 +208,10 @@ describe('startOutbox', () => {
     const seen: number[] = [];
     startOutbox();
     const unsub = subscribeStatus((s) => seen.push(s.pendingCount));
-    // Two macrotask ticks: one for emit()'s listEntries, one for the
-    // offline-branch emit() inside drain().
-    await new Promise((r) => setTimeout(r, 0));
-    await new Promise((r) => setTimeout(r, 0));
+    // emit() does an IDB roundtrip (listEntries) before pushing to subscribers,
+    // then drain()'s offline branch emits again. Counting macrotask ticks
+    // flakes under load (#87) — poll the actual condition instead.
+    await vi.waitFor(() => expect(seen).toContain(2));
     unsub();
-    expect(seen).toContain(2);
   });
 });

--- a/src/ui/KidModeGate/KidModeGate.test.tsx
+++ b/src/ui/KidModeGate/KidModeGate.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -60,7 +60,9 @@ describe('KidModeGate', () => {
     await tapDigits(user, '1234');
     expect(await screen.findByText('Confirm your PIN')).toBeInTheDocument();
     await tapDigits(user, '1234');
-    expect(onExit).toHaveBeenCalledTimes(1);
+    // handleSetupConfirm awaits setPin() before firing onExit; waitFor avoids
+    // racing the async chain (#87).
+    await waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
     expect(errorSpy).not.toHaveBeenCalled();
   });
 
@@ -91,7 +93,7 @@ describe('KidModeGate', () => {
     expect(await screen.findByText('Confirm your PIN')).toBeInTheDocument();
     await tapDigits(user, '1234');
 
-    expect(onExit).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
     expect(hasPin()).toBe(true);
     expect(await verifyPin('1234')).toBe(true);
   });
@@ -119,7 +121,8 @@ describe('KidModeGate', () => {
     expect(screen.getByText('Enter PIN to exit')).toBeInTheDocument();
     await tapDigits(user, '9999');
 
-    expect(onExit).toHaveBeenCalledTimes(1);
+    // handleVerify awaits verifyPin() (Web Crypto) before firing onExit (#87).
+    await waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
   });
 
   it('verify path rejects wrong digits and lets the user retry', async () => {


### PR DESCRIPTION
## Summary

Two observed flakes from #87 had the same root cause: an assertion fired synchronously after async work that hadn't finished yet. Under suite parallelism, the chain ran slower than the test's tick-counting heuristic allowed.

- **outbox.test.ts** `> startOutbox > primes lastStatus from IDB so cold-boot subscribers see real counts (#29)`: replaced two `setTimeout(0)` ticks with `vi.waitFor` against the actual expectation. `startOutbox` calls `void emit()` (awaits `listEntries` from IDB) then `void drain()` (more async work). Two macrotask ticks aren't always enough — under load the IDB roundtrip needs more.

- **KidModeGate.test.tsx**: three positive `expect(onExit).toHaveBeenCalled` assertions ran synchronously after `tapDigits`, but `handleVerify` awaits `verifyPin` (Web Crypto `subtle.digest`) and `handleSetupConfirm` awaits `setPin` before invoking the callback. Wrapped each in `waitFor`.

Negative assertions (`not.toHaveBeenCalled`) were left as-is — they're robust to timing because preceding awaits already wait for the rejection branch.

## Scope note

This fixes the **timing-race** source. The other two suspect mechanisms in #87 (fake-timer leaks, vi.mock / module-cache bleed) remain hypothetical with no observed failures pointing at them. #87 is left open until a new flake surfaces or we deliberately stress-test the harness.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 warnings
- [x] `npm test` — 200/200 pass
- [x] **10 consecutive parallel runs all green** (the flake had been intermittent, so a single run isn't proof)
- [x] Both previously-flaky tests pass when targeted directly

Refs #87