### PR TITLE
refactor(ui): adopt spacing scale across primitives with snap discipline (#134)

### DIFF
--- a/src/ui/Button/Button.module.css
+++ b/src/ui/Button/Button.module.css
@@ -1,7 +1,7 @@
 .button {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--tal-space-2);
   border-radius: var(--tal-r-pill);
   font-size: 15px;
   font-weight: 700;
@@ -18,7 +18,7 @@
 }
 
 .primary {
-  padding: 12px 18px;
+  padding: var(--tal-space-3) var(--tal-space-4);
   background: var(--tal-ink);
   color: var(--tal-on-accent);
   box-shadow: var(--tal-shadow-1);
@@ -29,6 +29,8 @@
 }
 
 .ghost {
+  /* 1px less than .primary to compensate for the 1px border so both
+     buttons render at the same outside dimensions. */
   padding: 11px 17px;
   background: var(--tal-surface);
   color: var(--tal-ink);
@@ -36,7 +38,7 @@
 }
 
 .pill {
-  padding: 10px 14px;
+  padding: var(--tal-space-3) var(--tal-space-4);
   background: var(--tal-surface);
   color: var(--tal-ink-soft);
   border: 1px solid var(--tal-line);

--- a/src/ui/Chip/Chip.module.css
+++ b/src/ui/Chip/Chip.module.css
@@ -1,7 +1,7 @@
 .chip {
   display: inline-flex;
   align-items: center;
-  padding: 6px 12px;
+  padding: var(--tal-space-2) var(--tal-space-3);
   border-radius: var(--tal-r-pill);
   font-size: 13px;
   font-weight: 700;

--- a/src/ui/ComingSoon/ComingSoon.module.css
+++ b/src/ui/ComingSoon/ComingSoon.module.css
@@ -1,7 +1,7 @@
 .wrap {
   display: flex;
   align-items: flex-start;
-  padding-top: 48px;
+  padding-top: var(--tal-space-12);
   max-width: 520px;
 }
 

--- a/src/ui/DialogActions/DialogActions.module.css
+++ b/src/ui/DialogActions/DialogActions.module.css
@@ -1,6 +1,6 @@
 .actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
-  margin-top: 20px;
+  gap: var(--tal-space-2);
+  margin-top: var(--tal-space-5);
 }

--- a/src/ui/DialogHeader/DialogHeader.module.css
+++ b/src/ui/DialogHeader/DialogHeader.module.css
@@ -2,8 +2,8 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 18px;
+  gap: var(--tal-space-4);
+  margin-bottom: var(--tal-space-4);
 }
 
 .title {

--- a/src/ui/EmptyState/EmptyState.module.css
+++ b/src/ui/EmptyState/EmptyState.module.css
@@ -4,9 +4,9 @@
   align-items: center;
   justify-content: center;
   text-align: center;
-  gap: 14px;
-  padding: 60px 32px;
-  margin-top: 8px;
+  gap: var(--tal-space-4);
+  padding: var(--tal-space-12) var(--tal-space-8);
+  margin-top: var(--tal-space-2);
   border: 2px dashed var(--tal-line);
   border-radius: var(--tal-r-lg);
   background: var(--tal-surface-alt);

--- a/src/ui/ErrorBoundary/ErrorBoundary.module.css
+++ b/src/ui/ErrorBoundary/ErrorBoundary.module.css
@@ -3,8 +3,8 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
-  padding: 48px 24px;
+  gap: var(--tal-space-4);
+  padding: var(--tal-space-12) var(--tal-space-6);
   text-align: center;
   color: var(--tal-ink);
 }
@@ -22,8 +22,8 @@
 
 .routeFallbackActions {
   display: inline-flex;
-  gap: 12px;
-  margin-top: 8px;
+  gap: var(--tal-space-3);
+  margin-top: var(--tal-space-2);
 }
 
 .routeFallbackBtn {
@@ -33,7 +33,7 @@
   color: var(--tal-ink);
   font-size: 14px;
   font-weight: 600;
-  padding: 10px 18px;
+  padding: var(--tal-space-3) var(--tal-space-4);
   border-radius: var(--tal-r-pill);
   border: 1px solid var(--tal-line);
   cursor: pointer;
@@ -72,7 +72,7 @@
   color: var(--tal-fatal-ink);
   font-size: 28px;
   font-weight: 800;
-  padding: 32px 48px;
+  padding: var(--tal-space-8) var(--tal-space-12);
   border-radius: 24px;
   cursor: pointer;
   text-decoration: none;
@@ -88,8 +88,8 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
-  padding: 24px;
+  gap: var(--tal-space-4);
+  padding: var(--tal-space-6);
   text-align: center;
   background: var(--tal-bg);
   color: var(--tal-ink);
@@ -105,7 +105,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
+  gap: var(--tal-space-4);
   height: 100vh;
 }
 

--- a/src/ui/KidModeGate/PinPad.module.css
+++ b/src/ui/KidModeGate/PinPad.module.css
@@ -1,5 +1,5 @@
 .wrap {
-  padding: 32px 28px 28px;
+  padding: var(--tal-space-8) var(--tal-space-7) var(--tal-space-7);
   min-width: 340px;
   text-align: center;
 }
@@ -8,20 +8,20 @@
   font-size: 22px;
   font-weight: 700;
   color: var(--tal-ink);
-  margin: 0 0 6px;
+  margin: 0 0 var(--tal-space-2);
 }
 
 .subtitle {
   font-size: 14px;
   color: var(--tal-ink-muted);
-  margin: 0 0 22px;
+  margin: 0 0 var(--tal-space-6);
 }
 
 .dots {
   display: flex;
-  gap: 14px;
+  gap: var(--tal-space-4);
   justify-content: center;
-  margin-bottom: 22px;
+  margin-bottom: var(--tal-space-6);
 }
 
 .dot {
@@ -41,7 +41,7 @@
 .grid {
   display: grid;
   grid-template-columns: repeat(3, 72px);
-  gap: 12px;
+  gap: var(--tal-space-3);
   justify-content: center;
 }
 
@@ -73,7 +73,7 @@
   font-size: 13px;
   color: var(--tal-danger);
   min-height: 18px;
-  margin-top: 14px;
+  margin-top: var(--tal-space-4);
 }
 
 .cancel {
@@ -82,7 +82,7 @@
   color: var(--tal-ink-muted);
   font-size: 13px;
   font-weight: 600;
-  padding: 8px 14px;
-  margin-top: 10px;
+  padding: var(--tal-space-2) var(--tal-space-4);
+  margin-top: var(--tal-space-3);
   cursor: pointer;
 }

--- a/src/ui/Modal/Modal.module.css
+++ b/src/ui/Modal/Modal.module.css
@@ -5,7 +5,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 30px;
+  padding: var(--tal-space-8);
   z-index: 20;
 }
 

--- a/src/ui/NewKidModal/NewKidModal.module.css
+++ b/src/ui/NewKidModal/NewKidModal.module.css
@@ -1,12 +1,12 @@
 .wrap {
-  padding: 28px 28px 24px;
+  padding: var(--tal-space-7) var(--tal-space-7) var(--tal-space-6);
   max-width: 440px;
   width: 100%;
   margin: 0 auto;
 }
 
 .error {
-  margin: 8px 0 0;
+  margin: var(--tal-space-2) 0 0;
   font-size: 13px;
   color: var(--tal-coral-ink);
 }

--- a/src/ui/OfflineIndicator/OfflineIndicator.module.css
+++ b/src/ui/OfflineIndicator/OfflineIndicator.module.css
@@ -1,8 +1,8 @@
 .pill {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 12px;
+  gap: var(--tal-space-2);
+  padding: var(--tal-space-2) var(--tal-space-3);
   border-radius: var(--tal-r-pill);
   font-size: 13px;
   font-weight: 500;
@@ -53,7 +53,7 @@
   color: inherit;
   font-size: 13px;
   font-weight: 600;
-  padding: 2px 6px;
+  padding: 2px var(--tal-space-2);
   cursor: pointer;
   text-decoration: underline;
 }

--- a/src/ui/PictoTile/PictoTile.module.css
+++ b/src/ui/PictoTile/PictoTile.module.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
+  gap: var(--tal-space-3);
   padding: 0;
 }
 

--- a/src/ui/Segmented/Segmented.module.css
+++ b/src/ui/Segmented/Segmented.module.css
@@ -1,13 +1,13 @@
 .segmented {
   display: inline-flex;
   background: var(--tal-surface-alt);
-  padding: 4px;
+  padding: var(--tal-space-1);
   border-radius: var(--tal-r-pill);
   gap: 2px;
 }
 
 .option {
-  padding: 9px 16px;
+  padding: var(--tal-space-2) var(--tal-space-4);
   border-radius: var(--tal-r-pill);
   background: transparent;
   color: var(--tal-ink-soft);

--- a/src/ui/Select/Select.module.css
+++ b/src/ui/Select/Select.module.css
@@ -1,8 +1,8 @@
 .wrapper {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 14px 10px 16px;
+  gap: var(--tal-space-3);
+  padding: var(--tal-space-3) var(--tal-space-4);
   border-radius: var(--tal-r-pill);
   background: var(--tal-surface);
   border: 1px solid var(--tal-line);
@@ -22,7 +22,7 @@
   border: 0;
   font: inherit;
   color: inherit;
-  padding-right: 20px;
+  padding-right: var(--tal-space-5);
   cursor: pointer;
   outline: none;
 }

--- a/src/ui/TextField/TextField.module.css
+++ b/src/ui/TextField/TextField.module.css
@@ -1,7 +1,7 @@
 .field {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--tal-space-2);
 }
 
 .label {
@@ -15,7 +15,7 @@
 .input {
   font: inherit;
   font-size: 15px;
-  padding: 10px 12px;
+  padding: var(--tal-space-3);
   border: 1px solid var(--tal-line);
   border-radius: var(--tal-r-md);
   background: var(--tal-surface);

--- a/src/ui/Toggle/Toggle.module.css
+++ b/src/ui/Toggle/Toggle.module.css
@@ -1,8 +1,8 @@
 .toggle {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 14px;
+  gap: var(--tal-space-3);
+  padding: var(--tal-space-3) var(--tal-space-4);
   border-radius: var(--tal-r-pill);
   background: var(--tal-surface);
   border: 1px solid var(--tal-line);
@@ -36,5 +36,5 @@
 }
 
 .thumbOn {
-  left: 16px;
+  left: var(--tal-space-4);
 }


### PR DESCRIPTION
## Summary

Sweeps `src/ui/*` to use the scale-position spacing tokens (#160). Off-scale literals snap to the nearest step:

| from | to | notes |
|---|---|---|
| 6px | space-2 (8) | +2 |
| 10px | space-3 (12) | +2 |
| 14px | space-4 (16) | +2 |
| 18px | space-4 (16) | -2 |
| 22px | space-6 (24) | +2 |
| 30px | space-8 (32) | +2 |
| 60px | space-12 (48) | -12 (EmptyState top padding) |

On-scale literals (4, 8, 12, 16, 20, 24, 28, 32, 40, 48) become the matching tokens with no pixel change. Border widths (1, 2px) and sizing (width/height/font-size) left as-is.

**Two raw-px holdouts** (commented):
- `Button.ghost` retains `11/17` — 1px less per side than `.primary` to compensate for its 1px border so both render at the same outside dimensions.

## Visible deltas

- `Button.pill`: 10×14 → 12×16 (slightly larger).
- `Chip`: 6×12 → 8×12.
- `DialogHeader.margin-bottom`: 18 → 16.
- `EmptyState.padding-top`: 60 → 48 (-20%).
- `KidModeGate` subtitle margin-bottom 22→24, dots margin-bottom 22→24, title margin-bottom 6→8, error margin-top 14→16, cancel padding 8/14→8/16.
- `Modal.overlay`: 30 → 32.
- `OfflineIndicator.pill`: 6/12 → 8/12.
- `PictoTile.tile.gap`: 10 → 12.
- `Segmented.option`: 9/16 → 8/16.
- `Select.wrapper`: 10/14/10/16 → 12/16/12/16.
- `TextField.input`: 10/12 → 12/12.
- `Toggle`: 10/14 → 12/16. Thumb travel unchanged (left:16 == space-4).

Refs #134. Builds on #160.

## Test plan

- [x] `npm run lint && npm run lint:css && npm run typecheck && npm run test` — clean (273/273).
- [ ] Visual smoke: open each primitive in dev, no broken layouts.