### PR TITLE
Honor labelsVisible on kid-side renderers (#82)

### DIFF
--- a/src/features/kid-choice/KidChoice.test.tsx
+++ b/src/features/kid-choice/KidChoice.test.tsx
@@ -85,7 +85,7 @@ describe('KidChoice', () => {
     expect(screen.getByText(/Let.+s go to/)).toBeInTheDocument();
   });
 
-  it('hides per-tile labels when board.labelsVisible is false, but keeps an accessible name', () => {
+  it('hides per-tile labels when board.labelsVisible is false, keeping marker+label as the accessible name', () => {
     const qc = makeClient();
     render(
       <Wrap qc={qc}>
@@ -95,9 +95,21 @@ describe('KidChoice', () => {
     // Visible label span gone — `Park` text is no longer in the DOM.
     expect(screen.queryByText('Park')).not.toBeInTheDocument();
     expect(screen.queryByText('Zoo')).not.toBeInTheDocument();
-    // Buttons remain operable for screen readers via the conditional aria-label.
-    expect(screen.getByRole('button', { name: /Park/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Zoo/i })).toBeInTheDocument();
+    // Marker letter must still ride with the accessible name. A teacher saying
+    // "tap A" needs the screen reader to announce both, not just the label.
+    expect(screen.getByRole('button', { name: /A.*Park/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /B.*Zoo/i })).toBeInTheDocument();
+  });
+
+  it('still shows the picked CTA text when labels are hidden (per-tile labels only, not all text)', async () => {
+    const qc = makeClient();
+    render(
+      <Wrap qc={qc}>
+        <KidChoice board={{ ...board, labelsVisible: false }} onExit={vi.fn()} />
+      </Wrap>,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /A.*Park/i }));
+    expect(screen.getByText(/Let.+s go to Park/)).toBeInTheDocument();
   });
 
   it('exit button calls onExit', async () => {

--- a/src/features/kid-choice/KidChoice.test.tsx
+++ b/src/features/kid-choice/KidChoice.test.tsx
@@ -85,6 +85,21 @@ describe('KidChoice', () => {
     expect(screen.getByText(/Let.+s go to/)).toBeInTheDocument();
   });
 
+  it('hides per-tile labels when board.labelsVisible is false, but keeps an accessible name', () => {
+    const qc = makeClient();
+    render(
+      <Wrap qc={qc}>
+        <KidChoice board={{ ...board, labelsVisible: false }} onExit={vi.fn()} />
+      </Wrap>,
+    );
+    // Visible label span gone — `Park` text is no longer in the DOM.
+    expect(screen.queryByText('Park')).not.toBeInTheDocument();
+    expect(screen.queryByText('Zoo')).not.toBeInTheDocument();
+    // Buttons remain operable for screen readers via the conditional aria-label.
+    expect(screen.getByRole('button', { name: /Park/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Zoo/i })).toBeInTheDocument();
+  });
+
   it('exit button calls onExit', async () => {
     const qc = makeClient();
     const onExit = vi.fn();

--- a/src/features/kid-choice/KidChoice.tsx
+++ b/src/features/kid-choice/KidChoice.tsx
@@ -64,6 +64,7 @@ export const KidChoice = ({ board, onExit }: KidChoiceProps): JSX.Element => {
                 .filter(Boolean)
                 .join(' ')}
               style={choiceStyle}
+              {...(board.labelsVisible ? {} : { 'aria-label': p.label })}
             >
               <span className={styles.marker} style={markerStyle}>
                 {String.fromCharCode(65 + idx)}
@@ -76,7 +77,7 @@ export const KidChoice = ({ board, onExit }: KidChoiceProps): JSX.Element => {
                   </div>
                 )}
               </div>
-              <span className={styles.label}>{p.label}</span>
+              {board.labelsVisible && <span className={styles.label}>{p.label}</span>}
             </button>
           );
         })}

--- a/src/features/kid-choice/KidChoice.tsx
+++ b/src/features/kid-choice/KidChoice.tsx
@@ -64,7 +64,9 @@ export const KidChoice = ({ board, onExit }: KidChoiceProps): JSX.Element => {
                 .filter(Boolean)
                 .join(' ')}
               style={choiceStyle}
-              {...(board.labelsVisible ? {} : { 'aria-label': p.label })}
+              aria-label={
+                board.labelsVisible ? undefined : `${String.fromCharCode(65 + idx)} ${p.label}`
+              }
             >
               <span className={styles.marker} style={markerStyle}>
                 {String.fromCharCode(65 + idx)}

--- a/src/features/kid-sequence/KidSequence.test.tsx
+++ b/src/features/kid-sequence/KidSequence.test.tsx
@@ -90,7 +90,24 @@ describe('KidSequence', () => {
     // Visible label span gone — the literal label text is no longer in the DOM.
     expect(screen.queryByText('Apple')).not.toBeInTheDocument();
     expect(screen.queryByText('Drink')).not.toBeInTheDocument();
-    // Buttons remain operable for screen readers via the conditional aria-label.
+    // The button's accessible name comes from the conditional aria-label.
+    expect(screen.getByRole('button', { name: /Apple/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Drink/i })).toBeInTheDocument();
+  });
+
+  it('preserves the accessible name on the kidReorderable (dnd-kit) branch', () => {
+    // The reorderable render path spreads dnd-kit's `attributes` and
+    // `listeners` onto the same button. `aria-label` as an explicit attribute
+    // (not a conditional spread) makes precedence over those spreads explicit.
+    const qc = makeClient();
+    render(
+      <Wrap qc={qc}>
+        <KidSequence
+          board={{ ...board, labelsVisible: false, kidReorderable: true }}
+          onExit={vi.fn()}
+        />
+      </Wrap>,
+    );
     expect(screen.getByRole('button', { name: /Apple/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Drink/i })).toBeInTheDocument();
   });

--- a/src/features/kid-sequence/KidSequence.test.tsx
+++ b/src/features/kid-sequence/KidSequence.test.tsx
@@ -80,6 +80,21 @@ describe('KidSequence', () => {
     );
   });
 
+  it('hides per-tile labels when board.labelsVisible is false, but keeps an accessible name', () => {
+    const qc = makeClient();
+    render(
+      <Wrap qc={qc}>
+        <KidSequence board={{ ...board, labelsVisible: false }} onExit={vi.fn()} />
+      </Wrap>,
+    );
+    // Visible label span gone — the literal label text is no longer in the DOM.
+    expect(screen.queryByText('Apple')).not.toBeInTheDocument();
+    expect(screen.queryByText('Drink')).not.toBeInTheDocument();
+    // Buttons remain operable for screen readers via the conditional aria-label.
+    expect(screen.getByRole('button', { name: /Apple/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Drink/i })).toBeInTheDocument();
+  });
+
   it('the exit button calls onExit', async () => {
     const qc = makeClient();
     const onExit = vi.fn();

--- a/src/features/kid-sequence/KidSequence.tsx
+++ b/src/features/kid-sequence/KidSequence.tsx
@@ -81,6 +81,7 @@ export const KidSequence = ({ board, onExit }: KidSequenceProps): JSX.Element =>
         style={drag?.style}
         {...(drag?.attributes ?? {})}
         {...(drag?.listeners ?? {})}
+        {...(board.labelsVisible ? {} : { 'aria-label': step.picto.label })}
       >
         <div className={styles.mediaWrap}>
           <PictogramMedia picto={step.picto} size={200} className={styles.media} />
@@ -92,7 +93,7 @@ export const KidSequence = ({ board, onExit }: KidSequenceProps): JSX.Element =>
             <SpeakerIcon size={20} />
           </div>
         </div>
-        <span className={styles.label}>{step.picto.label}</span>
+        {board.labelsVisible && <span className={styles.label}>{step.picto.label}</span>}
       </button>
     );
   };

--- a/src/features/kid-sequence/KidSequence.tsx
+++ b/src/features/kid-sequence/KidSequence.tsx
@@ -81,7 +81,7 @@ export const KidSequence = ({ board, onExit }: KidSequenceProps): JSX.Element =>
         style={drag?.style}
         {...(drag?.attributes ?? {})}
         {...(drag?.listeners ?? {})}
-        {...(board.labelsVisible ? {} : { 'aria-label': step.picto.label })}
+        aria-label={board.labelsVisible ? undefined : step.picto.label}
       >
         <div className={styles.mediaWrap}>
           <PictogramMedia picto={step.picto} size={200} className={styles.media} />


### PR DESCRIPTION
## Summary

- The Labels toggle in BoardBuilder writes `boards.labels_visible` and the parent-side preview respects it (`StepTile` → `PictoTile` `showLabel`), but both kid-side renderers compose `PictogramMedia` + a hand-rolled label span and ignored the flag entirely. Authoring and runtime diverged silently.
- Wrap each label span in a `board.labelsVisible` guard. Add a conditional `aria-label` on the option/tile button so its accessible name survives when the visible label is hidden.
- Issue title scoped to choiceboard but the bug was symmetric on both kinds — `KidChoice.tsx:79` and `KidSequence.tsx:95` had the same shape. Fixed both surfaces in one PR; flagging here so it's not a surprise vs the issue title.

## Out of scope (intentional)

- The board-name eyebrow ("SATURDAY" at the top of `KidModeLayout`) and the picked CTA ("Let's go to Park") are contextual UI strings, not pictogram labels — `labelsVisible` per the parent-side semantics governs **per-tile** labels. Happy to widen if your intent was stricter; file a follow-up.
- `BoardCard.tsx`'s `showLabel={false}` on parent home is a fixed dense-preview behavior, unrelated.

## Test plan

- [x] `npx vitest run src/features/kid-choice/KidChoice.test.tsx src/features/kid-sequence/KidSequence.test.tsx` — 10/10 pass.
- [x] Negative control: removed each `board.labelsVisible &&` guard, both new tests fail with "found `<span class='_label_…'>Park</span>` instead". Restored.
- [x] `npm run typecheck` — clean.
- [x] `npm test` — 203/203 pass.
- [ ] Manual smoke (dev server): turn Labels off in BoardBuilder for each board kind, open kid mode, confirm tile labels are gone but tap targets still operate.

Closes #82