### PR TITLE
Seed cloud template_pictograms + template_boards (#63)

### DIFF
--- a/supabase/migrations/20260427162919_seed_templates.sql
+++ b/supabase/migrations/20260427162919_seed_templates.sql
@@ -1,0 +1,51 @@
+-- Seed the starter template library that handle_new_user() clones into every
+-- new user's account on signup (closes #63). Without this, fresh signups on
+-- cloud land on a blank screen — the AAC tool's primary value (pictograms to
+-- react to, boards to use) is invisible until the parent creates content
+-- from scratch.
+--
+-- Why a migration and not supabase/seed.sql: by Supabase convention seed.sql
+-- only runs on local `supabase db reset`. `supabase db push --linked` (used
+-- by deploy-migrations.yml) does not run seed.sql, so cloud has stayed empty
+-- since the project's first deploy. A migration is the only path that lands
+-- on cloud automatically. After this PR, supabase/seed.sql is blanked and
+-- this file is the single source of truth for starter content — no drift
+-- between local and cloud.
+--
+-- Idempotency: ON CONFLICT (slug) DO NOTHING. Supabase doesn't reapply
+-- migrations, but the ON CONFLICT shape also makes a hand-run safe.
+--
+-- Future template changes: write a NEW migration that explicitly UPDATEs by
+-- slug for changes to existing rows, INSERTs new slugs, and DELETEs removed
+-- ones. Re-running this migration with a changed label would silently drop
+-- the change because of ON CONFLICT — that's intentional (this file is
+-- frozen as the v1 starter library).
+
+insert into template_pictograms
+  (slug, label, style, glyph, tint, image_path, audio_path) values
+  ('wakeup',    'Wake up',     'illus', 'sun',   'oklch(90% 0.06 90)',  null, null),
+  ('bed',       'Out of bed',  'illus', 'bed',   'oklch(88% 0.05 300)', null, null),
+  ('brush',     'Brush teeth', 'illus', 'tooth', 'oklch(88% 0.05 240)', null, null),
+  ('dress',     'Get dressed', 'illus', 'shirt', 'oklch(88% 0.05 45)',  null, null),
+  ('shoes',     'Shoes on',    'illus', 'shoe',  'oklch(88% 0.05 155)', null, null),
+  ('breakfast', 'Breakfast',   'illus', 'bowl',  'oklch(88% 0.05 45)',  null, null),
+  ('apple',     'Apple',       'illus', 'apple', 'oklch(88% 0.05 20)',  null, null),
+  ('cup',       'Drink',       'illus', 'cup',   'oklch(88% 0.05 240)', null, null),
+  ('bag',       'Backpack',    'illus', 'bag',   'oklch(88% 0.05 155)', null, null),
+  ('car',       'Go to car',   'illus', 'car',   'oklch(88% 0.05 300)', null, null),
+  ('park',      'Park',        'photo', null,    null,                  null, null),
+  ('store',     'Supermarket', 'photo', null,    null,                  null, null),
+  ('zoo',       'Zoo',         'photo', null,    null,                  null, null),
+  ('play',      'Playground',  'photo', null,    null,                  null, null),
+  ('book',      'Story time',  'illus', 'book',  'oklch(88% 0.05 300)', null, null),
+  ('bath',      'Bath',        'illus', 'bath',  'oklch(88% 0.05 240)', null, null),
+  ('heart',     'Love',        'illus', 'heart', 'oklch(88% 0.05 20)',  null, null)
+on conflict (slug) do nothing;
+
+insert into template_boards
+  (slug, name, kind, labels_visible, voice_mode, step_slugs, kid_reorderable, accent, accent_ink) values
+  ('morning',     'Morning routine',      'sequence', true, 'tts', array['wakeup', 'brush', 'dress', 'breakfast', 'bag', 'car']::text[], false, 'peach',    'peach-ink'),
+  ('afterschool', 'After school',         'sequence', true, 'tts', array['bag', 'apple', 'book', 'bath']::text[],                       false, 'sage',     'sage-ink'),
+  ('weekend',     'Saturday — where to?', 'choice',   true, 'tts', array['park', 'store', 'zoo']::text[],                               false, 'sky',      'sky-ink'),
+  ('bedtime',     'Bedtime',              'sequence', true, 'tts', array['bath', 'book', 'cup', 'bed']::text[],                         true,  'lavender', 'lavender-ink')
+on conflict (slug) do nothing;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,86 +1,10 @@
--- Demo boards + pictograms loaded by `supabase db reset`.
--- Edit directly; there is no generator.
-
-insert into template_pictograms
-  (slug, label, style, glyph, tint, image_path, audio_path) values
-  ('wakeup', 'Wake up', 'illus', 'sun', 'oklch(90% 0.06 90)', null, null);
-
-insert into template_pictograms
-  (slug, label, style, glyph, tint, image_path, audio_path) values
-  ('bed', 'Out of bed', 'illus', 'bed', 'oklch(88% 0.05 300)', null, null);
-
-insert into template_pictograms
-  (slug, label, style, glyph, tint, image_path, audio_path) values
-  ('brush', 'Brush teeth', 'illus', 'tooth', 'oklch(88% 0.05 240)', null, null);
-
-insert into template_pictograms
-  (slug, label, style, glyph, tint, image_path, audio_path) values
-  ('dress', 'Get dressed', 'illus', 'shirt', 'oklch(88% 0.05 45)', null, null);
-
-insert into template_pictograms
-  (slug, label, style, glyph, tint, image_path, audio_path) values
-  ('shoes', 'Shoes on', 'illus', 'shoe', 'oklch(88% 0.05 155)', null, null);
-
-insert into template_pictograms
-  (slug, label, style, glyph, tint, image_path, audio_path) values
-  ('breakfast', 'Breakfast', 'illus', 'bowl', 'oklch(88% 0.05 45)', null, null);
-
-insert into template_pictograms
-  (slug, label, style, glyph, tint, image_path, audio_path) values
-  ('apple', 'Apple', 'illus', 'apple', 'oklch(88% 0.05 20)', null, null);
-
-insert into template_pictograms
-  (slug, label, style, glyph, tint, image_path, audio_path) values
-  ('cup', 'Drink', 'illus', 'cup', 'oklch(88% 0.05 240)', null, null);
-
-insert into template_pictograms
-  (slug, label, style, glyph, tint, image_path, audio_path) values
-  ('bag', 'Backpack', 'illus', 'bag', 'oklch(88% 0.05 155)', null, null);
-
-insert into template_pictograms
-  (slug, label, style, glyph, tint, image_path, audio_path) values
-  ('car', 'Go to car', 'illus', 'car', 'oklch(88% 0.05 300)', null, null);
-
-insert into template_pictograms
-  (slug, label, style, glyph, tint, image_path, audio_path) values
-  ('park', 'Park', 'photo', null, null, null, null);
-
-insert into template_pictograms
-  (slug, label, style, glyph, tint, image_path, audio_path) values
-  ('store', 'Supermarket', 'photo', null, null, null, null);
-
-insert into template_pictograms
-  (slug, label, style, glyph, tint, image_path, audio_path) values
-  ('zoo', 'Zoo', 'photo', null, null, null, null);
-
-insert into template_pictograms
-  (slug, label, style, glyph, tint, image_path, audio_path) values
-  ('play', 'Playground', 'photo', null, null, null, null);
-
-insert into template_pictograms
-  (slug, label, style, glyph, tint, image_path, audio_path) values
-  ('book', 'Story time', 'illus', 'book', 'oklch(88% 0.05 300)', null, null);
-
-insert into template_pictograms
-  (slug, label, style, glyph, tint, image_path, audio_path) values
-  ('bath', 'Bath', 'illus', 'bath', 'oklch(88% 0.05 240)', null, null);
-
-insert into template_pictograms
-  (slug, label, style, glyph, tint, image_path, audio_path) values
-  ('heart', 'Love', 'illus', 'heart', 'oklch(88% 0.05 20)', null, null);
-
-insert into template_boards
-  (slug, name, kind, labels_visible, voice_mode, step_slugs, kid_reorderable, accent, accent_ink) values
-  ('morning', 'Morning routine', 'sequence', true, 'tts', array['wakeup', 'brush', 'dress', 'breakfast', 'bag', 'car']::text[], false, 'peach', 'peach-ink');
-
-insert into template_boards
-  (slug, name, kind, labels_visible, voice_mode, step_slugs, kid_reorderable, accent, accent_ink) values
-  ('afterschool', 'After school', 'sequence', true, 'tts', array['bag', 'apple', 'book', 'bath']::text[], false, 'sage', 'sage-ink');
-
-insert into template_boards
-  (slug, name, kind, labels_visible, voice_mode, step_slugs, kid_reorderable, accent, accent_ink) values
-  ('weekend', 'Saturday — where to?', 'choice', true, 'tts', array['park', 'store', 'zoo']::text[], false, 'sky', 'sky-ink');
-
-insert into template_boards
-  (slug, name, kind, labels_visible, voice_mode, step_slugs, kid_reorderable, accent, accent_ink) values
-  ('bedtime', 'Bedtime', 'sequence', true, 'tts', array['bath', 'book', 'cup', 'bed']::text[], true, 'lavender', 'lavender-ink');
+-- Local dev seed (runs on `supabase db reset`). Reserved for local-only
+-- test/dev data — anything that should NOT land on cloud.
+--
+-- Template content (template_pictograms, template_boards) is NOT seeded here
+-- anymore. It lives in a migration so deploy-migrations.yml can land it on
+-- cloud — see supabase/migrations/20260427162919_seed_templates.sql.
+-- That migration is the single source of truth for the starter library.
+--
+-- This file is intentionally empty. Add local-only fixtures here if/when
+-- they're needed.


### PR DESCRIPTION
Closes #63.

## Summary

Move the 17 starter pictograms + 4 starter boards from `supabase/seed.sql` into a migration. `seed.sql` is local-only (Supabase convention — `supabase db push --linked` doesn't run it), so cloud has had both `template_*` tables empty since the project's first deploy. That makes every fresh signup on cloud land on a blank account because `handle_new_user()` clones empty tables. **The launch-blocker for going live.**

After this PR: deploy-migrations.yml runs the migration on cloud → templates populate → next signup gets a usable starter library.

## Why a migration, not seed.sql

| Source | Runs on `supabase db reset` (local) | Runs on `supabase db push --linked` (cloud) |
|---|:---:|:---:|
| `supabase/seed.sql` | ✅ | ❌ |
| `supabase/migrations/*.sql` | ✅ | ✅ |

Cloud needs starter content. The only path that lands on cloud automatically is a migration. Keeping the data in two places (seed.sql AND a migration) would invite drift, so this PR also blanks `seed.sql` (kept as a file with a pointer comment, reserved for future local-only fixtures).

## Idempotency

`INSERT ... ON CONFLICT (slug) DO NOTHING` on both inserts. Supabase doesn't re-apply migrations, but the ON CONFLICT shape protects against any future hand-run / reset weirdness.

**Future template changes**: write a new migration that explicitly UPDATEs by slug for changes, INSERTs new slugs, DELETEs removed ones. Re-running this PR's migration with a changed label silently drops the change because of ON CONFLICT — that's intentional (this file is frozen as the v1 starter library).

## Verification

- [x] `supabase db reset --local` — clean apply
- [x] Counts after reset: `template_pictograms = 17`, `template_boards = 4`
- [x] **Live signup smoke**: `INSERT INTO auth.users (id, email) VALUES (...)` → handle_new_user clones 1 kid + 17 pictograms + 4 boards. All `boards.step_ids` resolve to UUIDs that exist in the new user's pictograms (no orphans).
- [x] Full pgTAP green (6 files / 91 assertions). The existing `handle_new_user_test.sql` floor checks (`cmp_ok >= 17`, `cmp_ok >= 4`) now pin both local AND cloud.
- [x] **Negative control**: temporarily reduce the migration to insert only 1 pictogram. `handle_new_user_test.sql:22-25` ("template_pictograms is populated (>=17)") correctly fails. Restoring re-greens the suite.
- [x] App typecheck clean
- [ ] Post-merge cloud smoke: sign up a real test user via Supabase Studio's Auth panel; confirm their account has 17 pictograms + 4 boards. **This is the actual go-live gate** — once it works on cloud, #63 is closed.

## Notes

- **No application code changes.** Templates land in the DB; existing queries just start returning data.
- **Existing user accounts unaffected.** Cloud has none today. If it had any, their cloned `pictograms`/`boards` are already own-data — they'd never hit the templates again.
- **`style='photo'` pictograms** (park, store, zoo, play) seed `image_path = null`. Each parent uploads their own photos. Stock photos for v1 would be a content design issue, not part of this PR.

## Test plan for reviewer

- [ ] `git checkout seed-cloud-templates-63 && supabase db reset --local`
- [ ] `psql -c "select count(*) from template_pictograms;"` → 17
- [ ] `psql -c "select count(*) from template_boards;"` → 4
- [ ] `supabase test db --local` — all 91 assertions green