### PR TITLE
chore(lint): pin supabase.storage to lib/storage (closes #130)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ supabase/      config, migrations, seed.sql, pgTAP tests
 
 Layering (shared → features → app) is enforced by `no-restricted-imports` in
 `eslint.config.js`. All DB reads go through `src/lib/queries/*`; all writes go
-through `src/lib/outbox`. Features never call `supabase.from(...)` directly.
+through `src/lib/outbox`; Storage minting goes through `src/lib/storage`.
+Features never call `supabase.from(...)` or `supabase.storage` directly —
+both are pinned by `no-restricted-imports` / `no-restricted-syntax` rules.
 
 ## Auth
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -83,5 +83,23 @@ export default tseslint.config(
       ],
     },
   },
+  {
+    // Mirrors the data-access boundary: DB reads go through lib/queries,
+    // writes through lib/outbox, and Storage minting through lib/storage.
+    // Features and ui primitives must not call supabase.storage directly.
+    files: ['src/features/**/*.{ts,tsx}', 'src/ui/**/*.{ts,tsx}'],
+    ignores: ['**/*.test.{ts,tsx}', '**/*.test-utils.{ts,tsx}'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "MemberExpression[object.name='supabase'][property.name='storage']",
+          message:
+            'Storage access goes through src/lib/storage; features and ui must not call supabase.storage directly.',
+        },
+      ],
+    },
+  },
 );
 


### PR DESCRIPTION
## Summary
- Extend the existing data-access boundary (queries/outbox) to cover Storage. New `no-restricted-syntax` rule scoped to `src/features/**` and `src/ui/**` blocks `supabase.storage.*` member access; tests are exempt so test-utilities can still mock Storage.
- README "Where things live" gets one sentence so the rule is documented alongside the existing queries/outbox guidance.

## Why
`src/lib/storage.ts` is the sole legitimate caller of `supabase.storage` (verified by grep). The principle was already followed but unenforced — this PR is purely a future-drift guard, no behavior change.

## Test plan
- [x] `npm run lint` clean (no new violations on existing code)
- [x] `npm run typecheck` clean
- [x] `npm run test` — 268/268
- [x] Probe: temp `src/features/parent-home/_storage_probe.tsx` calling `supabase.storage.from(...)` → lint errors with the documented message
- [x] Probe: same temp under `src/ui/` → lint errors (rule covers both scopes)
- [x] `src/lib/storage.ts` lints cleanly (rule exempts the only legitimate caller)
- [ ] CI green

Closes the layering/data-access cleanup sequence (#126, #128, #129, #138, #139, #130). Closes #130.