### PR TITLE
Rewrite DeleteAccountDialog on shared primitives + tokens

### DIFF
--- a/src/features/settings/DeleteAccountDialog.module.css
+++ b/src/features/settings/DeleteAccountDialog.module.css
@@ -1,47 +1,48 @@
-.dialog {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.85);
-  color: white;
-  padding: 2rem;
+.wrap {
+  padding: 28px 28px 24px;
+  max-width: 480px;
+  width: 100%;
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  z-index: 1000;
-  overflow-y: auto;
+  gap: 14px;
 }
 
-.input {
-  padding: 0.5rem 0.75rem;
-  font-size: 1rem;
-  border-radius: 0.25rem;
-  border: 1px solid rgba(255, 255, 255, 0.4);
-  background: rgba(255, 255, 255, 0.08);
-  color: inherit;
+.lead {
+  margin: 0;
+  font-size: 14px;
+  color: var(--tal-ink);
 }
 
-.input:disabled {
-  opacity: 0.6;
+.list {
+  margin: 0;
+  padding-left: 20px;
+  font-size: 14px;
+  color: var(--tal-ink-soft);
+  line-height: 1.6;
 }
 
-.actions {
-  display: flex;
-  gap: 1rem;
-  margin-top: auto;
-}
-
-.cancel,
-.destructive {
-  padding: 0.75rem 1.25rem;
-  border-radius: 0.25rem;
-  border: 0;
-  font: inherit;
-  cursor: pointer;
+.toast {
+  margin: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--tal-coral-ink);
+  background: var(--tal-coral);
+  color: var(--tal-coral-ink);
+  border-radius: var(--tal-r-md);
+  font-size: 13px;
+  font-weight: 600;
 }
 
 .cancel {
-  background: rgba(255, 255, 255, 0.15);
-  color: inherit;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 10px 18px;
+  border-radius: var(--tal-r-pill);
+  background: var(--tal-surface);
+  color: var(--tal-ink);
+  border: 1px solid var(--tal-line);
+  cursor: pointer;
 }
 
 .cancel:disabled {
@@ -50,34 +51,21 @@
 }
 
 .destructive {
-  background: var(--color-destructive, crimson);
-  color: white;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 700;
+  padding: 10px 18px;
+  border-radius: var(--tal-r-pill);
+  background: var(--tal-coral-ink);
+  color: var(--tal-surface);
+  border: 1px solid var(--tal-coral-ink);
+  cursor: pointer;
 }
 
 .destructive:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-}
-
-.toast {
-  background: rgba(255, 80, 80, 0.2);
-  border: 1px solid var(--color-destructive, crimson);
-  padding: 0.75rem;
-  border-radius: 0.25rem;
-}
-
-.spinner {
-  display: inline-block;
-  width: 1rem;
-  height: 1rem;
-  border: 2px solid rgba(255, 255, 255, 0.4);
-  border-top-color: white;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
 }

--- a/src/features/settings/DeleteAccountDialog.tsx
+++ b/src/features/settings/DeleteAccountDialog.tsx
@@ -1,10 +1,16 @@
-import { type JSX, useEffect, useId, useRef, useState } from 'react';
+import { type JSX, useEffect, useRef, useState } from 'react';
 
 import { type DeleteAccountError, useDeleteMyAccount } from '@/lib/queries/account';
+import { DialogActions } from '@/ui/DialogActions/DialogActions';
+import { DialogHeader } from '@/ui/DialogHeader/DialogHeader';
+import { Modal } from '@/ui/Modal/Modal';
+import { Spinner } from '@/ui/Spinner/Spinner';
+import { TextField } from '@/ui/TextField/TextField';
 
 import styles from './DeleteAccountDialog.module.css';
 
 const REQUIRED_PHRASE = 'delete my account';
+const TITLE_ID = 'del-acct-title';
 
 interface Props {
   onCancel: () => void;
@@ -44,7 +50,6 @@ const toastFor = (err: DeleteAccountError | null): string => {
  * dialog as part of the route change; no post-success effect needed.
  */
 export const DeleteAccountDialog = ({ onCancel, onPreSignOut }: Props): JSX.Element => {
-  const inputId = useId();
   const cancelRef = useRef<HTMLButtonElement>(null);
   const [phrase, setPhrase] = useState('');
   const mutation = useDeleteMyAccount({ onPreSignOut });
@@ -56,68 +61,64 @@ export const DeleteAccountDialog = ({ onCancel, onPreSignOut }: Props): JSX.Elem
     cancelRef.current?.focus();
   }, []);
 
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape' && !mutation.isPending) onCancel();
-    };
-    document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
-  }, [onCancel, mutation.isPending]);
+  // Block close while pending so the user doesn't yank the dialog out from
+  // under an in-flight mutation. Modal's Esc handler routes through here.
+  const handleClose = (): void => {
+    if (!mutation.isPending) onCancel();
+  };
 
   return (
-    <div role="dialog" aria-modal="true" aria-labelledby="del-acct-title" className={styles.dialog}>
-      <h2 id="del-acct-title">Delete your account?</h2>
-      <p>This permanently deletes:</p>
-      <ul>
-        <li>Your account</li>
-        <li>All kids you&apos;ve added</li>
-        <li>All boards</li>
-        <li>All pictograms (including images and recordings)</li>
-        <li>All sharing relationships</li>
-      </ul>
-      <p>
-        <strong>This cannot be undone.</strong>
-      </p>
-      <label htmlFor={inputId}>
-        Type <em>delete my account</em> to confirm.
-      </label>
-      <input
-        id={inputId}
-        type="text"
-        value={phrase}
-        onChange={(e) => setPhrase(e.target.value)}
-        disabled={disabled}
-        autoComplete="off"
-        className={styles.input}
-      />
-      {mutation.isError && (
-        <div role="alert" className={styles.toast}>
-          {toastFor(mutation.error)}
-        </div>
-      )}
-      <div className={styles.actions}>
-        <button
-          type="button"
-          ref={cancelRef}
-          onClick={onCancel}
+    <Modal onClose={handleClose} labelledBy={TITLE_ID}>
+      <div className={styles.wrap}>
+        <DialogHeader
+          title="Delete your account?"
+          subtitle="This is permanent and cannot be undone."
+          titleId={TITLE_ID}
+          onClose={handleClose}
+        />
+        <p className={styles.lead}>This permanently deletes:</p>
+        <ul className={styles.list}>
+          <li>Your account</li>
+          <li>All kids you&apos;ve added</li>
+          <li>All boards</li>
+          <li>All pictograms (including images and recordings)</li>
+          <li>All sharing relationships</li>
+        </ul>
+        <TextField
+          label="Type 'delete my account' to confirm"
+          type="text"
+          value={phrase}
+          onChange={(e) => setPhrase(e.target.value)}
           disabled={disabled}
-          className={styles.cancel}
-        >
-          Cancel
-        </button>
-        <button
-          type="button"
-          onClick={() => mutation.mutate()}
-          disabled={disabled || !matches}
-          className={styles.destructive}
-          aria-label="Delete forever"
-        >
-          {mutation.isPending && (
-            <span role="progressbar" aria-label="Deleting" className={styles.spinner} />
-          )}
-          <span aria-hidden={mutation.isPending}>Delete forever</span>
-        </button>
+          autoComplete="off"
+        />
+        {mutation.isError && (
+          <div role="alert" className={styles.toast}>
+            {toastFor(mutation.error)}
+          </div>
+        )}
+        <DialogActions>
+          <button
+            type="button"
+            ref={cancelRef}
+            onClick={onCancel}
+            disabled={disabled}
+            className={styles.cancel}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => mutation.mutate()}
+            disabled={disabled || !matches}
+            className={styles.destructive}
+            aria-label="Delete forever"
+          >
+            {mutation.isPending && <Spinner label="Deleting" size={16} />}
+            <span aria-hidden={mutation.isPending}>Delete forever</span>
+          </button>
+        </DialogActions>
       </div>
-    </div>
+    </Modal>
   );
 };


### PR DESCRIPTION
## Summary
DeleteAccountDialog was the only modal not on the design system — dark overlay, rgba() everywhere, crimson destructive, rem-based spacing.

This PR rewrites it on:
- \`Modal\` (shared overlay + Esc-to-close, gated by \`isPending\`)
- \`DialogHeader\` for title + close X
- \`TextField\` for the typed-phrase input
- \`DialogActions\` for the button row
- \`Spinner label="Deleting" size={16}\` for the in-button progressbar
- \`--tal-coral\` / \`--tal-coral-ink\` (now real tokens after #118) for the destructive button + error toast

All 13 existing dialog tests pass unchanged. Default Cancel focus, typed-phrase logic, error-toast text, progressbar role — all preserved.

PR ε of the CSS makeover (after #116, #118, #119, #120).

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm test\` — 259/259 (50 files)
- [ ] Manual: open Settings → Delete my account; dialog now matches the rest of the modal chrome (warm overlay over the page, light surface, coral destructive button). Type the phrase, confirm Delete enables. Esc cancels (when not pending).