### PR TITLE
ci: bump GitHub Actions to Node 24 runtimes (#94)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - run: npm run typecheck
@@ -23,7 +23,7 @@ jobs:
         with:
           deno-version: v2.x
       - run: npm run test:functions
-      - uses: supabase/setup-cli@v1
+      - uses: supabase/setup-cli@v2
         with:
           version: latest
       - run: supabase start

--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -15,8 +15,8 @@ jobs:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: supabase/setup-cli@v1
+      - uses: actions/checkout@v6
+      - uses: supabase/setup-cli@v2
         with:
           version: latest
       - run: supabase functions deploy delete-account --project-ref "$PROJECT_REF"

--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -17,8 +17,8 @@ jobs:
       SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
       PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: supabase/setup-cli@v1
+      - uses: actions/checkout@v6
+      - uses: supabase/setup-cli@v2
         with:
           version: latest
       - run: supabase link --project-ref "$PROJECT_REF"


### PR DESCRIPTION
Closes #94.

## Why

GitHub flips the runner default to Node 24 on 2026-06-02 and removes
Node 20 entirely on 2026-09-16. The 2026-04-26 `deploy-migrations`
run printed the deprecation warning. Bumping now keeps it from
becoming an emergency in June.

User constraint: latest stable Node, no backwards-compat shims.

## What changed (7 lines across 3 workflows)

| Action | Before | After | Runtime |
|---|---|---|---|
| `actions/checkout` | `@v4` | `@v6` | Node 24 |
| `actions/setup-node` | `@v4` | `@v6` | Node 24 |
| `supabase/setup-cli` | `@v1` | `@v2` | composite |
| `denoland/setup-deno` | `@v2` | `@v2` (unchanged) | Node 24 (already) |

Also: `node-version: '22' -> '24'` in `ci.yml` to match the runner
default.

## Verification

- CI on this PR exercises typecheck, lint, vitest, deno tests,
  `supabase start` + pgTAP, and the e2e edge-function shell test
  under the new pins.
- Confirm there's no "Node.js 20 actions are deprecated" warning in
  the CI run logs.
- Squash-merging will edit both `deploy-migrations.yml` and
  `deploy-functions.yml`, both of which path-filter on themselves -
  so the cloud-side `supabase link` / `db push` / `functions deploy`
  paths run end-to-end under `setup-cli@v2` immediately on merge.
- If the cloud workflows fail on `setup-cli@v2`, revert is one pin
  flip back to `@v1`.