### PR TITLE
Fix KID button no-op on stub routes via shared hook (#71)

### DIFF
--- a/src/features/kids/KidsRoute.test.tsx
+++ b/src/features/kids/KidsRoute.test.tsx
@@ -1,10 +1,13 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { TestSessionProvider } from '@/lib/auth/session.test-utils';
-import type { Kid } from '@/types/domain';
+import type { Board, Kid } from '@/types/domain';
+
+const useBoardsMock = vi.fn(() => ({ data: [] as Board[], isPending: false }));
 
 vi.mock('@/lib/queries/kids', () => ({
   useKids: (): { data: Kid[]; isPending: boolean } => ({
@@ -13,6 +16,11 @@ vi.mock('@/lib/queries/kids', () => ({
   }),
   useCreateKid: () => ({ mutate: vi.fn(), isPending: false }),
 }));
+
+vi.mock('@/lib/queries/boards', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, useBoards: () => useBoardsMock() };
+});
 
 vi.mock('@/lib/supabase', () => ({
   supabase: {
@@ -27,14 +35,31 @@ vi.mock('@/lib/supabase', () => ({
 const { KidsRoute } = await import('./KidsRoute');
 
 const renderRoute = (): void => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   render(
     <TestSessionProvider>
-      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-        <KidsRoute />
-      </MemoryRouter>
+      <QueryClientProvider client={qc}>
+        <MemoryRouter
+          initialEntries={['/kids']}
+          future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+        >
+          <Routes>
+            <Route path="/kids" element={<KidsRoute />} />
+            <Route
+              path="/kid/sequence/:boardId"
+              element={<div data-testid="kid-sequence-route" />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
     </TestSessionProvider>,
   );
 };
+
+beforeEach(() => {
+  useBoardsMock.mockReset();
+  useBoardsMock.mockReturnValue({ data: [], isPending: false });
+});
 
 describe('KidsRoute', () => {
   it('renders the Kids shell with rows from the cache', () => {
@@ -51,5 +76,33 @@ describe('KidsRoute', () => {
     await user.click(screen.getByRole('button', { name: /new kid/i }));
 
     expect(screen.getByRole('heading', { name: /add a kid/i })).toBeInTheDocument();
+  });
+
+  it('clicking KID navigates into the first sequence board (regression: #71)', async () => {
+    useBoardsMock.mockReturnValue({
+      data: [
+        {
+          id: 'b-seq',
+          ownerId: 'owner',
+          kidId: 'k1',
+          name: 'Morning',
+          kind: 'sequence',
+          labelsVisible: true,
+          voiceMode: 'tts',
+          stepIds: [],
+          kidReorderable: false,
+          accent: 'sage',
+          accentInk: 'sage-ink',
+          updatedLabel: 'just now',
+        },
+      ],
+      isPending: false,
+    });
+    renderRoute();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /^kid$/i }));
+
+    expect(screen.getByTestId('kid-sequence-route')).toBeInTheDocument();
   });
 });

--- a/src/features/kids/KidsRoute.tsx
+++ b/src/features/kids/KidsRoute.tsx
@@ -1,6 +1,7 @@
 import { type JSX, useState } from 'react';
 
 import { ParentShell } from '@/layouts/ParentShell';
+import { useKidModeNav } from '@/layouts/useKidModeNav';
 import { useParentNav } from '@/layouts/useParentNav';
 import { Button } from '@/ui/Button/Button';
 import { PlusIcon } from '@/ui/icons';
@@ -10,12 +11,14 @@ import { Kids } from './Kids';
 
 export const KidsRoute = (): JSX.Element => {
   const onNav = useParentNav();
+  const onKidMode = useKidModeNav();
   const [newKidOpen, setNewKidOpen] = useState(false);
   return (
     <>
       <ParentShell
         active="kids"
         onNav={onNav}
+        onKidMode={onKidMode}
         title="Kids"
         subtitle="The kids you're creating boards for"
         right={

--- a/src/features/library/LibraryRoute.test.tsx
+++ b/src/features/library/LibraryRoute.test.tsx
@@ -1,9 +1,13 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { TestSessionProvider } from '@/lib/auth/session.test-utils';
-import type { Pictogram } from '@/types/domain';
+import type { Board, Pictogram } from '@/types/domain';
+
+const useBoardsMock = vi.fn(() => ({ data: [] as Board[], isPending: false }));
 
 vi.mock('@/lib/queries/pictograms', () => ({
   usePictograms: (): { data: Pictogram[]; isPending: boolean } => ({
@@ -11,6 +15,11 @@ vi.mock('@/lib/queries/pictograms', () => ({
     isPending: false,
   }),
 }));
+
+vi.mock('@/lib/queries/boards', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, useBoards: () => useBoardsMock() };
+});
 
 vi.mock('@/lib/supabase', () => ({
   supabase: {
@@ -24,16 +33,65 @@ vi.mock('@/lib/supabase', () => ({
 
 const { LibraryRoute } = await import('./LibraryRoute');
 
+const renderRoute = (): void => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <TestSessionProvider>
+      <QueryClientProvider client={qc}>
+        <MemoryRouter
+          initialEntries={['/library']}
+          future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+        >
+          <Routes>
+            <Route path="/library" element={<LibraryRoute />} />
+            <Route
+              path="/kid/sequence/:boardId"
+              element={<div data-testid="kid-sequence-route" />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </TestSessionProvider>,
+  );
+};
+
+beforeEach(() => {
+  useBoardsMock.mockReset();
+  useBoardsMock.mockReturnValue({ data: [], isPending: false });
+});
+
 describe('LibraryRoute', () => {
   it('renders the Library shell with pictograms from the cache', () => {
-    render(
-      <TestSessionProvider>
-        <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-          <LibraryRoute />
-        </MemoryRouter>
-      </TestSessionProvider>,
-    );
+    renderRoute();
     expect(screen.getByRole('heading', { name: 'Library' })).toBeInTheDocument();
     expect(screen.getByText('Apple')).toBeInTheDocument();
+  });
+
+  it('clicking KID navigates into the first sequence board (regression: #71)', async () => {
+    useBoardsMock.mockReturnValue({
+      data: [
+        {
+          id: 'b-seq',
+          ownerId: 'owner',
+          kidId: 'k1',
+          name: 'Morning',
+          kind: 'sequence',
+          labelsVisible: true,
+          voiceMode: 'tts',
+          stepIds: [],
+          kidReorderable: false,
+          accent: 'sage',
+          accentInk: 'sage-ink',
+          updatedLabel: 'just now',
+        },
+      ],
+      isPending: false,
+    });
+    renderRoute();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /^kid$/i }));
+
+    expect(screen.getByTestId('kid-sequence-route')).toBeInTheDocument();
   });
 });

--- a/src/features/library/LibraryRoute.tsx
+++ b/src/features/library/LibraryRoute.tsx
@@ -1,16 +1,19 @@
 import type { JSX } from 'react';
 
 import { ParentShell } from '@/layouts/ParentShell';
+import { useKidModeNav } from '@/layouts/useKidModeNav';
 import { useParentNav } from '@/layouts/useParentNav';
 
 import { Library } from './Library';
 
 export const LibraryRoute = (): JSX.Element => {
   const onNav = useParentNav();
+  const onKidMode = useKidModeNav();
   return (
     <ParentShell
       active="library"
       onNav={onNav}
+      onKidMode={onKidMode}
       title="Library"
       subtitle="Every pictogram across your boards"
     >

--- a/src/features/parent-home/ParentHomeRoute.tsx
+++ b/src/features/parent-home/ParentHomeRoute.tsx
@@ -1,6 +1,7 @@
 import { type JSX, useEffect, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 
+import { useKidModeNav } from '@/layouts/useKidModeNav';
 import { useParentNav } from '@/layouts/useParentNav';
 import { getLastBoard, hasAutoLaunched, kidPathFor, markAutoLaunched } from '@/lib/lastBoard';
 import { useBoards, useCreateBoard } from '@/lib/queries/boards';
@@ -14,6 +15,7 @@ import { ParentHome } from './ParentHome';
 export const ParentHomeRoute = (): JSX.Element => {
   const navigate = useNavigate();
   const onNav = useParentNav();
+  const onKidMode = useKidModeNav();
   const boardsQuery = useBoards();
   const kidsQuery = useKids();
   const createBoard = useCreateBoard();
@@ -31,14 +33,6 @@ export const ParentHomeRoute = (): JSX.Element => {
     markAutoLaunched();
   }, []);
   if (redirect) return <Navigate to={redirect} replace />;
-
-  // Always expose onKidMode once boards have loaded — during the initial
-  // fetch we route to a stable placeholder that'll redirect as soon as the
-  // query settles. Avoids a visible flicker of the KID button in the sidebar.
-  const firstSequence = boardsQuery.data?.find((b) => b.kind === 'sequence');
-  const onKidMode = (): void => {
-    if (firstSequence) navigate(`/kid/sequence/${firstSequence.id}`);
-  };
 
   const firstKid = kidsQuery.data?.[0];
   const boardCount = boardsQuery.data?.length ?? 0;

--- a/src/features/settings/SettingsRoute.test.tsx
+++ b/src/features/settings/SettingsRoute.test.tsx
@@ -1,8 +1,18 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { TestSessionProvider } from '@/lib/auth/session.test-utils';
+import type { Board } from '@/types/domain';
+
+const useBoardsMock = vi.fn(() => ({ data: [] as Board[], isPending: false }));
+
+vi.mock('@/lib/queries/boards', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, useBoards: () => useBoardsMock() };
+});
 
 vi.mock('@/lib/supabase', () => ({
   supabase: {
@@ -16,16 +26,65 @@ vi.mock('@/lib/supabase', () => ({
 
 const { SettingsRoute } = await import('./SettingsRoute');
 
+const renderRoute = (): void => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <TestSessionProvider>
+      <QueryClientProvider client={qc}>
+        <MemoryRouter
+          initialEntries={['/settings']}
+          future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+        >
+          <Routes>
+            <Route path="/settings" element={<SettingsRoute />} />
+            <Route
+              path="/kid/sequence/:boardId"
+              element={<div data-testid="kid-sequence-route" />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </TestSessionProvider>,
+  );
+};
+
+beforeEach(() => {
+  useBoardsMock.mockReset();
+  useBoardsMock.mockReturnValue({ data: [], isPending: false });
+});
+
 describe('SettingsRoute', () => {
   it('renders the Settings header and a coming-soon body', () => {
-    render(
-      <TestSessionProvider>
-        <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-          <SettingsRoute />
-        </MemoryRouter>
-      </TestSessionProvider>,
-    );
+    renderRoute();
     expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
     expect(screen.getByText(/coming in a future release/i)).toBeInTheDocument();
+  });
+
+  it('clicking KID navigates into the first sequence board (regression: #71)', async () => {
+    useBoardsMock.mockReturnValue({
+      data: [
+        {
+          id: 'b-seq',
+          ownerId: 'owner',
+          kidId: 'k1',
+          name: 'Morning',
+          kind: 'sequence',
+          labelsVisible: true,
+          voiceMode: 'tts',
+          stepIds: [],
+          kidReorderable: false,
+          accent: 'sage',
+          accentInk: 'sage-ink',
+          updatedLabel: 'just now',
+        },
+      ],
+      isPending: false,
+    });
+    renderRoute();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /^kid$/i }));
+
+    expect(screen.getByTestId('kid-sequence-route')).toBeInTheDocument();
   });
 });

--- a/src/features/settings/SettingsRoute.tsx
+++ b/src/features/settings/SettingsRoute.tsx
@@ -1,13 +1,21 @@
 import type { JSX } from 'react';
 
 import { ParentShell } from '@/layouts/ParentShell';
+import { useKidModeNav } from '@/layouts/useKidModeNav';
 import { useParentNav } from '@/layouts/useParentNav';
 import { ComingSoon } from '@/ui/ComingSoon/ComingSoon';
 
 export const SettingsRoute = (): JSX.Element => {
   const onNav = useParentNav();
+  const onKidMode = useKidModeNav();
   return (
-    <ParentShell active="settings" onNav={onNav} title="Settings" subtitle="Coming soon">
+    <ParentShell
+      active="settings"
+      onNav={onNav}
+      onKidMode={onKidMode}
+      title="Settings"
+      subtitle="Coming soon"
+    >
       <ComingSoon body="Account preferences, voice settings, and PIN management. Coming in a future release." />
     </ParentShell>
   );

--- a/src/layouts/useKidModeNav.ts
+++ b/src/layouts/useKidModeNav.ts
@@ -1,0 +1,18 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { useBoards } from '@/lib/queries/boards';
+
+// Resolves the parent shell's KID button into a navigation into the first
+// sequence board the user owns. Routes that don't have their own board
+// context (Library, Kids, Settings, ParentHome) share this hook so the KID
+// button works consistently from anywhere in the parent shell. BoardBuilder
+// keeps its own wiring because it launches into the board being edited.
+export const useKidModeNav = (): (() => void) => {
+  const navigate = useNavigate();
+  const boardsQuery = useBoards();
+  const firstSequence = boardsQuery.data?.find((b) => b.kind === 'sequence');
+  return useCallback(() => {
+    if (firstSequence) navigate(`/kid/sequence/${firstSequence.id}`);
+  }, [navigate, firstSequence]);
+};


### PR DESCRIPTION
## Summary
- Extract `useKidModeNav()` in `src/layouts/` — reads `useBoards()`, finds the first sequence board, returns a navigate callback.
- Wire it into `LibraryRoute`, `KidsRoute`, `SettingsRoute` (the three routes the issue called out as no-op) and refactor `ParentHomeRoute` onto the same hook so there's one source of truth.
- `BoardBuilder` keeps its own wiring — it correctly launches into the board being edited.

Picked option (b) from the issue (shared hook) over (a) (duplicate wiring per route). The hook is shell-shaped logic that any route inside the parent shell needs, and now it has one home.

Closes #71

## Test plan
- [x] Regression test per route: clicking KID with one sequence board mocked navigates to \`/kid/sequence/{id}\`.
- [x] \`npm test\` — 210 pass.
- [x] \`npm run typecheck\` clean.
- [x] \`npm run lint\` clean.
- [ ] Manual smoke: KID button works from /library, /kids, /settings on cloud after merge.