### PR TITLE
Extract DialogHeader / DialogActions / TextField primitives

### DIFF
--- a/src/features/board-builder/ShareModal.module.css
+++ b/src/features/board-builder/ShareModal.module.css
@@ -5,41 +5,6 @@
   margin: 0 auto;
 }
 
-.header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 18px;
-}
-
-.title {
-  font-size: 22px;
-  font-weight: 800;
-  color: var(--tal-ink);
-  margin: 0 0 2px;
-}
-
-.subtitle {
-  font-size: 13px;
-  color: var(--tal-ink-muted);
-  margin: 0;
-}
-
-.closeBtn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  border-radius: 999px;
-  background: transparent;
-  color: var(--tal-ink-soft);
-  border: none;
-  cursor: pointer;
-  flex-shrink: 0;
-}
-
 .section {
   border-top: 1px solid var(--tal-line-soft);
   padding: 16px 0;
@@ -185,5 +150,5 @@
 .error {
   margin: 8px 0 0;
   font-size: 13px;
-  color: var(--tal-coral-ink, var(--tal-ink));
+  color: var(--tal-coral-ink);
 }

--- a/src/features/board-builder/ShareModal.tsx
+++ b/src/features/board-builder/ShareModal.tsx
@@ -8,6 +8,7 @@ import {
   useBoardMembers,
   useRemoveBoardMember,
 } from '@/lib/queries/board-members';
+import { DialogHeader } from '@/ui/DialogHeader/DialogHeader';
 import { XIcon } from '@/ui/icons';
 import { Modal } from '@/ui/Modal/Modal';
 
@@ -108,20 +109,12 @@ export const ShareModal = ({ boardId, isOwner, onClose }: ShareModalProps): JSX.
   return (
     <Modal onClose={onClose} labelledBy={TITLE_ID}>
       <div className={styles.wrap}>
-        <header className={styles.header}>
-          <div>
-            <h2 id={TITLE_ID} className={styles.title}>
-              Share this board
-            </h2>
-            <p className={styles.subtitle}>
-              People you share with see this board on their own iPad. They can't make changes.
-            </p>
-          </div>
-          <button type="button" onClick={onClose} aria-label="Close" className={styles.closeBtn}>
-            <XIcon size={18} />
-          </button>
-        </header>
-
+        <DialogHeader
+          title="Share this board"
+          subtitle="People you share with see this board on their own iPad. They can't make changes."
+          titleId={TITLE_ID}
+          onClose={onClose}
+        />
         <section className={styles.section}>
           <span className={styles.sectionLabel}>Your sharing ID</span>
           <div className={styles.idRow}>

--- a/src/features/login/Login.module.css
+++ b/src/features/login/Login.module.css
@@ -53,38 +53,6 @@
   gap: 16px;
 }
 
-.field {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.fieldLabel {
-  font-size: 12px;
-  font-weight: 700;
-  color: var(--tal-ink-soft);
-  letter-spacing: 0.4px;
-  text-transform: uppercase;
-}
-
-.input {
-  font: inherit;
-  padding: 12px 14px;
-  border: 1px solid var(--tal-line);
-  border-radius: var(--tal-r-md);
-  background: var(--tal-bg);
-  color: var(--tal-ink);
-  transition:
-    border-color 120ms ease,
-    box-shadow 120ms ease;
-}
-
-.input:focus {
-  outline: none;
-  border-color: var(--tal-sky-ink);
-  box-shadow: 0 0 0 3px var(--tal-sky);
-}
-
 .otp {
   font-size: 24px;
   letter-spacing: 10px;
@@ -109,8 +77,8 @@
 
 .error {
   font-size: 13px;
-  color: var(--tal-coral-ink, var(--tal-ink));
-  background: var(--tal-coral, var(--tal-surface-alt));
+  color: var(--tal-coral-ink);
+  background: var(--tal-coral);
   padding: 8px 12px;
   border-radius: var(--tal-r-md);
 }

--- a/src/features/login/Login.tsx
+++ b/src/features/login/Login.tsx
@@ -4,6 +4,7 @@ import talrumLogo from '@/assets/talrum-logo.png';
 import { supabase } from '@/lib/supabase';
 import { useOnline } from '@/lib/useOnline';
 import { Button } from '@/ui/Button/Button';
+import { TextField } from '@/ui/TextField/TextField';
 
 import styles from './Login.module.css';
 
@@ -75,20 +76,17 @@ export const Login = (): JSX.Element => {
         )}
         {stage === 'email' ? (
           <form className={styles.form} onSubmit={(e) => void sendCode(e)}>
-            <label className={styles.field}>
-              <span className={styles.fieldLabel}>Email</span>
-              <input
-                type="email"
-                name="email"
-                required
-                autoFocus
-                autoComplete="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                className={styles.input}
-                placeholder="parent@example.com"
-              />
-            </label>
+            <TextField
+              label="Email"
+              type="email"
+              name="email"
+              required
+              autoFocus
+              autoComplete="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="parent@example.com"
+            />
             {error && <div className={styles.error}>{error}</div>}
             <Button type="submit" variant="primary" disabled={busy || !email.trim() || !online}>
               {busy ? 'Sending…' : 'Send code'}
@@ -99,23 +97,21 @@ export const Login = (): JSX.Element => {
             <div className={styles.hint}>
               Code sent to <strong>{email}</strong>. Check your email (or Inbucket in dev).
             </div>
-            <label className={styles.field}>
-              <span className={styles.fieldLabel}>Code</span>
-              <input
-                type="text"
-                name="otp"
-                required
-                autoFocus
-                autoComplete="one-time-code"
-                inputMode="numeric"
-                pattern="[0-9]*"
-                maxLength={6}
-                value={code}
-                onChange={(e) => setCode(e.target.value.replace(/\D/g, ''))}
-                className={`${styles.input} ${styles.otp}`}
-                placeholder="••••••"
-              />
-            </label>
+            <TextField
+              label="Code"
+              type="text"
+              name="otp"
+              required
+              autoFocus
+              autoComplete="one-time-code"
+              inputMode="numeric"
+              pattern="[0-9]*"
+              maxLength={6}
+              value={code}
+              onChange={(e) => setCode(e.target.value.replace(/\D/g, ''))}
+              placeholder="••••••"
+              inputClassName={styles.otp}
+            />
             {error && <div className={styles.error}>{error}</div>}
             <div className={styles.row}>
               <Button

--- a/src/features/parent-home/NewBoardModal.module.css
+++ b/src/features/parent-home/NewBoardModal.module.css
@@ -5,46 +5,22 @@
   margin: 0 auto;
 }
 
-.header {
+.form {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
+  flex-direction: column;
   gap: 16px;
-  margin-bottom: 18px;
-}
-
-.title {
-  font-size: 22px;
-  font-weight: 800;
-  color: var(--tal-ink);
-  margin: 0 0 2px;
-}
-
-.subtitle {
-  font-size: 13px;
-  color: var(--tal-ink-muted);
+  border: 0;
+  padding: 0;
   margin: 0;
-}
-
-.closeBtn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  border-radius: 999px;
-  background: transparent;
-  color: var(--tal-ink-soft);
-  border: none;
-  cursor: pointer;
-  flex-shrink: 0;
 }
 
 .field {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  margin-bottom: 16px;
+  border: 0;
+  padding: 0;
+  margin: 0;
 }
 
 .fieldLabel {
@@ -56,6 +32,7 @@
 }
 
 .input {
+  font: inherit;
   font-size: 15px;
   padding: 10px 12px;
   border: 1px solid var(--tal-line);
@@ -63,14 +40,24 @@
   background: var(--tal-surface);
   color: var(--tal-ink);
   outline: none;
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease;
 }
 
 .input:focus {
-  border-color: var(--tal-ink-soft);
+  border-color: var(--tal-sky-ink);
+  box-shadow: 0 0 0 3px var(--tal-sky);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .input {
+    transition: none;
+  }
 }
 
 .kindGroup {
-  display: flex;
+  flex-direction: row;
   gap: 8px;
 }
 
@@ -98,21 +85,14 @@
   margin: 0;
 }
 
-.actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-  margin-top: 20px;
-}
-
 .error {
-  margin: 8px 0 0;
+  margin: 0;
   font-size: 13px;
-  color: var(--tal-coral-ink, var(--tal-ink));
+  color: var(--tal-coral-ink);
 }
 
 .noKids {
   font-size: 14px;
   color: var(--tal-ink-muted);
-  margin: 0 0 12px;
+  margin: 0;
 }

--- a/src/features/parent-home/NewBoardModal.tsx
+++ b/src/features/parent-home/NewBoardModal.tsx
@@ -4,8 +4,10 @@ import { useCreateBoard } from '@/lib/queries/boards';
 import { useKids } from '@/lib/queries/kids';
 import type { BoardKind } from '@/types/domain';
 import { Button } from '@/ui/Button/Button';
-import { XIcon } from '@/ui/icons';
+import { DialogActions } from '@/ui/DialogActions/DialogActions';
+import { DialogHeader } from '@/ui/DialogHeader/DialogHeader';
 import { Modal } from '@/ui/Modal/Modal';
+import { TextField } from '@/ui/TextField/TextField';
 
 import styles from './NewBoardModal.module.css';
 
@@ -62,41 +64,30 @@ export const NewBoardModal = ({ onClose, onCreated }: NewBoardModalProps): JSX.E
   return (
     <Modal onClose={onClose} labelledBy={TITLE_ID}>
       <div className={styles.wrap}>
-        <header className={styles.header}>
-          <div>
-            <h2 id={TITLE_ID} className={styles.title}>
-              New board
-            </h2>
-            <p className={styles.subtitle}>
-              You can add steps and tweak settings after the board is created.
-            </p>
-          </div>
-          <button type="button" onClick={onClose} aria-label="Close" className={styles.closeBtn}>
-            <XIcon size={18} />
-          </button>
-        </header>
-
-        <form onSubmit={submit}>
+        <DialogHeader
+          title="New board"
+          subtitle="You can add steps and tweak settings after the board is created."
+          titleId={TITLE_ID}
+          onClose={onClose}
+        />
+        <form onSubmit={submit} className={styles.form}>
           {noKids && (
             <p className={styles.noKids}>Add a kid first — boards need a kid to belong to.</p>
           )}
 
-          <label className={styles.field}>
-            <span className={styles.fieldLabel}>Name</span>
-            <input
-              type="text"
-              autoFocus
-              autoComplete="off"
-              value={name}
-              onChange={(e) => {
-                setName(e.target.value);
-                if (error) setError(null);
-              }}
-              className={styles.input}
-              placeholder="Morning routine"
-              disabled={noKids}
-            />
-          </label>
+          <TextField
+            label="Name"
+            type="text"
+            autoFocus
+            autoComplete="off"
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value);
+              if (error) setError(null);
+            }}
+            placeholder="Morning routine"
+            disabled={noKids}
+          />
 
           <fieldset className={`${styles.field} ${styles.kindGroup}`}>
             {KIND_OPTIONS.map((opt) => {
@@ -144,7 +135,7 @@ export const NewBoardModal = ({ onClose, onCreated }: NewBoardModalProps): JSX.E
             </p>
           )}
 
-          <div className={styles.actions}>
+          <DialogActions>
             <Button
               type="button"
               variant="ghost"
@@ -156,7 +147,7 @@ export const NewBoardModal = ({ onClose, onCreated }: NewBoardModalProps): JSX.E
             <Button type="submit" variant="primary" disabled={submitDisabled}>
               {createBoard.isPending ? 'Saving…' : 'Save'}
             </Button>
-          </div>
+          </DialogActions>
         </form>
       </div>
     </Modal>

--- a/src/ui/DialogActions/DialogActions.module.css
+++ b/src/ui/DialogActions/DialogActions.module.css
@@ -1,0 +1,6 @@
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 20px;
+}

--- a/src/ui/DialogActions/DialogActions.tsx
+++ b/src/ui/DialogActions/DialogActions.tsx
@@ -1,0 +1,11 @@
+import type { JSX, ReactNode } from 'react';
+
+import styles from './DialogActions.module.css';
+
+interface DialogActionsProps {
+  children: ReactNode;
+}
+
+export const DialogActions = ({ children }: DialogActionsProps): JSX.Element => (
+  <div className={styles.actions}>{children}</div>
+);

--- a/src/ui/DialogHeader/DialogHeader.module.css
+++ b/src/ui/DialogHeader/DialogHeader.module.css
@@ -1,0 +1,34 @@
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.title {
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--tal-ink);
+  margin: 0 0 2px;
+}
+
+.subtitle {
+  font-size: 13px;
+  color: var(--tal-ink-muted);
+  margin: 0;
+}
+
+.closeBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--tal-ink-soft);
+  border: none;
+  cursor: pointer;
+  flex-shrink: 0;
+}

--- a/src/ui/DialogHeader/DialogHeader.test.tsx
+++ b/src/ui/DialogHeader/DialogHeader.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DialogHeader } from './DialogHeader';
+
+describe('DialogHeader', () => {
+  it('renders title and subtitle and wires the close button', async () => {
+    const onClose = vi.fn();
+    render(
+      <DialogHeader
+        title="Add a kid"
+        subtitle="Each kid has their own boards."
+        titleId="t1"
+        onClose={onClose}
+      />,
+    );
+    expect(screen.getByRole('heading', { name: /add a kid/i })).toHaveAttribute('id', 't1');
+    expect(screen.getByText(/each kid has their own boards/i)).toBeInTheDocument();
+    await userEvent.setup().click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits subtitle when not provided', () => {
+    const noop = vi.fn();
+    render(<DialogHeader title="Plain" titleId="t2" onClose={noop} />);
+    expect(screen.getByRole('heading', { name: /plain/i })).toBeInTheDocument();
+    expect(screen.queryByText(/each kid/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/ui/DialogHeader/DialogHeader.tsx
+++ b/src/ui/DialogHeader/DialogHeader.tsx
@@ -1,0 +1,31 @@
+import type { JSX } from 'react';
+
+import { XIcon } from '@/ui/icons';
+
+import styles from './DialogHeader.module.css';
+
+interface DialogHeaderProps {
+  title: string;
+  subtitle?: string;
+  titleId: string;
+  onClose: () => void;
+}
+
+export const DialogHeader = ({
+  title,
+  subtitle,
+  titleId,
+  onClose,
+}: DialogHeaderProps): JSX.Element => (
+  <header className={styles.header}>
+    <div>
+      <h2 id={titleId} className={styles.title}>
+        {title}
+      </h2>
+      {subtitle && <p className={styles.subtitle}>{subtitle}</p>}
+    </div>
+    <button type="button" onClick={onClose} aria-label="Close" className={styles.closeBtn}>
+      <XIcon size={18} />
+    </button>
+  </header>
+);

--- a/src/ui/NewKidModal/NewKidModal.module.css
+++ b/src/ui/NewKidModal/NewKidModal.module.css
@@ -5,78 +5,8 @@
   margin: 0 auto;
 }
 
-.header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 18px;
-}
-
-.title {
-  font-size: 22px;
-  font-weight: 800;
-  color: var(--tal-ink);
-  margin: 0 0 2px;
-}
-
-.subtitle {
-  font-size: 13px;
-  color: var(--tal-ink-muted);
-  margin: 0;
-}
-
-.closeBtn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  border-radius: 999px;
-  background: transparent;
-  color: var(--tal-ink-soft);
-  border: none;
-  cursor: pointer;
-  flex-shrink: 0;
-}
-
-.field {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.fieldLabel {
-  font-size: 12px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: var(--tal-ink-muted);
-}
-
-.input {
-  font-size: 15px;
-  padding: 10px 12px;
-  border: 1px solid var(--tal-line);
-  border-radius: var(--tal-r-md);
-  background: var(--tal-surface);
-  color: var(--tal-ink);
-  outline: none;
-}
-
-.input:focus {
-  border-color: var(--tal-ink-soft);
-}
-
-.actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-  margin-top: 20px;
-}
-
 .error {
   margin: 8px 0 0;
   font-size: 13px;
-  color: var(--tal-coral-ink, var(--tal-ink));
+  color: var(--tal-coral-ink);
 }

--- a/src/ui/NewKidModal/NewKidModal.tsx
+++ b/src/ui/NewKidModal/NewKidModal.tsx
@@ -2,8 +2,10 @@ import { type FormEvent, type JSX, useState } from 'react';
 
 import { useCreateKid } from '@/lib/queries/kids';
 import { Button } from '@/ui/Button/Button';
-import { XIcon } from '@/ui/icons';
+import { DialogActions } from '@/ui/DialogActions/DialogActions';
+import { DialogHeader } from '@/ui/DialogHeader/DialogHeader';
 import { Modal } from '@/ui/Modal/Modal';
+import { TextField } from '@/ui/TextField/TextField';
 
 import styles from './NewKidModal.module.css';
 
@@ -37,49 +39,38 @@ export const NewKidModal = ({ onClose }: NewKidModalProps): JSX.Element => {
   return (
     <Modal onClose={onClose} labelledBy={TITLE_ID}>
       <div className={styles.wrap}>
-        <header className={styles.header}>
-          <div>
-            <h2 id={TITLE_ID} className={styles.title}>
-              Add a kid
-            </h2>
-            <p className={styles.subtitle}>
-              Each kid has their own boards. You can add more later.
-            </p>
-          </div>
-          <button type="button" onClick={onClose} aria-label="Close" className={styles.closeBtn}>
-            <XIcon size={18} />
-          </button>
-        </header>
-
+        <DialogHeader
+          title="Add a kid"
+          subtitle="Each kid has their own boards. You can add more later."
+          titleId={TITLE_ID}
+          onClose={onClose}
+        />
         <form onSubmit={submit}>
-          <label className={styles.field}>
-            <span className={styles.fieldLabel}>Name</span>
-            <input
-              type="text"
-              autoFocus
-              autoComplete="off"
-              value={name}
-              onChange={(e) => {
-                setName(e.target.value);
-                if (error) setError(null);
-              }}
-              className={styles.input}
-              placeholder="Liam"
-            />
-          </label>
+          <TextField
+            label="Name"
+            type="text"
+            autoFocus
+            autoComplete="off"
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value);
+              if (error) setError(null);
+            }}
+            placeholder="Liam"
+          />
           {error && (
             <p role="alert" className={styles.error}>
               {error}
             </p>
           )}
-          <div className={styles.actions}>
+          <DialogActions>
             <Button type="button" variant="ghost" onClick={onClose} disabled={createKid.isPending}>
               Cancel
             </Button>
             <Button type="submit" variant="primary" disabled={submitDisabled}>
               {createKid.isPending ? 'Saving…' : 'Save'}
             </Button>
-          </div>
+          </DialogActions>
         </form>
       </div>
     </Modal>

--- a/src/ui/TextField/TextField.module.css
+++ b/src/ui/TextField/TextField.module.css
@@ -1,0 +1,38 @@
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.label {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--tal-ink-muted);
+}
+
+.input {
+  font: inherit;
+  font-size: 15px;
+  padding: 10px 12px;
+  border: 1px solid var(--tal-line);
+  border-radius: var(--tal-r-md);
+  background: var(--tal-surface);
+  color: var(--tal-ink);
+  outline: none;
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.input:focus {
+  border-color: var(--tal-sky-ink);
+  box-shadow: 0 0 0 3px var(--tal-sky);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .input {
+    transition: none;
+  }
+}

--- a/src/ui/TextField/TextField.test.tsx
+++ b/src/ui/TextField/TextField.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TextField } from './TextField';
+
+describe('TextField', () => {
+  it('renders label associated with the input', async () => {
+    render(<TextField label="Name" placeholder="Liam" />);
+    expect(screen.getByLabelText('Name')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Liam')).toBeInTheDocument();
+  });
+
+  it('forwards onChange and value', async () => {
+    const onChange = vi.fn();
+    render(<TextField label="Name" value="" onChange={onChange} />);
+    await userEvent.setup().type(screen.getByLabelText('Name'), 'a');
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/src/ui/TextField/TextField.tsx
+++ b/src/ui/TextField/TextField.tsx
@@ -1,0 +1,22 @@
+import { forwardRef, type InputHTMLAttributes } from 'react';
+
+import styles from './TextField.module.css';
+
+interface TextFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'className'> {
+  label: string;
+  inputClassName?: string | undefined;
+}
+
+export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
+  ({ label, inputClassName, ...inputProps }, ref) => (
+    <label className={styles.field}>
+      <span className={styles.label}>{label}</span>
+      <input
+        ref={ref}
+        {...inputProps}
+        className={inputClassName ? `${styles.input} ${inputClassName}` : styles.input}
+      />
+    </label>
+  ),
+);
+TextField.displayName = 'TextField';


### PR DESCRIPTION
## Summary
- 3 modals (`NewKidModal`, `NewBoardModal`, `ShareModal`) plus the `Login` form shared byte-identical CSS rule bodies for the title bar, close button, action row, and labeled input.
- New primitives in \`src/ui/\`: \`DialogHeader\`, \`DialogActions\`, \`TextField\` (with accessible focus ring + reduced-motion guard).
- Net **-186** lines of duplicated CSS/JSX. New modals now compose 3 primitives rather than copy-paste.
- Side effect: modal text inputs gain Login's accessible blue focus ring — better default for keyboard users.

PR γ of the CSS makeover (after #116, #118).

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm test\` — 257/257 (49 files)
- [ ] Manual: open NewKidModal / NewBoardModal / ShareModal — title, subtitle, close button render identically; tab focus shows visible blue outline on inputs
- [ ] Manual: Login email + OTP inputs still work; OTP keeps its big-letter-spaced styling (passed via \`inputClassName\`)