### PR TITLE
Pin search_path on public.set_updated_at() (#64)

### DIFF
--- a/supabase/migrations/20260427122646_pin_search_path_set_updated_at.sql
+++ b/supabase/migrations/20260427122646_pin_search_path_set_updated_at.sql
@@ -1,0 +1,16 @@
+-- Pin search_path on public.set_updated_at() to close the Supabase advisor's
+-- function_search_path_mutable warning (issue #64).
+--
+-- The function was defined in 20260424145159_init.sql without an explicit
+-- `set search_path`. Every other function in our migrations (is_board_owner,
+-- is_board_member, is_board_editor, owner_or_share_helper, storage helpers,
+-- handle_new_user trigger machinery) pins `search_path = public` because
+-- otherwise a malicious or misconfigured per-role search_path could shadow
+-- objects the function references at runtime — a small but real privilege-
+-- escalation surface for SECURITY DEFINER and trigger functions alike.
+--
+-- `set_updated_at` is a SECURITY INVOKER trigger, so the practical risk is
+-- bounded, but the advisor flags the asymmetry with the rest of the function
+-- catalogue and the fix is one line. Closing the warning keeps future
+-- advisor scans signal-only.
+alter function public.set_updated_at() set search_path = public;

--- a/supabase/tests/functions_search_path_test.sql
+++ b/supabase/tests/functions_search_path_test.sql
@@ -1,0 +1,30 @@
+-- Regression test pinning the function-search_path contract.
+--
+-- Every function in `public` should set `search_path = public` (recorded in
+-- `pg_proc.proconfig`). Without this pin, a per-role search_path or a session-
+-- level override could shadow object lookups inside the function body — the
+-- attack surface called out by Supabase advisor lint 0011
+-- (function_search_path_mutable). #64 closed the last gap (set_updated_at);
+-- this test makes sure the next `create or replace function` does not silently
+-- reopen it.
+--
+-- The assertion is class-wide rather than naming each function, so it keeps
+-- working as new functions are added — anything missing the pin trips it.
+--
+-- Run with: supabase test db
+BEGIN;
+SELECT plan(1);
+
+SELECT is(
+  (SELECT count(*)::int
+     FROM pg_proc p
+     JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.prokind = 'f'
+      AND NOT (coalesce(p.proconfig, '{}'::text[]) @> ARRAY['search_path=public'])),
+  0,
+  'every public function has search_path=public pinned in pg_proc.proconfig'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Closes #64.

## Summary

One-line follow-up migration to close the Supabase advisor's `function_search_path_mutable` warning on `public.set_updated_at()`.

```sql
alter function public.set_updated_at() set search_path = public;
```

Every other function in our migration set (`is_board_owner`, `is_board_member`, `is_board_editor`, `owner_or_share_helper`, the storage RLS helpers, the `handle_new_user` trigger machinery) pins `set search_path = public`. `set_updated_at` was the lone holdout from `20260424145159_init.sql`. Closing the warning keeps future advisor scans signal-only and matches the rest of the catalogue.

`set_updated_at` is a SECURITY INVOKER trigger, so the practical attack surface is small — but the asymmetry was the only reason the warning was non-empty.

## Verification

- `supabase db reset` applies the new migration cleanly.
- `select proname, proconfig from pg_proc ... where proname='set_updated_at'` now returns `{search_path=public}`.
- `supabase test db --local` — all 4 pgTAP files / 98 assertions pass.
- `npm run typecheck` clean.
- After merge, `deploy-migrations` workflow will push the migration to cloud; advisor recheck via `mcp__supabase__get_advisors --type security` should drop the warning.

## Test plan

- [x] Migration applies on local reset
- [x] `pg_proc.proconfig` confirms `search_path=public` is pinned
- [x] pgTAP suite green
- [x] TypeScript typecheck green
- [ ] Post-merge: re-run security advisor on cloud and confirm warning is gone