### PR TITLE
theme: switch spacing tokens to scale-position semantics (#134)

### DIFF
--- a/src/theme/tokens.module.css
+++ b/src/theme/tokens.module.css
@@ -53,21 +53,21 @@
   --tal-photo-stripe-a: oklch(93% 0.01 85);
   --tal-photo-stripe-b: oklch(88% 0.014 85);
 
-  /* Spacing — keyed by px value for self-documentation. Use for
-     padding/margin/gap/inset, not border widths or font-size. */
-  --tal-space-4: 4px;
-  --tal-space-6: 6px;
-  --tal-space-8: 8px;
-  --tal-space-10: 10px;
-  --tal-space-12: 12px;
-  --tal-space-14: 14px;
-  --tal-space-16: 16px;
-  --tal-space-20: 20px;
-  --tal-space-24: 24px;
-  --tal-space-28: 28px;
-  --tal-space-32: 32px;
-  --tal-space-40: 40px;
-  --tal-space-48: 48px;
+  /* Spacing — scale-position tokens on a 4px base. The number is the
+     position on the scale, not the px value. Use for padding/margin/
+     gap/inset, not border widths or font-size. Off-scale values
+     (10/14/18/22/...) snap to the nearest step during the call-site
+     sweep (#134). */
+  --tal-space-1: 4px;
+  --tal-space-2: 8px;
+  --tal-space-3: 12px;
+  --tal-space-4: 16px;
+  --tal-space-5: 20px;
+  --tal-space-6: 24px;
+  --tal-space-7: 28px;
+  --tal-space-8: 32px;
+  --tal-space-10: 40px;
+  --tal-space-12: 48px;
 
   /* Radii */
   --tal-r-sm: 10px;

--- a/src/theme/tokens.test.ts
+++ b/src/theme/tokens.test.ts
@@ -11,8 +11,8 @@ describe('cssVar', () => {
 
 describe('spaceVar', () => {
   it('wraps a space token in a CSS var reference', () => {
+    expect(spaceVar('3')).toBe('var(--tal-space-3)');
     expect(spaceVar('12')).toBe('var(--tal-space-12)');
-    expect(spaceVar('48')).toBe('var(--tal-space-48)');
   });
 });
 

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -42,20 +42,7 @@ export type RadiusToken = 'sm' | 'md' | 'lg' | 'xl' | 'pill';
 
 export type ShadowToken = '1' | '2' | '3';
 
-export type SpaceToken =
-  | '4'
-  | '6'
-  | '8'
-  | '10'
-  | '12'
-  | '14'
-  | '16'
-  | '20'
-  | '24'
-  | '28'
-  | '32'
-  | '40'
-  | '48';
+export type SpaceToken = '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '10' | '12';
 
 export const cssVar = (token: ColorToken): string => `var(--tal-${token})`;
 


### PR DESCRIPTION
## Summary

Replaces the px-keyed `--tal-space-N` tokens from #159 with scale-position tokens on a 4px base. The number now means *position on the scale*, not the px value — matching Tailwind / Carbon / Radix conventions:

```
--tal-space-1: 4px;     --tal-space-6: 24px;
--tal-space-2: 8px;     --tal-space-7: 28px;
--tal-space-3: 12px;    --tal-space-8: 32px;
--tal-space-4: 16px;    --tal-space-10: 40px;
--tal-space-5: 20px;    --tal-space-12: 48px;
```

Off-scale values (6, 10, 14 px) are intentionally absent — they snap to the nearest step during the call-site sweep that follows. The previous px-keyed naming (added in #159) was 1:1 with literals and added no semantic value beyond enabling global rescaling; this revision provides the scale discipline that makes a stylelint guard meaningful.

Foundation only — no call-site sweep yet. Six sweep PRs and a stylelint spacing-px guard will close #134.

Refs #134.

## Test plan

- [x] `npm run lint && npm run lint:css && npm run typecheck && npm run test` — clean (273/273).