### PR TITLE
Reconcile cloud-only rls_auto_enable() into private schema (#92)

### DIFF
--- a/supabase/migrations/20260427150759_move_rls_auto_enable_to_private.sql
+++ b/supabase/migrations/20260427150759_move_rls_auto_enable_to_private.sql
@@ -1,0 +1,63 @@
+-- Reconcile cloud-only `rls_auto_enable()` into the migration set, in the
+-- private schema per the pattern adopted in #91 (closes #92).
+--
+-- This function existed only on cloud (created via dashboard SQL editor at
+-- some early stage of the project, never captured in a migration). It is an
+-- event-trigger function on `ddl_command_end` that auto-enables RLS on any
+-- new table created in `public` — a defense-in-depth catching "forgot to
+-- enable RLS" mistakes. Useful enough to keep, but the cloud-only state is
+-- the kind of drift that bites silently: local pgTAP and CI cannot see it,
+-- so any regression involving its behavior is invisible until production.
+--
+-- Closes the last 2 SECURITY DEFINER advisor warnings (lints 0028+0029)
+-- left over from #91. After this migration, only the auth-side
+-- `auth_leaked_password_protection` warning remains (#93, dashboard toggle).
+--
+-- Migration is drop-then-recreate rather than ALTER FUNCTION SET SCHEMA
+-- because it has to handle both states idempotently:
+--   - cloud: function + event trigger exist in public
+--   - local: nothing exists (this is the first time it lands)
+-- Drop-if-exists is a no-op on local. We also normalize the body's
+-- search_path from `pg_catalog` (cloud) to `public` (our convention),
+-- which a SET SCHEMA wouldn't have done.
+--
+-- Empirical Phase 0 verified: event triggers auto-rebind on ALTER FUNCTION
+-- SET SCHEMA, and event trigger functions fire correctly when housed in
+-- private (event triggers don't go through PostgREST or the API role's
+-- privilege check; they fire as the user running the DDL).
+
+drop event trigger if exists ensure_rls;
+drop function if exists public.rls_auto_enable();
+drop function if exists private.rls_auto_enable();
+
+create function private.rls_auto_enable() returns event_trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  cmd record;
+begin
+  for cmd in
+    select *
+      from pg_event_trigger_ddl_commands()
+     where command_tag in ('CREATE TABLE', 'CREATE TABLE AS', 'SELECT INTO')
+       and object_type in ('table', 'partitioned table')
+  loop
+    if cmd.schema_name is not null
+       and cmd.schema_name = 'public'
+       and cmd.schema_name not like 'pg_%' then
+      begin
+        execute format('alter table if exists %s enable row level security', cmd.object_identity);
+        raise log 'rls_auto_enable: enabled RLS on %', cmd.object_identity;
+      exception when others then
+        raise log 'rls_auto_enable: failed to enable RLS on %', cmd.object_identity;
+      end;
+    end if;
+  end loop;
+end;
+$$;
+
+create event trigger ensure_rls
+  on ddl_command_end
+  execute function private.rls_auto_enable();

--- a/supabase/tests/rest_surface_contract_test.sql
+++ b/supabase/tests/rest_surface_contract_test.sql
@@ -43,7 +43,8 @@ SELECT is(
     WHERE p.proname IN (
             'is_board_owner', 'is_board_member', 'is_board_editor',
             'is_owner_shared_with_me', 'is_pictogram_storage_visible',
-            'handle_new_user', 'set_updated_at'
+            'handle_new_user', 'set_updated_at',
+            'rls_auto_enable'
           )
       AND n.nspname <> 'private'),
   0,


### PR DESCRIPTION
Closes #92.

## Summary

The last 2 SECURITY DEFINER advisor warnings remaining after #91 are on `public.rls_auto_enable()`. That function existed only on cloud — never captured in a migration — and is an event-trigger function on `ddl_command_end` that auto-enables RLS on new `public` tables. This PR brings it into the migration set in the `private` schema, following the exact pattern from #91.

After this lands, the only remaining security advisor warning is `auth_leaked_password_protection` (#93, dashboard toggle).

## Why this PR

- **Closes the lint pair** (0028 + 0029 on `rls_auto_enable`).
- **Reconciles cloud↔local drift**. The function was running on cloud, silently catching "forgot to enable RLS" mistakes, but local dev never had the safety net. Now both match.
- **Preserves the defense-in-depth** rather than dropping it. Our migration discipline already enables RLS explicitly on every table, but this is a cheap belt-and-suspenders.

## Migration mechanics

Drop-then-recreate (rather than `ALTER FUNCTION SET SCHEMA`) because the migration must be idempotent across two states:
- **Cloud**: function + event trigger exist in `public`
- **Local**: nothing exists

`drop event trigger if exists` + `drop function if exists ... public` + `drop function if exists ... private` is a no-op on local and a clean reset on cloud. Recreating also lets us normalize `search_path` from `pg_catalog` (cloud's value) to `public` (our convention), which a `SET SCHEMA` wouldn't have done.

Body cleanup: collapsed redundant schema filter clauses (the function only fires on `public` so the various `pg_catalog` / `information_schema` / `pg_toast` / `pg_temp` checks are redundant). Behavior unchanged for the schema it actually targets.

## Phase 0 empirical checks (new for event triggers)

#91 already proved (a) `ALTER FUNCTION SET SCHEMA` auto-rebinds regular triggers and RLS policies, (b) USAGE on `private` is required for authenticated, (c) revoking EXECUTE crashes RLS. Those carry over.

New questions for this PR:
- **Event triggers auto-rebind**: confirmed. After `ALTER FUNCTION public.phase0_evt() SET SCHEMA private`, `pg_event_trigger.evtfoid` reads `private.phase0_evt()`.
- **Event triggers fire correctly with function in private**: confirmed via NOTICE on `CREATE TABLE`.

## Test changes

- `rest_surface_contract_test.sql` Assertion 2 now includes `rls_auto_enable` in the explicit helper-names list. Assertion 1 (class-wide "no SECURITY DEFINER in public") already covered it implicitly.

## Verification

- [x] `supabase db reset --local` — clean apply
- [x] `supabase test db --local` — 6 files / 91 assertions green
- [x] **Behavior smoke**: `CREATE TABLE smoke_test_xxx (id uuid)` results in `relrowsecurity = t` on the new table (event trigger fires correctly with function in `private`)
- [x] Function placement: `pg_proc.pronamespace = private`, `proconfig = {search_path=public}`
- [x] Event trigger placement: `pg_event_trigger.evtfoid = private.rls_auto_enable()`
- [x] Negative control: temporarily moving back to `public` fails both contract assertions; restoring re-greens
- [ ] Post-merge: `mcp__supabase__get_advisors --type security` should show **0** SECURITY DEFINER warnings (down from 2 after #91)

## Notes

- **Local-only side effect**: once this migration is in the set, every fresh `CREATE TABLE` in `public` (in tests, scratch SQL, dev work) gets RLS auto-enabled. This matches what cloud has been doing all along. None of our pgTAP tests create user tables in `public` so the risk is minimal, but flagging for awareness.
- **Cloud has no useful data** (per earlier note in this session), so the drop+recreate sequence is fully safe.

## Test plan for reviewer

- [ ] `git checkout move-rls-auto-enable-to-private-92 && supabase db reset --local`
- [ ] `supabase test db --local` — green
- [ ] In a transaction, `CREATE TABLE foo (id uuid)` and confirm `relrowsecurity = t`, then ROLLBACK