### PR TITLE
Build /settings route: real Account section + move sign-out off the avatar

### DIFF
--- a/src/features/parent-home/ParentHomeRoute.test.tsx
+++ b/src/features/parent-home/ParentHomeRoute.test.tsx
@@ -246,9 +246,9 @@ describe('ParentHomeRoute create flows', () => {
   });
 
   it.each([
-    { label: /library/i, testid: 'library-route' },
-    { label: /kids/i, testid: 'kids-route' },
-    { label: /settings/i, testid: 'settings-route' },
+    { label: /^library$/i, testid: 'library-route' },
+    { label: /^kids$/i, testid: 'kids-route' },
+    { label: /^settings$/i, testid: 'settings-route' },
   ])('clicking sidebar $label navigates to its stub route', async ({ label, testid }) => {
     const Wrap = makeWrap('/');
     render(<Wrap />);

--- a/src/features/settings/AccountSection.module.css
+++ b/src/features/settings/AccountSection.module.css
@@ -1,0 +1,28 @@
+.email {
+  margin: 0;
+  font-size: 14px;
+  color: var(--tal-ink-soft);
+}
+
+.emailValue {
+  color: var(--tal-ink);
+  font-weight: 600;
+}
+
+.signOut {
+  margin-top: 12px;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 10px 18px;
+  border-radius: var(--tal-r-pill);
+  background: var(--tal-surface);
+  color: var(--tal-ink);
+  border: 1px solid var(--tal-line);
+  cursor: pointer;
+}
+
+.signOut:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/features/settings/AccountSection.test.tsx
+++ b/src/features/settings/AccountSection.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+const signOutMock = vi.fn(() => Promise.resolve({ error: null }));
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: { auth: { signOut: signOutMock } },
+}));
+
+const { TestSessionProvider } = await import('@/lib/auth/session.test-utils');
+const { AccountSection } = await import('./AccountSection');
+
+describe('AccountSection', () => {
+  it('shows the signed-in email', () => {
+    render(
+      <TestSessionProvider>
+        <AccountSection />
+      </TestSessionProvider>,
+    );
+    expect(screen.getByText('parent@example.com')).toBeInTheDocument();
+  });
+
+  it('clicking Sign out calls supabase.auth.signOut', async () => {
+    signOutMock.mockClear();
+    render(
+      <TestSessionProvider>
+        <AccountSection />
+      </TestSessionProvider>,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /^sign out$/i }));
+    expect(signOutMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/settings/AccountSection.tsx
+++ b/src/features/settings/AccountSection.tsx
@@ -1,0 +1,36 @@
+import { type JSX, useState } from 'react';
+
+import { useSignOut, useUserEmail } from '@/lib/auth/session';
+
+import styles from './AccountSection.module.css';
+
+/**
+ * Identity + sign-out for the Settings page. Sign-out used to live on the
+ * sidebar avatar in ParentShell, where it could be hit by accident; the
+ * avatar is now a settings entry point and this is the single place that
+ * actually signs the user out.
+ */
+export const AccountSection = (): JSX.Element => {
+  const email = useUserEmail();
+  const signOut = useSignOut();
+  const [pending, setPending] = useState(false);
+
+  const handleSignOut = (): void => {
+    setPending(true);
+    void signOut().finally(() => setPending(false));
+  };
+
+  return (
+    <section>
+      <h2>Signed in</h2>
+      {email && (
+        <p className={styles.email}>
+          You are signed in as <span className={styles.emailValue}>{email}</span>.
+        </p>
+      )}
+      <button type="button" className={styles.signOut} onClick={handleSignOut} disabled={pending}>
+        {pending ? 'Signing out…' : 'Sign out'}
+      </button>
+    </section>
+  );
+};

--- a/src/features/settings/SettingsRoute.test.tsx
+++ b/src/features/settings/SettingsRoute.test.tsx
@@ -65,10 +65,11 @@ beforeEach(() => {
 });
 
 describe('SettingsRoute', () => {
-  it('renders the Settings header and a coming-soon body', () => {
+  it('renders the Settings header and the signed-in account block', () => {
     renderRoute();
     expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
-    expect(screen.getByText(/coming in a future release/i)).toBeInTheDocument();
+    expect(screen.getByText('parent@example.com')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^sign out$/i })).toBeInTheDocument();
   });
 
   it('renders the Delete-my-account section', () => {

--- a/src/features/settings/SettingsRoute.tsx
+++ b/src/features/settings/SettingsRoute.tsx
@@ -3,22 +3,16 @@ import type { JSX } from 'react';
 import { ParentShell } from '@/layouts/ParentShell';
 import { useKidModeNav } from '@/layouts/useKidModeNav';
 import { useParentNav } from '@/layouts/useParentNav';
-import { ComingSoon } from '@/ui/ComingSoon/ComingSoon';
 
+import { AccountSection } from './AccountSection';
 import { DeleteAccountSection } from './DeleteAccountSection';
 
 export const SettingsRoute = (): JSX.Element => {
   const onNav = useParentNav();
   const onKidMode = useKidModeNav();
   return (
-    <ParentShell
-      active="settings"
-      onNav={onNav}
-      onKidMode={onKidMode}
-      title="Settings"
-      subtitle="Coming soon"
-    >
-      <ComingSoon body="Account preferences, voice settings, and PIN management. Coming in a future release." />
+    <ParentShell active="settings" onNav={onNav} onKidMode={onKidMode} title="Settings">
+      <AccountSection />
       <DeleteAccountSection />
     </ParentShell>
   );

--- a/src/layouts/ParentShell.tsx
+++ b/src/layouts/ParentShell.tsx
@@ -1,6 +1,6 @@
 import type { JSX, ReactNode } from 'react';
 
-import { useSignOut, useUserInitial } from '@/lib/auth/session';
+import { useUserInitial } from '@/lib/auth/session';
 import type { NavIconName } from '@/ui/icons';
 import { LockIcon, NavIcon } from '@/ui/icons';
 import { OfflineIndicator } from '@/ui/OfflineIndicator/OfflineIndicator';
@@ -47,7 +47,6 @@ export const ParentShell = ({
   right,
   children,
 }: ParentShellProps): JSX.Element => {
-  const signOut = useSignOut();
   const userInitial = useUserInitial();
   return (
     <div className={styles.shell}>
@@ -79,9 +78,9 @@ export const ParentShell = ({
           <button
             type="button"
             className={styles.avatar}
-            onClick={() => void signOut()}
-            title="Sign out"
-            aria-label="Sign out"
+            onClick={() => onNav?.('settings')}
+            title="Open settings"
+            aria-label="Open settings"
           >
             {userInitial ?? ''}
           </button>

--- a/src/layouts/ParentShell.tsx
+++ b/src/layouts/ParentShell.tsx
@@ -29,7 +29,8 @@ interface ParentShellProps {
   /**
    * Page-specific kid-mode entry point. Each route picks the right board
    * (e.g. ParentHome → first sequence board; BoardBuilder → this board).
-   * Sign-out and avatar pull from session and don't need props.
+   * The avatar shows the user's initial from session and navigates to
+   * /settings via onNav; it no longer signs out directly.
    */
   onKidMode?: () => void;
   title?: string;

--- a/src/lib/auth/session.test-utils.tsx
+++ b/src/lib/auth/session.test-utils.tsx
@@ -28,7 +28,7 @@ interface TestSessionProviderProps {
 /**
  * Wraps tests in a SessionProvider with a fake authenticated user. Use when
  * rendering anything that calls useSession / useSessionUser / useSignOut /
- * useUserInitial — e.g. ParentShell-wrapping screens.
+ * useUserInitial / useUserEmail — e.g. ParentShell-wrapping screens.
  */
 export const TestSessionProvider = ({
   children,

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -29,3 +29,5 @@ export const useUserInitial = (): string | undefined => {
   const first = useSessionUser().email?.[0];
   return first ? first.toUpperCase() : undefined;
 };
+
+export const useUserEmail = (): string | undefined => useSessionUser().email;

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -30,4 +30,5 @@ export const useUserInitial = (): string | undefined => {
   return first ? first.toUpperCase() : undefined;
 };
 
+/** Same undefined caveat as useUserInitial — phone-only auth has no email. */
 export const useUserEmail = (): string | undefined => useSessionUser().email;


### PR DESCRIPTION
## Summary
- Replaces the "Coming soon" placeholder on `/settings` with a real `AccountSection` (signed-in email + Sign-out button).
- Sidebar avatar in `ParentShell` no longer signs the user out on click — it navigates to `/settings`. Sign-out lives in one place now, alongside Delete-my-account.
- Adds `useUserEmail` hook and unit tests for `AccountSection`; updates `SettingsRoute` test to assert the new content; tightens the `ParentHomeRoute` sidebar-nav test selector so the avatar's `aria-label="Open settings"` doesn't collide with the sidebar's "Settings" button.

## Why
Issue #62 calls for a real Settings screen. The avatar doing double duty (identity + destructive sign-out on a single click) was easy to misfire. Centralizing both account actions (sign out + delete) on Settings keeps destructive moves out of the shell chrome.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx tsc -b` — clean
- [x] `npx vitest run` — 261/261 passing
- [ ] Manual: click avatar → lands on /settings; click Sign out on Settings → signs out; click Settings sidebar item → same screen, active highlight set

Closes #62