### PR TITLE
Move SECURITY DEFINER helpers into a private schema (#91)

### DIFF
--- a/supabase/migrations/20260427145144_move_helpers_to_private_schema.sql
+++ b/supabase/migrations/20260427145144_move_helpers_to_private_schema.sql
@@ -1,0 +1,62 @@
+-- Move SECURITY DEFINER helpers and trigger functions out of `public` into a
+-- non-exposed `private` schema (#91). Closes Supabase advisor lints 0028+0029
+-- (anon/authenticated SECURITY DEFINER function executable) for our 6 helpers,
+-- by removing them from PostgREST's exposure list rather than by revoking
+-- EXECUTE — which would crash RLS evaluation on every dependent SELECT.
+--
+-- Why schema-move, not REVOKE EXECUTE: the helpers (is_board_owner, etc.) are
+-- referenced from RLS policy USING clauses on every read-side operation. When
+-- a user does `select from pictograms`, Postgres' policy machinery calls
+-- `is_owner_shared_with_me(owner_id)` as part of the policy expression. That
+-- call is gated by the API role's EXECUTE privilege on the function. Revoking
+-- EXECUTE on a function used in this position causes Postgres to terminate
+-- the backend (verified empirically — server enters recovery mode mid-query).
+-- The advisor's "Revoke EXECUTE" remediation is correct only for SECURITY
+-- DEFINER functions that are NOT referenced by RLS. The advisor offers two
+-- other remediations for this exact case: switch to SECURITY INVOKER (would
+-- recurse on `boards` policies via the helpers), or move out of the exposed
+-- API schema. Supabase's official RLS guide explicitly recommends the third:
+-- "Security-definer functions should never be created in a schema in the
+-- 'Exposed schemas' inside your API settings."
+-- Reference: https://supabase.com/docs/guides/postgres/row-level-security
+--
+-- Why this works: PostgREST exposes only schemas listed in `[api].schemas`
+-- (config.toml: ["public", "graphql_public"]). Functions in `private` are
+-- unreachable via `/rest/v1/rpc/<name>`. Postgres' RLS evaluation, by
+-- contrast, doesn't go through PostgREST — it evaluates policy expressions
+-- inside the planner with whatever schemas the role can see (USAGE-granted)
+-- and EXECUTE-granted functions, regardless of API exposure.
+--
+-- ALTER FUNCTION ... SET SCHEMA preserves the function's OID, body,
+-- SECURITY DEFINER flag, search_path pin, and ACL. Postgres also rewrites
+-- every dependent policy expression and trigger binding in pg_policy and
+-- pg_trigger to use the new qualified name. We do not drop+recreate any
+-- policies or triggers — the rewrite is automatic and atomic with the move.
+-- (Empirically verified Phase 0; pg_policies.qual goes from `is_board_owner(id)`
+-- to `private.is_board_owner(id)` after ALTER, and all RLS-mediated SELECTs
+-- continue to return the same rows.)
+
+create schema if not exists private;
+
+-- USAGE on `private` for the API roles is required: without it, the role
+-- can't resolve the qualified function name during policy evaluation, and
+-- the same backend-crash failure mode reappears. anon doesn't have policies
+-- that match real rows (no anon-readable surface in this app), but grant
+-- USAGE for symmetry — denying it would diverge from `public`'s shape and
+-- create a future trap where adding an anon-readable table works in `public`
+-- but breaks if the policy reaches into `private`. service_role bypasses
+-- RLS entirely but may invoke helpers from edge functions; grant for that.
+grant usage on schema private to anon, authenticated, service_role;
+
+-- Move all six SECURITY DEFINER RLS helpers + the SECURITY INVOKER trigger.
+-- Functions stay owned by postgres (the migration runner) so the SECURITY
+-- DEFINER "executes as owner" semantics are unchanged. Postgres rewrites
+-- the dependent objects (six policies in public, two in storage.objects,
+-- two triggers) automatically; verify by running the pgTAP suite afterward.
+alter function public.is_board_owner(uuid)               set schema private;
+alter function public.is_board_member(uuid)              set schema private;
+alter function public.is_board_editor(uuid)              set schema private;
+alter function public.is_owner_shared_with_me(uuid)      set schema private;
+alter function public.is_pictogram_storage_visible(text) set schema private;
+alter function public.handle_new_user()                  set schema private;
+alter function public.set_updated_at()                   set schema private;

--- a/supabase/tests/functions_search_path_test.sql
+++ b/supabase/tests/functions_search_path_test.sql
@@ -1,12 +1,16 @@
 -- Regression test pinning the function-search_path contract.
 --
--- Every function in `public` should set `search_path = public` (recorded in
--- `pg_proc.proconfig`). Without this pin, a per-role search_path or a session-
--- level override could shadow object lookups inside the function body — the
--- attack surface called out by Supabase advisor lint 0011
+-- Every function in `public` AND `private` should set `search_path = public`
+-- (recorded in `pg_proc.proconfig`). Without this pin, a per-role search_path
+-- or a session-level override could shadow object lookups inside the function
+-- body — the attack surface called out by Supabase advisor lint 0011
 -- (function_search_path_mutable). #64 closed the last gap (set_updated_at);
 -- this test makes sure the next `create or replace function` does not silently
 -- reopen it.
+--
+-- Both schemas are scanned because #91 moved RLS helpers into `private`. A
+-- helper that lacks the pin is the same vulnerability whether it lives in
+-- `public` or `private`.
 --
 -- The assertion is class-wide rather than naming each function, so it keeps
 -- working as new functions are added — anything missing the pin trips it.
@@ -19,11 +23,11 @@ SELECT is(
   (SELECT count(*)::int
      FROM pg_proc p
      JOIN pg_namespace n ON n.oid = p.pronamespace
-    WHERE n.nspname = 'public'
+    WHERE n.nspname IN ('public', 'private')
       AND p.prokind = 'f'
       AND NOT (coalesce(p.proconfig, '{}'::text[]) @> ARRAY['search_path=public'])),
   0,
-  'every public function has search_path=public pinned in pg_proc.proconfig'
+  'every function in public+private has search_path=public pinned in pg_proc.proconfig'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/handle_new_user_test.sql
+++ b/supabase/tests/handle_new_user_test.sql
@@ -135,7 +135,7 @@ SELECT is(
 -- re-inserting auth.users.
 CREATE TRIGGER tmp_retest
   AFTER UPDATE ON auth.users
-  FOR EACH ROW EXECUTE FUNCTION handle_new_user();
+  FOR EACH ROW EXECUTE FUNCTION private.handle_new_user();
 UPDATE auth.users SET email = email
  WHERE id = '11111111-1111-1111-1111-111111111111';
 DROP TRIGGER tmp_retest ON auth.users;

--- a/supabase/tests/pictograms_kids_share_rls_test.sql
+++ b/supabase/tests/pictograms_kids_share_rls_test.sql
@@ -10,9 +10,6 @@
 -- Bob member of Alice; Charlie unrelated; Dana cross-owner member of
 -- Charlie's board, NOT Alice's). Asserts:
 --
---   helper layer  — `is_owner_shared_with_me(uuid)` returns the right
---                   answer for owner / member / non-member /
---                   cross-owner-member.
 --   policy layer  — SELECT through `pictograms_select` and
 --                   `kids_select` returns the owner's rows for the
 --                   owner and the member; zero rows for the
@@ -21,9 +18,16 @@
 --                   (the existing `pictograms_owner_write` policy
 --                   still gates writes).
 --
+-- Helper-layer assertions previously here called `is_owner_shared_with_me`
+-- directly under role-switched sessions — that pinned the wrong contract.
+-- The helper now lives in `private` (not the exposed API schema, per #91),
+-- so calling it directly is no longer the surface to test. The policy-layer
+-- assertions below still exercise the helper through the actual RLS path,
+-- which is what production depends on.
+--
 -- Run with: supabase test db
 BEGIN;
-SELECT plan(13);
+SELECT plan(8);
 
 INSERT INTO auth.users (id, email)
 VALUES
@@ -57,52 +61,9 @@ CREATE TEMP TABLE expected AS
       WHERE owner_id = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa') AS kids;
 GRANT SELECT ON expected TO authenticated;
 
--- ── 1. Helper exists ───────────────────────────────────────────────────────
-
-SELECT ok(
-  EXISTS (
-    SELECT 1 FROM pg_proc p
-      JOIN pg_namespace n ON n.oid = p.pronamespace
-     WHERE n.nspname = 'public'
-       AND p.proname = 'is_owner_shared_with_me'
-       AND p.prosecdef = true
-  ),
-  'is_owner_shared_with_me exists in public schema as SECURITY DEFINER'
-);
-
--- ── 2-5. Helper logic, four roles ──────────────────────────────────────────
-
 SET LOCAL ROLE authenticated;
 
-SET LOCAL "request.jwt.claims" TO
-  '{"sub":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","role":"authenticated"}';
-SELECT ok(
-  is_owner_shared_with_me('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid),
-  'helper: owner shares with self'
-);
-
-SET LOCAL "request.jwt.claims" TO
-  '{"sub":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb","role":"authenticated"}';
-SELECT ok(
-  is_owner_shared_with_me('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid),
-  'helper: board member sees owner data'
-);
-
-SET LOCAL "request.jwt.claims" TO
-  '{"sub":"cccccccc-cccc-4ccc-8ccc-cccccccccccc","role":"authenticated"}';
-SELECT ok(
-  NOT is_owner_shared_with_me('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid),
-  'helper: stranger does not see owner data'
-);
-
-SET LOCAL "request.jwt.claims" TO
-  '{"sub":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","role":"authenticated"}';
-SELECT ok(
-  NOT is_owner_shared_with_me('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid),
-  'helper: cross-owner member (dana) does not see alice data (scoped-membership guard)'
-);
-
--- ── 6-9. pictograms_select policy, four roles ──────────────────────────────
+-- ── 1-4. pictograms_select policy, four roles ──────────────────────────────
 
 SET LOCAL "request.jwt.claims" TO
   '{"sub":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","role":"authenticated"}';
@@ -140,7 +101,7 @@ SELECT is(
   'policy: cross-owner member sees zero of owner pictograms (scoped-membership guard)'
 );
 
--- ── 10-12. kids_select policy, three roles ─────────────────────────────────
+-- ── 5-7. kids_select policy, three roles ─────────────────────────────────
 -- Owner and member must see Alice's seeded kid; non-member and
 -- cross-owner-member must not. (Picking three of the four roles —
 -- owner/member/cross-owner — covers the same logic plane as pictograms;
@@ -174,7 +135,7 @@ SELECT is(
   'policy: cross-owner member sees zero of owner kids (scoped-membership guard)'
 );
 
--- ── 13. Member cannot UPDATE owner pictograms ──────────────────────────────
+-- ── 8. Member cannot UPDATE owner pictograms ──────────────────────────────
 -- The widened SELECT must not have widened writes. The existing
 -- `pictograms_owner_write` policy keeps writes owner-only.
 

--- a/supabase/tests/rest_surface_contract_test.sql
+++ b/supabase/tests/rest_surface_contract_test.sql
@@ -1,0 +1,54 @@
+-- Regression test pinning the REST surface contract introduced in #91.
+--
+-- PostgREST exposes every function in the schemas listed in
+-- `[api].schemas` (config.toml: ["public", "graphql_public"]) as
+-- `/rest/v1/rpc/<name>`. SECURITY DEFINER helpers used inside RLS policies
+-- are internal plumbing — they should never be reachable as REST endpoints,
+-- because their bodies (`exists (select 1 from boards where ...)`) are
+-- designed for evaluation inside policy expressions, not for direct callers.
+--
+-- The fix in #91 was to move every internal helper into `private` (a schema
+-- not in `[api].schemas`). This test pins that contract: any future
+-- `create or replace function` that lands a SECURITY DEFINER helper in
+-- `public` re-introduces the same advisor warning surface (lints 0028+0029)
+-- and trips this assertion.
+--
+-- Run with: supabase test db
+BEGIN;
+SELECT plan(2);
+
+-- 1. No SECURITY DEFINER function should exist in `public`. SECURITY INVOKER
+--    functions in `public` are fine (they have no privilege-elevation surface
+--    even when REST-exposed). DEFINER functions in `public` are the lint
+--    target.
+SELECT is(
+  (SELECT count(*)::int
+     FROM pg_proc p
+     JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.prokind = 'f'
+      AND p.prosecdef = true),
+  0,
+  'no SECURITY DEFINER function exists in public schema (use private instead)'
+);
+
+-- 2. The seven internal helpers from this app must live in `private`. Pinning
+--    by name catches a regression where a maintainer drops one of them, then
+--    recreates it in `public` (which a class-wide DEFINER check could miss
+--    if they happened to flip the function to INVOKER along the way).
+SELECT is(
+  (SELECT count(*)::int
+     FROM pg_proc p
+     JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE p.proname IN (
+            'is_board_owner', 'is_board_member', 'is_board_editor',
+            'is_owner_shared_with_me', 'is_pictogram_storage_visible',
+            'handle_new_user', 'set_updated_at'
+          )
+      AND n.nspname <> 'private'),
+  0,
+  'all known internal helpers live in private schema (none stray into public)'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/storage_share_rls_test.sql
+++ b/supabase/tests/storage_share_rls_test.sql
@@ -11,9 +11,6 @@
 -- The test exercises the actual policies under role-switched sessions
 -- and asserts:
 --
---   helper layer  — `is_pictogram_storage_visible(path)` returns
---                   true for the owner, true for a member, false for
---                   a stranger or a cross-owner member.
 --   policy layer  — SELECT through `pictogram_audio_select` and
 --                   `pictogram_images_select` returns 1/1/0/0 rows
 --                   for owner/member/non-member/cross-owner-member.
@@ -29,9 +26,16 @@
 -- that re-breaks the member branch (column shadow, missing helper,
 -- bad cast) will land on these.
 --
+-- Helper-layer assertions previously here called `is_pictogram_storage_visible`
+-- directly under role-switched sessions — that pinned the wrong contract.
+-- The helper now lives in `private` (not the exposed API schema, per #91),
+-- so calling it directly is no longer the surface to test. The policy-layer
+-- assertions below still exercise the helper through the actual storage RLS
+-- path, which is what production depends on.
+--
 -- Run with: supabase test db
 BEGIN;
-SELECT plan(17);
+SELECT plan(12);
 
 -- Four users. handle_new_user() seeds a starter library for each on
 -- INSERT, so Alice and Charlie each end up owning a few boards.
@@ -83,57 +87,11 @@ INSERT INTO storage.objects (bucket_id, name, owner) VALUES
    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/wakeup.jpg',
    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid);
 
--- ── 1. Helper exists with the right shape ──────────────────────────────────
-
-SELECT ok(
-  EXISTS (
-    SELECT 1 FROM pg_proc p
-      JOIN pg_namespace n ON n.oid = p.pronamespace
-     WHERE n.nspname = 'public'
-       AND p.proname = 'is_pictogram_storage_visible'
-       AND p.prosecdef = true
-  ),
-  'is_pictogram_storage_visible exists in public schema as SECURITY DEFINER'
-);
-
--- ── 2-4. Helper logic, three roles ─────────────────────────────────────────
+-- ── Policy through SELECT, four roles, audio ───────────────────────────────
 -- SET LOCAL applies for the rest of the transaction; subsequent SET LOCALs
 -- replace previous values. ROLLBACK at the end discards everything.
 
 SET LOCAL ROLE authenticated;
-
-SET LOCAL "request.jwt.claims" TO
-  '{"sub":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","role":"authenticated"}';
-SELECT ok(
-  is_pictogram_storage_visible('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/wakeup.webm'),
-  'helper: owner sees own audio path'
-);
-
-SET LOCAL "request.jwt.claims" TO
-  '{"sub":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb","role":"authenticated"}';
-SELECT ok(
-  is_pictogram_storage_visible('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/wakeup.webm'),
-  'helper: board member sees owner audio path (#37 regression guard)'
-);
-
-SET LOCAL "request.jwt.claims" TO
-  '{"sub":"cccccccc-cccc-4ccc-8ccc-cccccccccccc","role":"authenticated"}';
-SELECT ok(
-  NOT is_pictogram_storage_visible('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/wakeup.webm'),
-  'helper: non-member does not see owner audio path'
-);
-
--- Dana is a member of CHARLIE's board, not Alice's. She must not see
--- Alice's storage. Catches a regression where the predicate loosens
--- from "scoped to this owner's boards" to "any membership anywhere".
-SET LOCAL "request.jwt.claims" TO
-  '{"sub":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","role":"authenticated"}';
-SELECT ok(
-  NOT is_pictogram_storage_visible('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/wakeup.webm'),
-  'helper: cross-owner member (dana) does not see alice audio path'
-);
-
--- ── Policy through SELECT, four roles, audio ───────────────────────────────
 
 SET LOCAL "request.jwt.claims" TO
   '{"sub":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","role":"authenticated"}';


### PR DESCRIPTION
Closes #91.

## Summary

Move all 7 internal helper functions out of `public` into a new `private` schema. PostgREST exposes only the schemas listed in `[api].schemas` (config.toml: `["public", "graphql_public"]`), so functions in `private` are no longer reachable as `/rest/v1/rpc/<name>`. This closes 12 of the 14 Supabase advisor warnings (lints 0028 + 0029 — anon/authenticated SECURITY DEFINER function executable) in one stroke. The remaining 2 are on the cloud-only `rls_auto_enable`, tracked by #92.

## Why this is the right fix (and "revoke EXECUTE" is not)

The advisor's text suggests three remediations:
1. Revoke EXECUTE
2. Switch to SECURITY INVOKER
3. **Move it out of your exposed API schema**

The first two are wrong for *this codebase*:
- **Revoke EXECUTE**: I tried this. Postgres crashed mid-policy-evaluation — server entered recovery mode every time a policy expression tried to call the helper after EXECUTE was revoked. Verified empirically across PUBLIC, anon, and authenticated.
- **Switch to SECURITY INVOKER**: would cause infinite RLS recursion (the helpers exist *because* `is_board_owner(id)` needs to read `boards` from inside a `boards` policy, which only works if the helper bypasses RLS via SECURITY DEFINER).

Option 3 is the canonical Supabase pattern, [explicitly recommended in the RLS guide](https://supabase.com/docs/guides/postgres/row-level-security): *"Security-definer functions should never be created in a schema in the 'Exposed schemas' inside your API settings."*

## Migration mechanics — simpler than expected

Phase 0 empirical checks (run before writing the migration) revealed:

- **`ALTER FUNCTION ... SET SCHEMA private` automatically rewrites every dependent RLS policy and trigger binding** to use the qualified name. `pg_policies.qual` goes from `is_board_owner(id)` → `private.is_board_owner(id)` after one ALTER. No drop+recreate needed.
- **USAGE on `private` IS required** for anon/authenticated/service_role. Without it, RLS evaluation crashes with the same recovery-mode signature as revoking EXECUTE. Granted defensively in the migration.
- **EXECUTE on the helpers stays granted by default**. Revoking it crashes RLS — schema separation alone is sufficient to clear the advisor lints.

The full migration is ~10 lines of SQL plus a long comment explaining the why. See `supabase/migrations/20260427145144_move_helpers_to_private_schema.sql`.

## Test changes

The two "share RLS" tests had a structural problem the user called out: the "helper layer" assertions called `is_owner_shared_with_me(...)` and `is_pictogram_storage_visible(...)` **directly** under role-switched sessions. That pins the *wrong* contract — calling internal helpers via the REST surface is exactly what this PR closes. The "policy layer" assertions in the same files (SELECT through RLS via `pictograms_select`, `pictogram_audio_select`, etc.) test what production actually depends on, and they still pass.

- `pictograms_kids_share_rls_test.sql`: deleted lines 75-103 (5 helper-layer assertions); `plan(13)` → `plan(8)`
- `storage_share_rls_test.sql`: deleted lines 99-134 (5 helper-layer assertions); `plan(17)` → `plan(12)`
- `functions_search_path_test.sql`: scan extended from `public` to `public + private` (the search_path pin from #64 still applies)
- `handle_new_user_test.sql:138`: trigger function reference qualified to `private.handle_new_user()`
- **New** `rest_surface_contract_test.sql`: 2 assertions — no SECURITY DEFINER function in `public`, and every known helper lives in `private`. Catches future drift class-wide.

## Verification

- [x] `supabase db reset --local` — clean apply
- [x] `supabase test db --local` — 6 files, 91 assertions, all green
- [x] Negative control: `ALTER FUNCTION private.is_board_owner(uuid) SET SCHEMA public` causes both contract assertions to fail; restoring re-greens them
- [x] `curl -X POST http://127.0.0.1:54321/rest/v1/rpc/is_board_owner -H 'apikey: <anon>' ...` returns HTTP 404 (PostgREST cannot find the function in the exposed schemas). Pre-fix this returned a JSON boolean.
- [x] `curl /rest/v1/rpc/handle_new_user` also returns 404
- [x] `npm run typecheck` — clean
- [x] `npm test` — 43 files / 205 tests green
- [x] No application code references the helpers via RPC (`grep -rn "rpc(\(is_board_\|...\)" src/` is empty)
- [ ] Post-merge: `mcp__supabase__get_advisors --type security` should drop from 14 → 2 SECURITY DEFINER warnings (only `rls_auto_enable` × {anon, authenticated} remain, tracked by #92)

## Notes

- **Cloud has no useful data**, so this migration is safe to apply on the linked cloud project. Rollback if needed: `supabase db reset --linked`.
- **Project learning** about this pattern was captured in `CLAUDE.md` § 11. CLAUDE.md is gitignored in this repo, so the learning persists in the local working tree but doesn't travel with the PR. If the user wants this committed, that's a separate decision (move to a tracked AGENTS.md or unignore CLAUDE.md).

## Test plan for reviewer

- [ ] `git checkout move-helpers-to-private-schema-91 && supabase db reset --local`
- [ ] `supabase test db --local` — all 91 assertions green
- [ ] `npm run typecheck && npm test` — green
- [ ] Spot-check: `psql -c "select polname, qual from pg_policies where schemaname = 'public' and qual like '%private.%'"` shows 6 policies referencing `private.X(...)`