### PR TITLE
theme: spacing tokens + spaceVar helper (#134, foundation)

### DIFF
--- a/src/theme/tokens.module.css
+++ b/src/theme/tokens.module.css
@@ -53,6 +53,22 @@
   --tal-photo-stripe-a: oklch(93% 0.01 85);
   --tal-photo-stripe-b: oklch(88% 0.014 85);
 
+  /* Spacing — keyed by px value for self-documentation. Use for
+     padding/margin/gap/inset, not border widths or font-size. */
+  --tal-space-4: 4px;
+  --tal-space-6: 6px;
+  --tal-space-8: 8px;
+  --tal-space-10: 10px;
+  --tal-space-12: 12px;
+  --tal-space-14: 14px;
+  --tal-space-16: 16px;
+  --tal-space-20: 20px;
+  --tal-space-24: 24px;
+  --tal-space-28: 28px;
+  --tal-space-32: 32px;
+  --tal-space-40: 40px;
+  --tal-space-48: 48px;
+
   /* Radii */
   --tal-r-sm: 10px;
   --tal-r-md: 16px;

--- a/src/theme/tokens.test.ts
+++ b/src/theme/tokens.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from 'vitest';
 
-import { accentForIndex, cssVar } from './tokens';
+import { accentForIndex, cssVar, spaceVar } from './tokens';
 
 describe('cssVar', () => {
   it('wraps a color token in a CSS var reference', () => {
     expect(cssVar('sage')).toBe('var(--tal-sage)');
     expect(cssVar('ink-muted')).toBe('var(--tal-ink-muted)');
+  });
+});
+
+describe('spaceVar', () => {
+  it('wraps a space token in a CSS var reference', () => {
+    expect(spaceVar('12')).toBe('var(--tal-space-12)');
+    expect(spaceVar('48')).toBe('var(--tal-space-48)');
   });
 });
 

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -42,11 +42,28 @@ export type RadiusToken = 'sm' | 'md' | 'lg' | 'xl' | 'pill';
 
 export type ShadowToken = '1' | '2' | '3';
 
+export type SpaceToken =
+  | '4'
+  | '6'
+  | '8'
+  | '10'
+  | '12'
+  | '14'
+  | '16'
+  | '20'
+  | '24'
+  | '28'
+  | '32'
+  | '40'
+  | '48';
+
 export const cssVar = (token: ColorToken): string => `var(--tal-${token})`;
 
 export const radiusVar = (token: RadiusToken): string => `var(--tal-r-${token})`;
 
 export const shadowVar = (token: ShadowToken): string => `var(--tal-shadow-${token})`;
+
+export const spaceVar = (token: SpaceToken): string => `var(--tal-space-${token})`;
 
 export interface Accent {
   bg: ColorToken;


### PR DESCRIPTION
## Summary

- 13 new `--tal-space-N` tokens covering the natural scale derived by frequency-ranking padding/gap/margin literals across `src/{features,ui,layouts}` (`4,6,8,10,12,14,16,20,24,28,32,40,48`). Token names equal their px value, so the sweep that follows is purely mechanical (1:1 same-value).
- `SpaceToken` union + `spaceVar()` helper in `tokens.ts` mirroring `radiusVar` / `shadowVar`.
- `tokens.test.ts` extended with one assertion.

This is the foundation PR. Three sweep PRs follow (`src/ui` + `src/layouts`, `src/features/board-builder`, then the remaining feature folders) before #134 closes.

Refs #134.

## Test plan

- [x] `npm run lint && npm run lint:css && npm run typecheck && npm run test` — clean (273/273).