### PR TITLE
refactor(board-builder): split ShareModal into hooks + dialog (#140)

### DIFF
--- a/src/features/board-builder/ShareModal.test.tsx
+++ b/src/features/board-builder/ShareModal.test.tsx
@@ -1,5 +1,5 @@
 import type { Session, User } from '@supabase/supabase-js';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import type { JSX } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -8,19 +8,7 @@ import type { BoardMember } from '@/lib/queries/board-members';
 import type * as BoardMembersModule from '@/lib/queries/board-members';
 
 const useBoardMembersMock = vi.fn();
-const addMutateMock = vi.fn();
 const removeMutateMock = vi.fn();
-let lastAddOptions: { onSuccess?: () => void; onError?: (err: unknown) => void } | undefined;
-
-const baseAddState = {
-  mutate: (input: unknown, opts?: { onSuccess?: () => void; onError?: (err: unknown) => void }) => {
-    lastAddOptions = opts;
-    addMutateMock(input);
-  },
-  isPending: false,
-};
-
-let addState: typeof baseAddState = { ...baseAddState };
 
 const removeState = {
   mutate: (input: unknown) => {
@@ -34,7 +22,10 @@ vi.mock('@/lib/queries/board-members', async (importActual) => {
   return {
     ...actual,
     useBoardMembers: () => useBoardMembersMock(),
-    useAddBoardMember: () => addState,
+    useAddBoardMember: () => ({
+      mutate: () => undefined,
+      isPending: false,
+    }),
     useRemoveBoardMember: () => removeState,
   };
 });
@@ -81,11 +72,8 @@ const renderModal = (
 };
 
 beforeEach(() => {
-  addMutateMock.mockReset();
   removeMutateMock.mockReset();
   useBoardMembersMock.mockReset();
-  addState = { ...baseAddState };
-  lastAddOptions = undefined;
 });
 
 afterEach(() => {
@@ -108,48 +96,6 @@ describe('ShareModal — owner', () => {
   it('shows "No one yet." when the board has no members', () => {
     renderModal([]);
     expect(screen.getByText('No one yet.')).toBeInTheDocument();
-  });
-
-  it('rejects a non-UUID input with an inline error and does not fire the mutation', () => {
-    renderModal([]);
-    fireEvent.change(screen.getByLabelText('Sharing ID'), { target: { value: 'not-a-uuid' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
-    expect(screen.getByRole('alert')).toHaveTextContent("doesn't look like a valid sharing ID");
-    expect(addMutateMock).not.toHaveBeenCalled();
-  });
-
-  it("rejects pasting one's own sharing ID with an inline error", () => {
-    renderModal([]);
-    fireEvent.change(screen.getByLabelText('Sharing ID'), { target: { value: ME_ID } });
-    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
-    expect(screen.getByRole('alert')).toHaveTextContent('your own sharing ID');
-    expect(addMutateMock).not.toHaveBeenCalled();
-  });
-
-  it('fires useAddBoardMember on a valid UUID and clears the input on success', async () => {
-    renderModal([]);
-    const input = screen.getByLabelText('Sharing ID') as HTMLInputElement;
-    fireEvent.change(input, { target: { value: OTHER_ID } });
-    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
-    expect(addMutateMock).toHaveBeenCalledWith({
-      boardId: 'board-1',
-      userId: OTHER_ID,
-      role: 'viewer',
-    });
-    act(() => {
-      lastAddOptions?.onSuccess?.();
-    });
-    await waitFor(() => expect(input.value).toBe(''));
-  });
-
-  it('renders an inline error when the mutation reports a 23505 (already a member)', async () => {
-    renderModal([]);
-    fireEvent.change(screen.getByLabelText('Sharing ID'), { target: { value: OTHER_ID } });
-    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
-    act(() => {
-      lastAddOptions?.onError?.({ code: '23505', message: 'duplicate' });
-    });
-    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('already has access'));
   });
 
   it('fires useRemoveBoardMember when an X button is clicked on a member row', () => {
@@ -194,43 +140,5 @@ describe('ShareModal — members loading state (#35)', () => {
     );
     expect(screen.getByText('Loading…')).toBeInTheDocument();
     expect(screen.queryByText('No one yet.')).not.toBeInTheDocument();
-  });
-});
-
-describe('ShareModal — clipboard error (#36)', () => {
-  const realClipboard = navigator.clipboard;
-
-  afterEach(() => {
-    Object.defineProperty(navigator, 'clipboard', {
-      value: realClipboard,
-      configurable: true,
-    });
-  });
-
-  it('shows an inline error if clipboard.writeText rejects', async () => {
-    Object.defineProperty(navigator, 'clipboard', {
-      value: { writeText: () => Promise.reject(new Error('denied')) },
-      configurable: true,
-    });
-    renderModal([]);
-    fireEvent.click(screen.getByRole('button', { name: 'Copy your sharing ID' }));
-    await waitFor(() =>
-      expect(screen.getByRole('alert')).toHaveTextContent('select the ID and copy manually'),
-    );
-  });
-
-  it('shows an inline error when running in an insecure context', () => {
-    const realIsSecure = window.isSecureContext;
-    Object.defineProperty(window, 'isSecureContext', { value: false, configurable: true });
-    try {
-      renderModal([]);
-      fireEvent.click(screen.getByRole('button', { name: 'Copy your sharing ID' }));
-      expect(screen.getByRole('alert')).toHaveTextContent('select the ID and copy manually');
-    } finally {
-      Object.defineProperty(window, 'isSecureContext', {
-        value: realIsSecure,
-        configurable: true,
-      });
-    }
   });
 });

--- a/src/features/board-builder/ShareModal.tsx
+++ b/src/features/board-builder/ShareModal.tsx
@@ -1,24 +1,16 @@
-import { type FormEvent, type JSX, useState } from 'react';
+import { type JSX } from 'react';
 
 import { useSessionUser } from '@/lib/auth/session';
-import {
-  isAlreadyMemberError,
-  isShareForbiddenError,
-  useAddBoardMember,
-  useBoardMembers,
-  useRemoveBoardMember,
-} from '@/lib/queries/board-members';
+import { useBoardMembers, useRemoveBoardMember } from '@/lib/queries/board-members';
+import { useCopy } from '@/lib/useCopy';
 import { DialogHeader } from '@/ui/DialogHeader/DialogHeader';
 import { XIcon } from '@/ui/icons';
 import { Modal } from '@/ui/Modal/Modal';
 
 import styles from './ShareModal.module.css';
+import { useShareSubmit } from './useShareSubmit';
 
 const TITLE_ID = 'share-modal-title';
-
-// RFC 4122 v4 / v7 / generic UUID surface check. Supabase uses gen_random_uuid()
-// which emits v4; browser-pasted IDs from a sibling user will look the same.
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 interface ShareModalProps {
   boardId: string;
@@ -26,85 +18,15 @@ interface ShareModalProps {
   onClose: () => void;
 }
 
-interface CopyState {
-  copied: boolean;
-  error: string | null;
-  copy: (text: string) => void;
-}
-
-const useCopy = (): CopyState => {
-  const [copied, setCopied] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const copy = (text: string): void => {
-    // Insecure context (http://) blocks clipboard API in Chrome/Safari; the
-    // call would reject with an unhelpful DOMException. Short-circuit and
-    // surface the same fallback copy.
-    if (
-      typeof navigator === 'undefined' ||
-      !navigator.clipboard ||
-      (typeof window !== 'undefined' && window.isSecureContext === false)
-    ) {
-      setError("Couldn't copy — select the ID and copy manually.");
-      return;
-    }
-    setError(null);
-    void navigator.clipboard.writeText(text).then(
-      () => {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
-      },
-      () => {
-        setError("Couldn't copy — select the ID and copy manually.");
-      },
-    );
-  };
-  return { copied, error, copy };
-};
-
 export const ShareModal = ({ boardId, isOwner, onClose }: ShareModalProps): JSX.Element => {
   const me = useSessionUser();
   const members = useBoardMembers(boardId);
-  const addMember = useAddBoardMember();
   const removeMember = useRemoveBoardMember();
   const { copied, error: copyError, copy } = useCopy();
-
-  const [draftId, setDraftId] = useState('');
-  const [submitError, setSubmitError] = useState<string | null>(null);
-
-  const submitting = addMember.isPending;
-
-  const submit = (e: FormEvent): void => {
-    e.preventDefault();
-    const trimmed = draftId.trim().toLowerCase();
-    if (!UUID_RE.test(trimmed)) {
-      setSubmitError("That doesn't look like a valid sharing ID.");
-      return;
-    }
-    if (trimmed === me.id) {
-      setSubmitError("That's your own sharing ID.");
-      return;
-    }
-    setSubmitError(null);
-    addMember.mutate(
-      { boardId, userId: trimmed, role: 'viewer' },
-      {
-        onSuccess: () => {
-          setDraftId('');
-        },
-        onError: (err) => {
-          if (isAlreadyMemberError(err)) {
-            setSubmitError('That person already has access to this board.');
-            return;
-          }
-          if (isShareForbiddenError(err)) {
-            setSubmitError("You can't share this board.");
-            return;
-          }
-          setSubmitError("Couldn't add that person. Try again.");
-        },
-      },
-    );
-  };
+  const { draftId, setDraftId, submit, submitError, submitting } = useShareSubmit({
+    boardId,
+    meId: me.id,
+  });
 
   return (
     <Modal onClose={onClose} labelledBy={TITLE_ID}>
@@ -178,10 +100,7 @@ export const ShareModal = ({ boardId, isOwner, onClose }: ShareModalProps): JSX.
                   placeholder="Paste a sharing ID"
                   autoComplete="off"
                   value={draftId}
-                  onChange={(e) => {
-                    setDraftId(e.target.value);
-                    if (submitError) setSubmitError(null);
-                  }}
+                  onChange={(e) => setDraftId(e.target.value)}
                   aria-label="Sharing ID"
                 />
                 <button

--- a/src/features/board-builder/useShareSubmit.test.tsx
+++ b/src/features/board-builder/useShareSubmit.test.tsx
@@ -1,0 +1,132 @@
+import { act, renderHook } from '@testing-library/react';
+import type { FormEvent } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as BoardMembersModule from '@/lib/queries/board-members';
+
+const addMutateMock = vi.fn();
+let lastAddOptions: { onSuccess?: () => void; onError?: (err: unknown) => void } | undefined;
+
+const baseAddState = {
+  mutate: (input: unknown, opts?: { onSuccess?: () => void; onError?: (err: unknown) => void }) => {
+    lastAddOptions = opts;
+    addMutateMock(input);
+  },
+  isPending: false,
+};
+
+let addState: typeof baseAddState = { ...baseAddState };
+
+vi.mock('@/lib/queries/board-members', async (importActual) => {
+  const actual = await importActual<typeof BoardMembersModule>();
+  return {
+    ...actual,
+    useAddBoardMember: () => addState,
+  };
+});
+
+const { useShareSubmit } = await import('./useShareSubmit');
+
+const ME_ID = '11111111-1111-4111-8111-111111111111';
+const OTHER_ID = '22222222-2222-4222-8222-222222222222';
+const BOARD_ID = 'board-1';
+
+const fakeEvent = (): FormEvent => ({ preventDefault: () => undefined }) as FormEvent;
+
+beforeEach(() => {
+  addMutateMock.mockReset();
+  addState = { ...baseAddState };
+  lastAddOptions = undefined;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useShareSubmit', () => {
+  it('rejects a non-UUID draft with an inline error and skips the mutation', () => {
+    const { result } = renderHook(() => useShareSubmit({ boardId: BOARD_ID, meId: ME_ID }));
+    act(() => {
+      result.current.setDraftId('not-a-uuid');
+    });
+    act(() => {
+      result.current.submit(fakeEvent());
+    });
+    expect(result.current.submitError).toMatch(/doesn.?t look like a valid sharing ID/);
+    expect(addMutateMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects pasting one's own sharing ID", () => {
+    const { result } = renderHook(() => useShareSubmit({ boardId: BOARD_ID, meId: ME_ID }));
+    act(() => {
+      result.current.setDraftId(ME_ID);
+    });
+    act(() => {
+      result.current.submit(fakeEvent());
+    });
+    expect(result.current.submitError).toMatch(/your own sharing ID/);
+    expect(addMutateMock).not.toHaveBeenCalled();
+  });
+
+  it('fires useAddBoardMember on a valid UUID and clears the draft on success', () => {
+    const { result } = renderHook(() => useShareSubmit({ boardId: BOARD_ID, meId: ME_ID }));
+    act(() => {
+      result.current.setDraftId(OTHER_ID);
+    });
+    act(() => {
+      result.current.submit(fakeEvent());
+    });
+    expect(addMutateMock).toHaveBeenCalledWith({
+      boardId: BOARD_ID,
+      userId: OTHER_ID,
+      role: 'viewer',
+    });
+    act(() => {
+      lastAddOptions?.onSuccess?.();
+    });
+    expect(result.current.draftId).toBe('');
+  });
+
+  it('maps a 23505 (already-member) error to the user-facing message', () => {
+    const { result } = renderHook(() => useShareSubmit({ boardId: BOARD_ID, meId: ME_ID }));
+    act(() => {
+      result.current.setDraftId(OTHER_ID);
+    });
+    act(() => {
+      result.current.submit(fakeEvent());
+    });
+    act(() => {
+      lastAddOptions?.onError?.({ code: '23505', message: 'duplicate' });
+    });
+    expect(result.current.submitError).toMatch(/already has access/);
+  });
+
+  it('maps a forbidden (42501) error to the user-facing message', () => {
+    const { result } = renderHook(() => useShareSubmit({ boardId: BOARD_ID, meId: ME_ID }));
+    act(() => {
+      result.current.setDraftId(OTHER_ID);
+    });
+    act(() => {
+      result.current.submit(fakeEvent());
+    });
+    act(() => {
+      lastAddOptions?.onError?.({ code: '42501', message: 'forbidden' });
+    });
+    expect(result.current.submitError).toMatch(/can.?t share this board/);
+  });
+
+  it('clears submitError when the user edits the draft', () => {
+    const { result } = renderHook(() => useShareSubmit({ boardId: BOARD_ID, meId: ME_ID }));
+    act(() => {
+      result.current.setDraftId('not-a-uuid');
+    });
+    act(() => {
+      result.current.submit(fakeEvent());
+    });
+    expect(result.current.submitError).not.toBeNull();
+    act(() => {
+      result.current.setDraftId('not-a-uuid-but-typing');
+    });
+    expect(result.current.submitError).toBeNull();
+  });
+});

--- a/src/features/board-builder/useShareSubmit.ts
+++ b/src/features/board-builder/useShareSubmit.ts
@@ -1,0 +1,81 @@
+import { type FormEvent, useState } from 'react';
+
+import {
+  isAlreadyMemberError,
+  isShareForbiddenError,
+  useAddBoardMember,
+} from '@/lib/queries/board-members';
+
+// RFC 4122 v4 / v7 / generic UUID surface check. Supabase uses
+// gen_random_uuid() (v4); browser-pasted IDs from a sibling user look the same.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export interface ShareSubmitState {
+  draftId: string;
+  setDraftId: (next: string) => void;
+  submitError: string | null;
+  submitting: boolean;
+  submit: (e: FormEvent) => void;
+}
+
+interface Args {
+  boardId: string;
+  meId: string;
+}
+
+/**
+ * Owns the add-member submit flow for ShareModal: input draft state, UUID
+ * surface validation, self-paste rejection, and the mutation call with
+ * error-code → user-message mapping. ShareModal stays presentation-only.
+ */
+export const useShareSubmit = ({ boardId, meId }: Args): ShareSubmitState => {
+  const addMember = useAddBoardMember();
+  const [draftId, setDraftIdState] = useState('');
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const setDraftId = (next: string): void => {
+    setDraftIdState(next);
+    if (submitError) setSubmitError(null);
+  };
+
+  const submit = (e: FormEvent): void => {
+    e.preventDefault();
+    const trimmed = draftId.trim().toLowerCase();
+    if (!UUID_RE.test(trimmed)) {
+      setSubmitError("That doesn't look like a valid sharing ID.");
+      return;
+    }
+    if (trimmed === meId) {
+      setSubmitError("That's your own sharing ID.");
+      return;
+    }
+    setSubmitError(null);
+    addMember.mutate(
+      { boardId, userId: trimmed, role: 'viewer' },
+      {
+        onSuccess: () => {
+          setDraftIdState('');
+        },
+        onError: (err) => {
+          if (isAlreadyMemberError(err)) {
+            setSubmitError('That person already has access to this board.');
+            return;
+          }
+          if (isShareForbiddenError(err)) {
+            setSubmitError("You can't share this board.");
+            return;
+          }
+          setSubmitError("Couldn't add that person. Try again.");
+        },
+      },
+    );
+  };
+
+  return {
+    draftId,
+    setDraftId,
+    submitError,
+    submitting: addMember.isPending,
+    submit,
+  };
+};

--- a/src/lib/useCopy.test.ts
+++ b/src/lib/useCopy.test.ts
@@ -1,0 +1,64 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useCopy } from './useCopy';
+
+const realClipboard = navigator.clipboard;
+const realIsSecure = window.isSecureContext;
+
+afterEach(() => {
+  Object.defineProperty(navigator, 'clipboard', { value: realClipboard, configurable: true });
+  Object.defineProperty(window, 'isSecureContext', { value: realIsSecure, configurable: true });
+  vi.useRealTimers();
+});
+
+describe('useCopy', () => {
+  it('writes to the clipboard and flips `copied` true for 1.5s, then back to false', async () => {
+    const writeText = vi.fn(() => Promise.resolve());
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+    vi.useFakeTimers();
+
+    const { result } = renderHook(() => useCopy());
+    await act(async () => {
+      result.current.copy('hello');
+    });
+    expect(writeText).toHaveBeenCalledWith('hello');
+    expect(result.current.copied).toBe(true);
+    expect(result.current.error).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(result.current.copied).toBe(false);
+  });
+
+  it('sets the fallback error when running in an insecure context', () => {
+    Object.defineProperty(window, 'isSecureContext', { value: false, configurable: true });
+    const { result } = renderHook(() => useCopy());
+    act(() => {
+      result.current.copy('hello');
+    });
+    expect(result.current.error).toMatch(/select the ID and copy manually/i);
+    expect(result.current.copied).toBe(false);
+  });
+
+  it('sets the fallback error when navigator.clipboard is missing', () => {
+    Object.defineProperty(navigator, 'clipboard', { value: undefined, configurable: true });
+    const { result } = renderHook(() => useCopy());
+    act(() => {
+      result.current.copy('hello');
+    });
+    expect(result.current.error).toMatch(/select the ID and copy manually/i);
+  });
+
+  it('sets the fallback error when writeText rejects', async () => {
+    const writeText = vi.fn(() => Promise.reject(new Error('denied')));
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+    const { result } = renderHook(() => useCopy());
+    await act(async () => {
+      result.current.copy('hello');
+    });
+    expect(result.current.error).toMatch(/select the ID and copy manually/i);
+    expect(result.current.copied).toBe(false);
+  });
+});

--- a/src/lib/useCopy.ts
+++ b/src/lib/useCopy.ts
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+export interface CopyState {
+  copied: boolean;
+  error: string | null;
+  copy: (text: string) => void;
+}
+
+const FALLBACK_MESSAGE = "Couldn't copy — select the ID and copy manually.";
+const COPIED_FLASH_MS = 1500;
+
+/**
+ * Generic clipboard hook. `copy(text)` writes to the system clipboard, sets
+ * `copied=true` for 1.5s, and resets. On a permission denial, an insecure
+ * context (http://), or a missing Clipboard API surface, sets `error` to a
+ * fallback message instead — Chrome/Safari reject `navigator.clipboard` on
+ * non-HTTPS origins with an unhelpful DOMException, so we short-circuit
+ * before calling and surface the same copy as the rejection path.
+ */
+export const useCopy = (): CopyState => {
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const copy = (text: string): void => {
+    if (
+      typeof navigator === 'undefined' ||
+      !navigator.clipboard ||
+      (typeof window !== 'undefined' && window.isSecureContext === false)
+    ) {
+      setError(FALLBACK_MESSAGE);
+      return;
+    }
+    setError(null);
+    void navigator.clipboard.writeText(text).then(
+      () => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), COPIED_FLASH_MS);
+      },
+      () => {
+        setError(FALLBACK_MESSAGE);
+      },
+    );
+  };
+  return { copied, error, copy };
+};


### PR DESCRIPTION
Closes #140.

## Summary
- Lift the local `useCopy` hook from ShareModal to `src/lib/useCopy.ts` so it's reusable and testable without rendering. ~28 LoC moved verbatim.
- Extract the add-member submit flow (UUID validation + `addMember.mutate` + error-code mapping for 23505 / 42501) into `src/features/board-builder/useShareSubmit.ts`.
- ShareModal becomes a thin presentational dialog (~125 LoC, was 207). JSX unchanged.
- Tests reshape to match: 4 cases in `useCopy.test.ts`, 6 in `useShareSubmit.test.tsx`, ShareModal.test.tsx keeps 6 structural cases (3 sections render, no-one-yet, fires-remove, close, non-owner hides sections, loading state).

Pure refactor: zero behavior change, zero call-site changes, net coverage parity.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run test` — 272 / 272 pass (was 268; +4 net from added hook tests minus relocated cases)