### PR TITLE
theme: semantic tokens + sweep hardcoded colors (#127, #141)

### DIFF
--- a/src/features/board-builder/pictogram-picker/VoiceRecorderDialog.module.css
+++ b/src/features/board-builder/pictogram-picker/VoiceRecorderDialog.module.css
@@ -52,7 +52,7 @@
 }
 
 .recDot {
-  color: #b4261a;
+  color: var(--tal-danger);
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -63,7 +63,7 @@
   width: 10px;
   height: 10px;
   border-radius: 999px;
-  background: #b4261a;
+  background: var(--tal-danger);
   animation: tal-rec-pulse 1.2s ease-in-out infinite;
 }
 
@@ -86,7 +86,7 @@
 }
 
 .error {
-  color: #b4261a;
+  color: var(--tal-danger);
   font-size: 14px;
   text-align: center;
   max-width: 40ch;

--- a/src/features/kid-choice/KidChoice.module.css
+++ b/src/features/kid-choice/KidChoice.module.css
@@ -55,7 +55,7 @@
   width: 52px;
   height: 52px;
   border-radius: var(--tal-r-pill);
-  color: #fff;
+  color: var(--tal-on-accent);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -81,7 +81,7 @@
   padding: 20px 40px;
   border-radius: var(--tal-r-pill);
   background: var(--tal-ink);
-  color: #fff;
+  color: var(--tal-on-accent);
   font-size: 22px;
   font-weight: 800;
   display: inline-flex;

--- a/src/layouts/TalrumMark.tsx
+++ b/src/layouts/TalrumMark.tsx
@@ -21,7 +21,7 @@ export const TalrumMark = ({ size = 44 }: TalrumMarkProps): JSX.Element => (
     aria-label="Talrum"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <rect x="0" y="0" width="100" height="100" rx="20" fill="#7cb8e0" />
+    <rect x="0" y="0" width="100" height="100" rx="20" fill="var(--tal-brand-sky)" />
     <rect
       x="7"
       y="7"
@@ -29,28 +29,28 @@ export const TalrumMark = ({ size = 44 }: TalrumMarkProps): JSX.Element => (
       height="86"
       rx="14"
       fill="none"
-      stroke="#ffffff"
+      stroke="var(--tal-brand-mark)"
       strokeWidth="2.5"
     />
-    <path d="M 22 42 L 22 58 L 34 58 L 50 72 L 50 28 L 34 42 Z" fill="#ffffff" />
+    <path d="M 22 42 L 22 58 L 34 58 L 50 72 L 50 28 L 34 42 Z" fill="var(--tal-brand-mark)" />
     <path
       d="M 56 36 Q 66 50 56 64"
       fill="none"
-      stroke="#ffffff"
+      stroke="var(--tal-brand-mark)"
       strokeWidth="3"
       strokeLinecap="round"
     />
     <path
       d="M 64 30 Q 78 50 64 70"
       fill="none"
-      stroke="#ffffff"
+      stroke="var(--tal-brand-mark)"
       strokeWidth="3"
       strokeLinecap="round"
     />
     <path
       d="M 72 25 Q 88 50 72 75"
       fill="none"
-      stroke="#ffffff"
+      stroke="var(--tal-brand-mark)"
       strokeWidth="3"
       strokeLinecap="round"
     />

--- a/src/theme/tokens.module.css
+++ b/src/theme/tokens.module.css
@@ -36,6 +36,19 @@
   --tal-glyph-stroke: oklch(30% 0.03 260);
   --tal-glyph-fill: oklch(99% 0.005 85);
 
+  /* Semantic — text on accent fills, modal scrim, danger/recording red */
+  --tal-on-accent: #fff;
+  --tal-overlay: rgb(40 30 20 / 32%);
+  --tal-danger: #b4261a;
+
+  /* Kid-mode fatal screen — high-contrast regardless of theme */
+  --tal-fatal-bg: #000;
+  --tal-fatal-ink: #fff;
+
+  /* Brand mark — fixed by design, tokenized so retinting is possible */
+  --tal-brand-sky: #7cb8e0;
+  --tal-brand-mark: #ffffff;
+
   /* Photo-placeholder stripe colors */
   --tal-photo-stripe-a: oklch(93% 0.01 85);
   --tal-photo-stripe-b: oklch(88% 0.014 85);

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -29,7 +29,14 @@ export type ColorToken =
   | 'glyph-stroke'
   | 'glyph-fill'
   | 'photo-stripe-a'
-  | 'photo-stripe-b';
+  | 'photo-stripe-b'
+  | 'on-accent'
+  | 'overlay'
+  | 'danger'
+  | 'fatal-bg'
+  | 'fatal-ink'
+  | 'brand-sky'
+  | 'brand-mark';
 
 export type RadiusToken = 'sm' | 'md' | 'lg' | 'xl' | 'pill';
 

--- a/src/ui/Button/Button.module.css
+++ b/src/ui/Button/Button.module.css
@@ -20,7 +20,7 @@
 .primary {
   padding: 12px 18px;
   background: var(--tal-ink);
-  color: #fff;
+  color: var(--tal-on-accent);
   box-shadow: var(--tal-shadow-1);
 }
 

--- a/src/ui/ErrorBoundary/ErrorBoundary.module.css
+++ b/src/ui/ErrorBoundary/ErrorBoundary.module.css
@@ -57,8 +57,8 @@
 .kidFallback {
   position: fixed;
   inset: 0;
-  background: #000;
-  color: #fff;
+  background: var(--tal-fatal-bg);
+  color: var(--tal-fatal-ink);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -67,9 +67,9 @@
 
 .kidFallbackBtn {
   appearance: none;
-  border: 4px solid #fff;
+  border: 4px solid var(--tal-fatal-ink);
   background: transparent;
-  color: #fff;
+  color: var(--tal-fatal-ink);
   font-size: 28px;
   font-weight: 800;
   padding: 32px 48px;

--- a/src/ui/KidModeGate/PinPad.module.css
+++ b/src/ui/KidModeGate/PinPad.module.css
@@ -71,7 +71,7 @@
 
 .error {
   font-size: 13px;
-  color: #b4261a;
+  color: var(--tal-danger);
   min-height: 18px;
   margin-top: 14px;
 }

--- a/src/ui/Modal/Modal.module.css
+++ b/src/ui/Modal/Modal.module.css
@@ -1,7 +1,7 @@
 .overlay {
   position: absolute;
   inset: 0;
-  background: rgb(40 30 20 / 32%);
+  background: var(--tal-overlay);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/ui/Toggle/Toggle.module.css
+++ b/src/ui/Toggle/Toggle.module.css
@@ -31,7 +31,7 @@
   width: 14px;
   height: 14px;
   border-radius: var(--tal-r-pill);
-  background: #fff;
+  background: var(--tal-on-accent);
   transition: left 0.15s;
 }
 


### PR DESCRIPTION
## Summary

- Adds `--tal-on-accent`, `--tal-overlay`, `--tal-danger`, `--tal-fatal-bg`, `--tal-fatal-ink`, `--tal-brand-sky`, `--tal-brand-mark` to `src/theme/tokens.module.css` and the `ColorToken` union in `tokens.ts`.
- Sweeps the ten remaining hex/rgb literals across 8 files outside `src/theme/`. `TalrumMark.tsx` SVG fills now reference brand tokens (#141 — tokenized so retinting is possible later).
- Zero pixel change: every new token is initialized to the literal it replaces.

Closes #127.
Closes #141.

## Test plan

- [x] `npm run lint && npm run typecheck && npm run test` — clean (272/272).
- [x] `grep -rn "#fff\|#000\|#b4261a\|#7cb8e0\|#ffffff" src/ --include="*.module.css" --include="*.tsx" | grep -v "src/theme/" | grep -v "\.test\."` — zero hits.
- [ ] Manual smoke: brand mark in sidebar, recording-red in VoiceRecorderDialog, kid-mode fatal screen still high-contrast.