### PR TITLE
Show real pictogram count in PictoPicker Library tab (#75)

### DIFF
--- a/src/features/pictogram-picker/PictoPicker.test.tsx
+++ b/src/features/pictogram-picker/PictoPicker.test.tsx
@@ -52,6 +52,13 @@ describe('PictoPicker', () => {
     expect(screen.getByText('Shoes')).toBeInTheDocument();
   });
 
+  it('shows the real pictogram count in the Library tab sub, not a mockup', () => {
+    render(wrap(<PictoPicker onClose={vi.fn()} />));
+    const libraryTab = within(screen.getByRole('tablist')).getByRole('tab', { name: /Library/ });
+    expect(libraryTab).toHaveTextContent(String(SEED_PICTOGRAMS.length));
+    expect(libraryTab).not.toHaveTextContent('1,400');
+  });
+
   it('switches between library, upload, and generate tabs', async () => {
     const user = userEvent.setup();
     render(wrap(<PictoPicker onClose={vi.fn()} />));

--- a/src/features/pictogram-picker/PictoPicker.tsx
+++ b/src/features/pictogram-picker/PictoPicker.tsx
@@ -20,12 +20,6 @@ interface TabDef {
   sub: string;
 }
 
-const TABS: readonly TabDef[] = [
-  { value: 'library', label: 'Library', sub: '1,400+' },
-  { value: 'upload', label: 'Upload', sub: 'Photo / image' },
-  { value: 'ai', label: 'Generate', sub: 'Describe it' },
-];
-
 interface PictoPickerProps {
   onClose: () => void;
   onConfirm?: (selectedIds: readonly string[]) => void;
@@ -38,7 +32,12 @@ export const PictoPicker = ({ onClose, onConfirm }: PictoPickerProps): JSX.Eleme
   const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
   const [query, setQuery] = useState('');
   const [editingVoice, setEditingVoice] = useState<Pictogram | null>(null);
-  const { data: pictograms = [] } = usePictograms();
+  const { data: pictograms = [], isPending } = usePictograms();
+  const tabs: readonly TabDef[] = [
+    { value: 'library', label: 'Library', sub: isPending ? '' : `${pictograms.length}` },
+    { value: 'upload', label: 'Upload', sub: 'Photo / image' },
+    { value: 'ai', label: 'Generate', sub: 'Describe it' },
+  ];
   // Keep the dialog's pictogram in sync with the query cache so `audio_path`
   // updates (record → save, delete) flow through without remounting.
   const editingVoiceLive = editingVoice
@@ -78,7 +77,7 @@ export const PictoPicker = ({ onClose, onConfirm }: PictoPickerProps): JSX.Eleme
         </button>
       </header>
       <div className={styles.tabs} role="tablist">
-        {TABS.map((t) => {
+        {tabs.map((t) => {
           const active = tab === t.value;
           return (
             <button


### PR DESCRIPTION
## Summary
- The Library tab in the Add-pictograms picker displayed a hardcoded `1,400+` mockup string. Replaced it with the actual length of `usePictograms()` data so the user sees the real count of pictograms in their library.
- Sub label is blank while the query is pending (rather than briefly flashing `0`).
- Added a regression test asserting the Library tab shows the seeded count and never `1,400`.

Closes #75.

## Test plan
- [x] `npx vitest run src/features/pictogram-picker/PictoPicker.test.tsx` — 5 passed
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] Full `npx vitest run` — 211 passed