### PR TITLE
chore(types): refresh supabase types + fix lint-staged for ignored files (#107)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "lint-staged": {
     "src/**/*.{ts,tsx}": [
-      "eslint --max-warnings 0"
+      "eslint --max-warnings 0 --no-warn-ignored"
     ],
     "*.{ts,tsx,json,css}": [
       "prettier --write"

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -247,9 +247,7 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      is_board_editor: { Args: { b_id: string }; Returns: boolean }
-      is_board_member: { Args: { b_id: string }; Returns: boolean }
-      is_board_owner: { Args: { b_id: string }; Returns: boolean }
+      [_ in never]: never
     }
     Enums: {
       [_ in never]: never


### PR DESCRIPTION
## Summary
- Regenerates \`src/types/supabase.ts\` against current local schema. Removes three stale \`is_board_*\` entries from \`Database['public']['Functions']\` left over from when the helpers moved to the \`private\` schema in 34c31bd.
- Adds \`--no-warn-ignored\` to the lint-staged eslint command. Without it, ESLint emits a \"File ignored\" warning for \`src/types/supabase.ts\` (in eslintignore as a generated file) that trips \`--max-warnings 0\` and blocks every future types refresh.

## Test plan
- [x] \`npm run typecheck\` clean.
- [x] \`npm test -- --run\`: 259/259 passing.
- [x] Pre-commit hook now passes on the regenerated types file (was failing pre-fix).

Closes #107