### PR TITLE
Define --tal-coral / --tal-coral-ink tokens

### DIFF
--- a/src/theme/tokens.module.css
+++ b/src/theme/tokens.module.css
@@ -29,6 +29,8 @@
   --tal-lavender-ink: oklch(42% 0.06 300);
   --tal-sun: oklch(90% 0.06 90);
   --tal-sun-ink: oklch(42% 0.06 90);
+  --tal-coral: oklch(86% 0.05 25);
+  --tal-coral-ink: oklch(42% 0.06 25);
 
   /* Glyph line + fill (shared across all illustrated pictograms) */
   --tal-glyph-stroke: oklch(30% 0.03 260);


### PR DESCRIPTION
## Summary
- Seven CSS rules across login, three modals, and the upload tab use `var(--tal-coral, ...)` / `var(--tal-coral-ink, ...)` for error styling — but neither token was defined.
- Errors currently render as `--tal-ink` (regular copy color), so users can't tell error messages apart from normal text.
- This PR adds both tokens to the accents block. No CSS file edits needed; existing consumers auto-pick up the new values via their fallback expressions.

PR β of the CSS makeover (after #116).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` — 253/253 pass
- [ ] Manual: trigger an error in NewKidModal / NewBoardModal / Login (e.g. submit with invalid input or simulate RLS denial) — error text should now read coral-ink, not regular ink