### PR TITLE
Extract EmptyState primitive (#73)

### DIFF
--- a/src/features/kids/Kids.module.css
+++ b/src/features/kids/Kids.module.css
@@ -21,32 +21,3 @@
   font-weight: 700;
   color: var(--tal-ink);
 }
-
-.emptyState {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  gap: 14px;
-  padding: 60px 32px;
-  margin-top: 8px;
-  border: 2px dashed var(--tal-line);
-  border-radius: var(--tal-r-lg);
-  background: var(--tal-surface-alt);
-}
-
-.emptyTitle {
-  margin: 0;
-  font-size: 22px;
-  font-weight: 800;
-  color: var(--tal-ink);
-}
-
-.emptyBody {
-  margin: 0;
-  max-width: 420px;
-  font-size: 14px;
-  line-height: 1.5;
-  color: var(--tal-ink-soft);
-}

--- a/src/features/kids/Kids.tsx
+++ b/src/features/kids/Kids.tsx
@@ -2,6 +2,7 @@ import type { JSX } from 'react';
 
 import { useKids } from '@/lib/queries/kids';
 import { Button } from '@/ui/Button/Button';
+import { EmptyState } from '@/ui/EmptyState/EmptyState';
 import { PlusIcon } from '@/ui/icons';
 
 import styles from './Kids.module.css';
@@ -15,15 +16,15 @@ export const Kids = ({ onNewKid }: KidsProps): JSX.Element => {
 
   if (kids.length === 0) {
     return (
-      <div className={styles.emptyState} role="status">
-        <h2 className={styles.emptyTitle}>No kids yet</h2>
-        <p className={styles.emptyBody}>
-          Add a kid to start creating boards for them. Each kid has their own boards.
-        </p>
-        <Button variant="primary" icon={<PlusIcon />} onClick={onNewKid}>
-          Add your first kid
-        </Button>
-      </div>
+      <EmptyState
+        title="No kids yet"
+        body="Add a kid to start creating boards for them. Each kid has their own boards."
+        action={
+          <Button variant="primary" icon={<PlusIcon />} onClick={onNewKid}>
+            Add your first kid
+          </Button>
+        }
+      />
     );
   }
 

--- a/src/features/library/Library.module.css
+++ b/src/features/library/Library.module.css
@@ -4,32 +4,3 @@
   gap: 20px;
   margin-top: 8px;
 }
-
-.emptyState {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  gap: 14px;
-  padding: 60px 32px;
-  margin-top: 8px;
-  border: 2px dashed var(--tal-line);
-  border-radius: var(--tal-r-lg);
-  background: var(--tal-surface-alt);
-}
-
-.emptyTitle {
-  margin: 0;
-  font-size: 22px;
-  font-weight: 800;
-  color: var(--tal-ink);
-}
-
-.emptyBody {
-  margin: 0;
-  max-width: 420px;
-  font-size: 14px;
-  line-height: 1.5;
-  color: var(--tal-ink-soft);
-}

--- a/src/features/library/Library.tsx
+++ b/src/features/library/Library.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from 'react';
 
 import { usePictograms } from '@/lib/queries/pictograms';
+import { EmptyState } from '@/ui/EmptyState/EmptyState';
 import { PictoCard } from '@/ui/PictoTile/PictoCard';
 
 import styles from './Library.module.css';
@@ -10,12 +11,10 @@ export const Library = (): JSX.Element => {
 
   if (pictograms.length === 0) {
     return (
-      <div className={styles.emptyState} role="status">
-        <h2 className={styles.emptyTitle}>No pictograms yet</h2>
-        <p className={styles.emptyBody}>
-          Pictograms you upload, generate, or pick from the library will show up here.
-        </p>
-      </div>
+      <EmptyState
+        title="No pictograms yet"
+        body="Pictograms you upload, generate, or pick from the library will show up here."
+      />
     );
   }
 

--- a/src/features/parent-home/ParentHome.module.css
+++ b/src/features/parent-home/ParentHome.module.css
@@ -36,35 +36,6 @@
   color: var(--tal-ink-soft);
 }
 
-.emptyState {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  gap: 14px;
-  padding: 60px 32px;
-  margin-top: 8px;
-  border: 2px dashed var(--tal-line);
-  border-radius: var(--tal-r-lg);
-  background: var(--tal-surface-alt);
-}
-
-.emptyTitle {
-  margin: 0;
-  font-size: 22px;
-  font-weight: 800;
-  color: var(--tal-ink);
-}
-
-.emptyBody {
-  margin: 0;
-  max-width: 420px;
-  font-size: 14px;
-  line-height: 1.5;
-  color: var(--tal-ink-soft);
-}
-
 .recent {
   margin-top: 36px;
 }

--- a/src/features/parent-home/ParentHome.tsx
+++ b/src/features/parent-home/ParentHome.tsx
@@ -4,6 +4,7 @@ import { type ParentNavKey, ParentShell } from '@/layouts/ParentShell';
 import { useBoards } from '@/lib/queries/boards';
 import { usePictogramsBySlug } from '@/lib/queries/pictograms';
 import { Button } from '@/ui/Button/Button';
+import { EmptyState } from '@/ui/EmptyState/EmptyState';
 import { PlusIcon } from '@/ui/icons';
 import { PictoTile } from '@/ui/PictoTile/PictoTile';
 
@@ -66,16 +67,15 @@ export const ParentHome = ({
       }
     >
       {noBoards ? (
-        <div className={styles.emptyState} role="status">
-          <h2 className={styles.emptyTitle}>No boards yet</h2>
-          <p className={styles.emptyBody}>
-            Create your first board to start communicating. You can add steps and tweak settings
-            after.
-          </p>
-          <Button variant="primary" icon={<PlusIcon />} onClick={onNewBoard}>
-            Create your first board
-          </Button>
-        </div>
+        <EmptyState
+          title="No boards yet"
+          body="Create your first board to start communicating. You can add steps and tweak settings after."
+          action={
+            <Button variant="primary" icon={<PlusIcon />} onClick={onNewBoard}>
+              Create your first board
+            </Button>
+          }
+        />
       ) : (
         <div className={styles.grid}>
           {boards.map((b) => (

--- a/src/ui/EmptyState/EmptyState.module.css
+++ b/src/ui/EmptyState/EmptyState.module.css
@@ -1,0 +1,28 @@
+.wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 14px;
+  padding: 60px 32px;
+  margin-top: 8px;
+  border: 2px dashed var(--tal-line);
+  border-radius: var(--tal-r-lg);
+  background: var(--tal-surface-alt);
+}
+
+.title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--tal-ink);
+}
+
+.body {
+  margin: 0;
+  max-width: 420px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--tal-ink-soft);
+}

--- a/src/ui/EmptyState/EmptyState.test.tsx
+++ b/src/ui/EmptyState/EmptyState.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { EmptyState } from './EmptyState';
+
+describe('EmptyState', () => {
+  it('renders title and body with role=status', () => {
+    render(<EmptyState title="No boards yet" body="Create your first board." />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /no boards yet/i })).toBeInTheDocument();
+    expect(screen.getByText(/create your first board/i)).toBeInTheDocument();
+  });
+
+  it('renders an action when provided', () => {
+    render(
+      <EmptyState
+        title="No kids yet"
+        body="Add a kid to get started."
+        action={<button type="button">Add</button>}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /add/i })).toBeInTheDocument();
+  });
+});

--- a/src/ui/EmptyState/EmptyState.tsx
+++ b/src/ui/EmptyState/EmptyState.tsx
@@ -1,0 +1,17 @@
+import type { JSX, ReactNode } from 'react';
+
+import styles from './EmptyState.module.css';
+
+interface EmptyStateProps {
+  title: string;
+  body: string;
+  action?: ReactNode;
+}
+
+export const EmptyState = ({ title, body, action }: EmptyStateProps): JSX.Element => (
+  <div className={styles.wrap} role="status">
+    <h2 className={styles.title}>{title}</h2>
+    <p className={styles.body}>{body}</p>
+    {action}
+  </div>
+);


### PR DESCRIPTION
## Summary
- Three feature surfaces (ParentHome, Library, Kids) rendered byte-identical empty-state cards with copy-pasted CSS.
- New `<EmptyState title body action?>` primitive in `src/ui/EmptyState/`, role=status by default.
- Net -87 CSS lines; single source of truth for the empty-state visual.

This is PR α of a 5-PR CSS makeover (also covers Buckets B/C/D/E from the audit).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` for EmptyState, Library, Kids, ParentHomeRoute (28 tests pass)
- [ ] Manual: visit /, /library, /kids on a fresh account — empty states render identically to before

Closes #73.