### PR TITLE
Fix ParentHome header showing 'Liam' for every user (#68)

### DIFF
--- a/src/features/parent-home/ParentHome.tsx
+++ b/src/features/parent-home/ParentHome.tsx
@@ -31,7 +31,7 @@ interface ParentHomeProps {
 }
 
 export const ParentHome = ({
-  kidName = 'Liam',
+  kidName,
   onOpenBoard,
   onKidMode,
   onNav,
@@ -52,7 +52,7 @@ export const ParentHome = ({
       active="home"
       {...(onNav ? { onNav } : {})}
       {...(onKidMode ? { onKidMode } : {})}
-      title={`${kidName}'s boards`}
+      title={kidName ? `${kidName}'s boards` : 'Boards'}
       subtitle="Pick a board to edit, or start a new one."
       right={
         <div className={styles.rightActions}>

--- a/src/features/parent-home/ParentHomeRoute.test.tsx
+++ b/src/features/parent-home/ParentHomeRoute.test.tsx
@@ -123,6 +123,27 @@ describe('ParentHomeRoute auto-launch', () => {
   });
 });
 
+describe('ParentHomeRoute header kidName', () => {
+  it('reflects the real first kid name from the kids query (not a hardcoded placeholder)', () => {
+    useKidsMock.mockReturnValue({
+      data: [{ id: 'k-mira', ownerId: 'owner', name: 'Mira' }],
+      isPending: false,
+    });
+    const Wrap = makeWrap('/');
+    render(<Wrap />);
+    expect(screen.getByText(/Mira's boards/)).toBeInTheDocument();
+    expect(screen.queryByText(/Liam's boards/)).not.toBeInTheDocument();
+  });
+
+  it('falls back to a neutral "Boards" title when no kid is loaded yet', () => {
+    useKidsMock.mockReturnValue({ data: [], isPending: false });
+    const Wrap = makeWrap('/');
+    render(<Wrap />);
+    expect(screen.getByRole('heading', { level: 1, name: 'Boards' })).toBeInTheDocument();
+    expect(screen.queryByText(/Liam's boards/)).not.toBeInTheDocument();
+  });
+});
+
 describe('ParentHomeRoute create flows', () => {
   it('clicking New kid opens the kid modal', async () => {
     const Wrap = makeWrap('/');

--- a/src/features/parent-home/ParentHomeRoute.tsx
+++ b/src/features/parent-home/ParentHomeRoute.tsx
@@ -64,6 +64,7 @@ export const ParentHomeRoute = (): JSX.Element => {
   return (
     <>
       <ParentHome
+        {...(firstKid ? { kidName: firstKid.name } : {})}
         onOpenBoard={(id) => navigate(`/boards/${id}/edit`)}
         onKidMode={onKidMode}
         onNav={onNav}


### PR DESCRIPTION
## Summary

- `ParentHome.tsx` defaulted `kidName = 'Liam'` and `ParentHomeRoute.tsx` never passed the prop, so every signed-in parent saw "Liam's boards" in the header regardless of their actual kid's name. Trust-killer on first launch once real users sign up via the New kid flow.
- `ParentHomeRoute` now passes `kidName={firstKid?.name}` from `useKids()`. `ParentHome` falls back to a neutral `"Boards"` title when no kid is loaded yet (initial fetch / brand-new account before first kid is created), instead of inventing a name.
- Added two regression tests: header reflects a non-"Liam" kid name (Mira), and falls back to `"Boards"` heading when the kids query returns empty.

Multi-kid case the issue flagged ("Liam's boards" still wrong once a user has multiple kids) is left out of scope — proper fix lands with the multi-kid UI, which doesn't exist yet.

## Test plan

- [x] `npm run test` — 207/207 green
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [ ] Manual: sign in on cloud as a real user with a kid named anything other than "Liam" and confirm the header reflects it

Closes #68