### PR TITLE
refactor(ui): let PictoCard own sizing; PictoTile is a pure button (#136)

### DIFF
--- a/src/ui/PictoTile/PictoTile.tsx
+++ b/src/ui/PictoTile/PictoTile.tsx
@@ -28,12 +28,13 @@ export const PictoTile = ({
   onClick,
   style,
 }: PictoTileProps): JSX.Element => (
-  <button
-    type="button"
-    className={styles.tileButton}
-    onClick={onClick}
-    style={{ width: size, ...style }}
-  >
-    <PictoCard picto={picto} size={size} showLabel={showLabel} selected={selected} />
+  <button type="button" className={styles.tileButton} onClick={onClick}>
+    <PictoCard
+      picto={picto}
+      size={size}
+      showLabel={showLabel}
+      selected={selected}
+      {...(style ? { style } : {})}
+    />
   </button>
 );


### PR DESCRIPTION
## Summary

Both `PictoTile.tsx` and `PictoCard.tsx` applied `style={{ width: size, ...style }}`. The duplication is gone: PictoTile becomes a thin flex-column button that hugs its child's width (`tileButton` has no width rule), and PictoCard owns the inline sizing.

The `style` prop is conditionally spread to satisfy `exactOptionalPropertyTypes`.

Closes #136.

## Test plan

- [x] `npm run lint && npm run lint:css && npm run typecheck && npm run test` — clean (272/272).
- [ ] Manual: parent-home picto previews and board-builder picker grid render at the correct width.