### PR TITLE
docs: SUPABASE_SERVICE_ROLE_KEY is auto-injected, not a manual secret

### DIFF
--- a/docs/runbooks/deploy.md
+++ b/docs/runbooks/deploy.md
@@ -15,41 +15,65 @@ reads them in `.github/workflows/deploy-migrations.yml` and
 | `SUPABASE_DB_PASSWORD` | `deploy-migrations.yml` | dashboard → Project settings → Database |
 | `SUPABASE_PROJECT_REF` | `deploy-migrations.yml`, `deploy-functions.yml` | dashboard → Project settings → General |
 
-## Required edge-function secrets (one-time per project)
+## Edge function default secrets — no manual bootstrap
 
-Edge functions need `SUPABASE_SERVICE_ROLE_KEY` to perform privileged
-operations (notably the `delete-account` function, which uses the admin
-API to delete `auth.users` rows after verifying the caller's JWT).
+Hosted edge functions automatically receive these env vars on every
+invocation, per Supabase's
+[default secrets](https://supabase.com/docs/guides/functions/secrets#default-secrets)
+contract:
 
-This is **not** stored in CI. Set it directly against the Supabase
-project:
+- `SUPABASE_URL`
+- `SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `SUPABASE_DB_URL`
+
+The `delete-account` function reads `SUPABASE_URL` and
+`SUPABASE_SERVICE_ROLE_KEY` from `Deno.env` to construct the admin
+client. **Do not** run `supabase secrets set` for any of these — they
+are managed by Supabase. If the service-role key is rotated in the
+dashboard (Project settings → API → "Reset service_role key"), the
+runtime picks up the new value on the next invocation; no redeploy
+or CLI action on our side.
+
+Custom (non-default) secrets a function might need — e.g., a
+`STRIPE_SECRET_KEY` — go through `supabase secrets set` as documented
+upstream. The `delete-account` function has no custom secrets today.
+
+### Verifying the deployed function is running
+
+Smoke-check the function with no Authorization header. The handler
+returns its closed-set 401 when the JWT is missing or the user is not
+a real user (e.g., when sending the `anon` JWT). A 200 / 401 from our
+own handler proves the runtime resolved env vars and booted; a 500
+suggests the runtime failed to start.
 
 ```sh
-supabase secrets set --project-ref <ref> \
-  SUPABASE_SERVICE_ROLE_KEY=<value>
+APIKEY="$(gh api ... or paste publishable key)"  # safe to share
+USER_JWT="..."                                    # any project JWT works
+curl -sS --max-time 5 -o /dev/null -w 'HTTP %{http_code}\n' \
+  -X POST \
+  -H "apikey: $APIKEY" \
+  -H "Authorization: Bearer $USER_JWT" \
+  -H "Content-Type: application/json" \
+  --data '{}' \
+  "https://<project-ref>.supabase.co/functions/v1/delete-account"
 ```
 
-Source the value from dashboard → Project settings → API → `service_role`
-key. Treat it like a root credential: never commit it, never paste it
-into chat, never set it as a GitHub Actions secret (functions read it
-from Supabase's own secret store, not from CI).
+Expected: `HTTP 401`.
 
-## Rotation procedure for `SUPABASE_SERVICE_ROLE_KEY`
+### Local development
 
-1. Copy the new value from dashboard → Project settings → API.
-2. Push it to Supabase:
-   ```sh
-   supabase secrets set --project-ref <ref> \
-     SUPABASE_SERVICE_ROLE_KEY=<new-value>
-   ```
-3. Functions are stateless. The next invocation picks up the new value;
-   no redeploy is required.
-4. Verify end-to-end by running the delete-account E2E:
-   ```sh
-   npm run test:e2e:delete-account
-   ```
-   Run against staging if available; otherwise run after a manual
-   sign-up against the rotated project.
+`supabase functions serve` does **not** auto-inject default secrets.
+For local invocation, populate `supabase/functions/.env.local` (gitignored)
+with values from `supabase status -o env`:
+
+```
+SUPABASE_URL=http://127.0.0.1:54321
+SUPABASE_SERVICE_ROLE_KEY=<from supabase status>
+```
+
+Then: `supabase functions serve delete-account --env-file supabase/functions/.env.local`.
+This is what `npm run test:e2e:delete-account` and CI both rely on.
 
 ## Manual fallback if workflows are broken
 

--- a/docs/superpowers/plans/2026-04-28-delete-my-account.md
+++ b/docs/superpowers/plans/2026-04-28-delete-my-account.md
@@ -2465,32 +2465,17 @@ GitHub Actions secrets must be set:
 
 Set them with: `gh secret set <NAME> --repo nbhansen/Talrum`
 
-## Required edge-function secrets (one-time per project)
+## Edge function default secrets — no manual bootstrap
 
-The `delete-account` function reads `SUPABASE_SERVICE_ROLE_KEY` from
-`Deno.env`. Set it once per project:
+The `delete-account` function reads `SUPABASE_URL` and
+`SUPABASE_SERVICE_ROLE_KEY` from `Deno.env`. These are part of
+Supabase's [default secrets](https://supabase.com/docs/guides/functions/secrets#default-secrets)
+contract — auto-injected on every hosted invocation. **Do not run
+`supabase secrets set` for any of them.**
 
-```sh
-supabase secrets set --project-ref <project-ref> \
-  SUPABASE_SERVICE_ROLE_KEY=<value-from-dashboard>
-```
-
-The value lives at: Supabase dashboard → Project settings → API →
-service_role key.
-
-**This is a one-shot manual step.** It is not part of CI. If the
-key is rotated (see "Rotation" below), this command must be re-run.
-
-## Rotation: SUPABASE_SERVICE_ROLE_KEY
-
-If the service-role key is rotated:
-
-1. From the Supabase dashboard, copy the new value.
-2. Re-run `supabase secrets set --project-ref <ref> SUPABASE_SERVICE_ROLE_KEY=<new>`.
-3. The next function invocation will pick up the new value (functions
-   are stateless; no redeploy needed).
-4. Verify by triggering the integration test:
-   `npm run test:e2e:delete-account` (against staging if available).
+If the service-role key is rotated in the dashboard (Project settings →
+API → "Reset service_role key"), the runtime picks up the new value on
+the next invocation. No CLI action on our side; no redeploy.
 
 ## Manual fallback
 

--- a/docs/superpowers/specs/2026-04-28-delete-my-account-design.md
+++ b/docs/superpowers/specs/2026-04-28-delete-my-account-design.md
@@ -424,16 +424,8 @@ Triggers on push to `main` for paths under `supabase/functions/**`. Steps:
 Required GH secrets (added to existing list documented in #95):
 - `SUPABASE_ACCESS_TOKEN` (already exists for migrations).
 - `SUPABASE_PROJECT_REF` (already exists).
-- `SUPABASE_SERVICE_ROLE_KEY` — **NEW**. Required by the function at runtime via `Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')`. Set as a function secret via `supabase secrets set`, not as workflow env var. The workflow itself does not read the service-role key.
 
-### Function-secret bootstrap (one-time, documented)
-
-```bash
-supabase secrets set --project-ref <ref> \
-  SUPABASE_SERVICE_ROLE_KEY=<value-from-dashboard>
-```
-
-This is documented in `docs/runbooks/deploy.md` (or extends #95's deploy doc) so a future maintainer can stand it up cold. The workflow does not handle this; it's a manual one-shot per project (prod, future staging).
+The function reads `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` from `Deno.env` at runtime. These are NOT GitHub Actions secrets and they are NOT something we set via `supabase secrets set` — they are part of Supabase's [default secrets](https://supabase.com/docs/guides/functions/secrets#default-secrets) contract, auto-injected on every hosted invocation. No manual bootstrap is required.
 
 ### CI test job extension
 
@@ -526,7 +518,7 @@ Short doc covering operator-side scenarios:
 - **Markdown rendering for `/privacy-policy`.** Repo has no markdown-rendering dependency today. Plan-time decision: pull `react-markdown` (small, well-maintained) vs. ship privacy policy as static HTML. I lean `react-markdown` because the privacy policy will be edited as markdown by humans, but it's a plan decision.
 - **Function deploy authorization.** Confirm `supabase functions deploy` requires `SUPABASE_ACCESS_TOKEN` only and does not need additional secrets beyond what #95 already documents. Verifiable during plan.
 - **pgTAP coverage for FK cascade behavior.** Asserting the constraint exists is cheap. Asserting cascade *behavior* end-to-end (insert auth row, insert app rows, delete auth row, assert app rows gone) is costlier but proves the chain works. Recommend including the behavioral test; final decision in plan.
-- **`SUPABASE_SERVICE_ROLE_KEY` rotation.** Supabase rotates this key on demand; the function reads from `Deno.env`, which is sourced from `supabase secrets`. Document rotation procedure in `docs/runbooks/deploy.md` so a future rotation doesn't silently break the function.
+- **`SUPABASE_SERVICE_ROLE_KEY` rotation.** This is one of Supabase's [default secrets](https://supabase.com/docs/guides/functions/secrets#default-secrets) — auto-injected into every hosted edge-function invocation. If rotated (dashboard → Project settings → API → "Reset service_role key"), the runtime picks up the new value on the next invocation; no `supabase secrets set` action is needed on our side. Document this in `docs/runbooks/deploy.md` so a future maintainer doesn't try to manage it manually.
 
 ---
 


### PR DESCRIPTION
Post-merge correction to PR #100 (#112).

## Problem

The runbook (\`docs/runbooks/deploy.md\`) and the spec/plan claimed operators must run \`supabase secrets set SUPABASE_SERVICE_ROLE_KEY=...\` once per project to make the \`delete-account\` edge function work. That was wrong.

\`SUPABASE_SERVICE_ROLE_KEY\` is one of Supabase's [default secrets](https://supabase.com/docs/guides/functions/secrets#default-secrets) — auto-injected into every hosted edge-function invocation. The runbook claim originated from training-data recollection, not from the official docs.

## Verification

Empirical: after PR #112 merged, hitting the deployed function with no manual \`secrets set\` step returned our own \`{\"ok\":false,\"error\":\"unauthorized\",\"message\":\"missing or invalid JWT\"}\` — proving the runtime resolved both \`SUPABASE_URL\` and \`SUPABASE_SERVICE_ROLE_KEY\` from default injection.

Authoritative: https://supabase.com/docs/guides/functions/secrets#default-secrets.

## Changes (docs only)

- \`docs/runbooks/deploy.md\` — replaced the \"Required edge-function secrets (one-time per project)\" + \"Rotation procedure\" sections with \"Edge function default secrets — no manual bootstrap\". Kept the local-dev \`.env.local\` guidance (locally \`supabase functions serve\` does NOT auto-inject defaults). Added a smoke-test recipe.
- \`docs/superpowers/specs/2026-04-28-delete-my-account-design.md\` — removed the function-secret bootstrap subsection; corrected the rotation note.
- \`docs/superpowers/plans/2026-04-28-delete-my-account.md\` — same correction in the runbook task.

## Code

Unchanged. \`Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')\` in \`supabase/functions/delete-account/index.ts\` is correct per the docs and works in production today.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run test\` clean (251/251)
- [x] No code changes; CI \`verify\` should pass identically to PR #112.