### PR TITLE
Extract Spinner primitive

### DIFF
--- a/src/app/AuthGate.module.css
+++ b/src/app/AuthGate.module.css
@@ -24,27 +24,6 @@
   margin: 0;
 }
 
-.spinner {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  border: 3px solid var(--tal-line);
-  border-top-color: var(--tal-sage);
-  animation: tal-auth-spin 0.9s linear infinite;
-}
-
-@keyframes tal-auth-spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .spinner {
-    animation-duration: 2.5s;
-  }
-}
-
 .errorTitle {
   font-size: 24px;
   font-weight: 800;

--- a/src/app/AuthGate.tsx
+++ b/src/app/AuthGate.tsx
@@ -5,6 +5,7 @@ import { Login } from '@/features/login/Login';
 import { clearPersistedCache } from '@/lib/queryClient';
 import { supabase } from '@/lib/supabase';
 import { useOnline } from '@/lib/useOnline';
+import { Spinner } from '@/ui/Spinner/Spinner';
 
 import styles from './AuthGate.module.css';
 import { SessionProvider } from './SessionProvider';
@@ -118,7 +119,7 @@ const AuthGateLoading = ({ onRetry }: { onRetry: () => void }): JSX.Element => {
   }
   return (
     <div className={`tal ${styles.loading}`}>
-      <div className={styles.spinner} aria-hidden="true" />
+      <Spinner />
       <p className={styles.loadingBody}>Loading…</p>
     </div>
   );

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -4,6 +4,7 @@ import { createBrowserRouter, Link, Navigate } from 'react-router-dom';
 import { queryClient } from '@/lib/queryClient';
 import { ErrorBoundary } from '@/ui/ErrorBoundary/ErrorBoundary';
 import styles from '@/ui/ErrorBoundary/ErrorBoundary.module.css';
+import { Spinner } from '@/ui/Spinner/Spinner';
 
 const ParentHomeRoute = lazy(() =>
   import('@/features/parent-home/ParentHomeRoute').then((m) => ({ default: m.ParentHomeRoute })),
@@ -77,7 +78,7 @@ export const kidRouteFallback = (): ReactNode => (
 
 const parentSuspenseFallback = (
   <div className={`tal ${styles.parentSuspense}`}>
-    <div className={styles.spinner} aria-hidden="true" />
+    <Spinner />
     <p className={styles.parentSuspenseBody}>Loading…</p>
   </div>
 );

--- a/src/ui/ErrorBoundary/ErrorBoundary.module.css
+++ b/src/ui/ErrorBoundary/ErrorBoundary.module.css
@@ -114,24 +114,3 @@
   color: var(--tal-ink-soft);
   margin: 0;
 }
-
-.spinner {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  border: 3px solid var(--tal-line);
-  border-top-color: var(--tal-sage);
-  animation: tal-route-spin 0.9s linear infinite;
-}
-
-@keyframes tal-route-spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .spinner {
-    animation-duration: 2.5s;
-  }
-}

--- a/src/ui/Spinner/Spinner.module.css
+++ b/src/ui/Spinner/Spinner.module.css
@@ -1,0 +1,21 @@
+.spinner {
+  width: var(--tal-spinner-size, 32px);
+  height: var(--tal-spinner-size, 32px);
+  border-radius: 50%;
+  border: 3px solid var(--tal-line);
+  border-top-color: var(--tal-sage);
+  animation: tal-spinner-rotate 0.9s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes tal-spinner-rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation-duration: 2.5s;
+  }
+}

--- a/src/ui/Spinner/Spinner.test.tsx
+++ b/src/ui/Spinner/Spinner.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Spinner } from './Spinner';
+
+describe('Spinner', () => {
+  it('is decorative by default', () => {
+    const { container } = render(<Spinner />);
+    expect(container.querySelector('[aria-hidden="true"]')).toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+
+  it('exposes a progressbar role when given a label', () => {
+    render(<Spinner label="Loading" />);
+    expect(screen.getByRole('progressbar', { name: /loading/i })).toBeInTheDocument();
+  });
+});

--- a/src/ui/Spinner/Spinner.tsx
+++ b/src/ui/Spinner/Spinner.tsx
@@ -1,0 +1,17 @@
+import type { CSSProperties, JSX } from 'react';
+
+import styles from './Spinner.module.css';
+
+interface SpinnerProps {
+  size?: number;
+  /** Override the default `aria-hidden`; pass an a11y label to make it announce. */
+  label?: string;
+}
+
+export const Spinner = ({ size, label }: SpinnerProps): JSX.Element => {
+  const style = size ? ({ '--tal-spinner-size': `${size}px` } as CSSProperties) : undefined;
+  if (label) {
+    return <span role="progressbar" aria-label={label} className={styles.spinner} style={style} />;
+  }
+  return <span aria-hidden="true" className={styles.spinner} style={style} />;
+};


### PR DESCRIPTION
## Summary
- AuthGate and ErrorBoundary each defined their own circular spinner with a uniquely-named keyframe — byte-identical otherwise.
- New \`<Spinner size? label?>\` in \`src/ui/Spinner/\`. Defaults to \`aria-hidden\` decoration; pass \`label\` for \`role=progressbar\`.
- One shared keyframe + reduced-motion guard.
- DeleteAccountDialog's white-on-dark inline spinner stays put for now — its replacement lands in the upcoming dialog-tokenization PR where the dialog moves to light tokens.

PR δ of the CSS makeover (after #116, #118, #119).

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm test\` — 259/259 (50 files)
- [ ] Manual: cold-load the app — AuthGate's loading state renders the spinner. Navigate between routes after a network throttle — Suspense fallback shows the same spinner.