### PR TITLE
Surface rls_auto_enable failures (#102)

### DIFF
--- a/supabase/migrations/20260428193125_surface_rls_auto_enable_failures.sql
+++ b/supabase/migrations/20260428193125_surface_rls_auto_enable_failures.sql
@@ -1,0 +1,58 @@
+-- Surface trigger-function failures (#102).
+--
+-- `private.rls_auto_enable()` was an event trigger that ran on every
+-- `ddl_command_end` and tried to enable RLS on any new table created in
+-- `public`. Failures inside the per-table loop were swallowed by an inner
+-- `exception when others then raise log` block, which writes to the Postgres
+-- log but is not surfaced anywhere actionable. A failure means a new public
+-- table was created WITHOUT row-level security — a real security regression
+-- that we'd never see unless someone happened to scroll the dashboard logs.
+--
+-- Fix: drop the inner exception handler. Any RLS-enable failure now
+-- propagates and aborts the originating CREATE TABLE. The migration author
+-- will see the error in their `supabase db push` output and have to deal
+-- with it before the migration can land.
+--
+-- Drop-then-recreate (rather than CREATE OR REPLACE) because the function's
+-- return type / language / volatility don't change but we want the migration
+-- diff to read as a deliberate body swap, not a one-line edit. The event
+-- trigger has to be dropped first because it depends on the function.
+--
+-- handle_new_user(): NOT touched in this migration. It already has no
+-- try/catch, so any failure (template-clone INSERT, slug-mismatch RAISE
+-- EXCEPTION) propagates and aborts the auth.users insert — signup fails
+-- loudly. Once #45 (Sentry) ships, those propagated errors get captured
+-- at the `auth.signUp` call site on the client. Adding a
+-- `public.signup_errors` table now would be speculative infrastructure
+-- for a logging system we haven't picked yet.
+
+drop event trigger if exists ensure_rls;
+drop function if exists private.rls_auto_enable();
+
+create function private.rls_auto_enable() returns event_trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  cmd record;
+begin
+  for cmd in
+    select *
+      from pg_event_trigger_ddl_commands()
+     where command_tag in ('CREATE TABLE', 'CREATE TABLE AS', 'SELECT INTO')
+       and object_type in ('table', 'partitioned table')
+  loop
+    if cmd.schema_name is not null
+       and cmd.schema_name = 'public'
+       and cmd.schema_name not like 'pg_%' then
+      execute format('alter table if exists %s enable row level security', cmd.object_identity);
+      raise log 'rls_auto_enable: enabled RLS on %', cmd.object_identity;
+    end if;
+  end loop;
+end;
+$$;
+
+create event trigger ensure_rls
+  on ddl_command_end
+  execute function private.rls_auto_enable();

--- a/supabase/tests/rls_auto_enable_test.sql
+++ b/supabase/tests/rls_auto_enable_test.sql
@@ -1,0 +1,44 @@
+-- Regression test for #102: `private.rls_auto_enable()` must not silently
+-- swallow per-table RLS-enable failures.
+--
+-- The original event-trigger body wrapped its `alter table ... enable row
+-- level security` call in `begin ... exception when others then raise log
+-- ... end`. A failure there meant a public table got created WITHOUT RLS
+-- and the only signal was a log line on the dashboard. Since the trigger
+-- runs SECURITY DEFINER as `postgres`, forcing a real failure is contrived
+-- (postgres has ALTER on everything we'd plausibly create in a migration).
+-- So instead, this test asserts a structural property: the function source
+-- has no `exception when others` clause.
+--
+-- This is weaker than a behavioral test but strong enough to catch the
+-- specific regression — someone adding the swallow-block back. The happy
+-- path (RLS gets enabled on new public tables) is implicitly covered by
+-- every other migration that creates a public table plus the RLS-coverage
+-- assertion in rest_surface_contract_test.sql.
+--
+-- Run with: supabase test db
+BEGIN;
+SELECT plan(2);
+
+SELECT ok(
+  (SELECT prosrc FROM pg_proc p
+     JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'private' AND p.proname = 'rls_auto_enable')
+    !~* '\mexception\s+when\s+others\M',
+  'private.rls_auto_enable has no `exception when others` swallow-block'
+);
+
+-- The event trigger must still be wired. A regression that dropped the
+-- function-body handler but also dropped the trigger would silently disable
+-- the whole RLS-auto-enable safety net.
+SELECT is(
+  (SELECT count(*)::int FROM pg_event_trigger
+    WHERE evtname = 'ensure_rls'
+      AND evtevent = 'ddl_command_end'
+      AND evtenabled <> 'D'),
+  1,
+  'ensure_rls event trigger is installed and enabled on ddl_command_end'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary

- New migration drops the inner `exception when others then raise log` swallow-block in `private.rls_auto_enable()`. A per-table `ALTER TABLE ... ENABLE RLS` failure now propagates and aborts the originating `CREATE TABLE`, instead of leaving a public table without RLS and only a log line on the dashboard.
- `handle_new_user()` intentionally untouched — it already has no try/catch, so failures already propagate as a failed signup. Decision documented in the new migration's comment. Sentry (#45) will pick those up at the call site once it lands.
- New pgTAP test pins the regression: the function source must not contain `exception when others`, and the `ensure_rls` event trigger must still be wired/enabled.

## Why a structural test, not a behavioral one

The acceptance criterion in #102 asks for a test that simulates a `CREATE TABLE` whose RLS-enable would fail. The trigger runs `SECURITY DEFINER` as `postgres`, which has `ALTER` on anything we'd plausibly create in a migration — there isn't a realistic failure path to exercise. The structural assertion catches the specific regression the issue is about (someone re-adding the swallow-block) without pretending to test something we can't reach. Happy path is implicitly covered by every migration that creates a public table, gated by `rest_surface_contract_test.sql`'s RLS-coverage scan.

## Test plan

- [x] `supabase db reset` applies the new migration cleanly
- [x] `supabase test db` — all 8 files / 128 tests pass, including the new `rls_auto_enable_test.sql`

Closes #102