### PR TITLE
refactor(board-builder): adopt spacing scale (#134)

### DIFF
--- a/src/features/board-builder/BoardBuilder.module.css
+++ b/src/features/board-builder/BoardBuilder.module.css
@@ -1,8 +1,9 @@
 .breadcrumb {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 8px;
+  gap: var(--tal-space-3);
+  margin-bottom: var(--tal-space-2);
+  /* Negative pull to align breadcrumb above the title row. */
   margin-top: -4px;
 }
 
@@ -14,7 +15,7 @@
   background: var(--tal-surface);
   border: 1px solid var(--tal-line);
   border-radius: var(--tal-r-pill);
-  padding: 6px 14px;
+  padding: var(--tal-space-2) var(--tal-space-4);
   cursor: pointer;
 }
 
@@ -25,11 +26,11 @@
 .back {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--tal-space-2);
   font-size: 14px;
   font-weight: 700;
   color: var(--tal-ink-soft);
-  padding: 6px 10px;
+  padding: var(--tal-space-2) var(--tal-space-3);
   border-radius: 8px;
 }
 
@@ -52,7 +53,7 @@
   border: none;
   outline: none;
   width: 100%;
-  padding: 4px 0;
+  padding: var(--tal-space-1) 0;
   border-bottom: 2px solid transparent;
   font-family: inherit;
 }
@@ -64,7 +65,7 @@
 .track {
   background: var(--tal-surface);
   border-radius: var(--tal-r-lg);
-  padding: 28px 24px;
+  padding: var(--tal-space-7) var(--tal-space-6);
   box-shadow: var(--tal-shadow-1);
   border: 1px solid var(--tal-line-soft);
 }
@@ -72,15 +73,15 @@
 .rail {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
+  gap: var(--tal-space-2);
   overflow-x: auto;
-  padding-bottom: 10px;
+  padding-bottom: var(--tal-space-3);
 }
 
 .connector {
   align-self: center;
   color: var(--tal-ink-muted);
-  margin-top: 14px;
+  margin-top: var(--tal-space-4);
   flex-shrink: 0;
 }
 
@@ -88,13 +89,13 @@
   font-size: 13px;
   font-weight: 800;
   color: var(--tal-ink-muted);
-  padding: 6px 10px;
+  padding: var(--tal-space-2) var(--tal-space-3);
   border-radius: var(--tal-r-pill);
   background: var(--tal-bg);
 }
 
 .addTile {
-  margin-top: 14px;
+  margin-top: var(--tal-space-4);
   width: 132px;
   height: 132px;
   border-radius: var(--tal-r-lg);
@@ -105,21 +106,21 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: var(--tal-space-2);
   font-size: 13px;
   font-weight: 700;
   flex-shrink: 0;
 }
 
 .quickAdd {
-  margin-top: 32px;
+  margin-top: var(--tal-space-8);
 }
 
 .quickAddHeader {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  margin-bottom: 14px;
+  margin-bottom: var(--tal-space-4);
 }
 
 .quickAddHeading {
@@ -137,6 +138,6 @@
 
 .quickAddGrid {
   display: flex;
-  gap: 14px;
+  gap: var(--tal-space-4);
   flex-wrap: wrap;
 }

--- a/src/features/board-builder/BoardErrorBanner.module.css
+++ b/src/features/board-builder/BoardErrorBanner.module.css
@@ -1,9 +1,9 @@
 .banner {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 10px 14px;
-  margin: 8px 0;
+  gap: var(--tal-space-3);
+  padding: var(--tal-space-3) var(--tal-space-4);
+  margin: var(--tal-space-2) 0;
   background: var(--tal-peach);
   color: var(--tal-peach-ink);
   border-radius: var(--tal-r-md);
@@ -18,7 +18,7 @@
 
 .retry,
 .dismiss {
-  padding: 6px 12px;
+  padding: var(--tal-space-2) var(--tal-space-3);
   border-radius: var(--tal-r-pill);
   font-size: 13px;
   font-weight: 700;

--- a/src/features/board-builder/BoardNotFound.module.css
+++ b/src/features/board-builder/BoardNotFound.module.css
@@ -2,8 +2,8 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 16px;
-  padding-top: 48px;
+  gap: var(--tal-space-4);
+  padding-top: var(--tal-space-12);
   max-width: 520px;
 }
 
@@ -23,6 +23,6 @@
 
 .actions {
   display: flex;
-  gap: 12px;
-  margin-top: 4px;
+  gap: var(--tal-space-3);
+  margin-top: var(--tal-space-1);
 }

--- a/src/features/board-builder/SettingsRow.module.css
+++ b/src/features/board-builder/SettingsRow.module.css
@@ -1,9 +1,9 @@
 .row {
   display: flex;
-  gap: 10px;
+  gap: var(--tal-space-3);
   flex-wrap: wrap;
-  margin-top: 12px;
-  margin-bottom: 28px;
+  margin-top: var(--tal-space-3);
+  margin-bottom: var(--tal-space-7);
 }
 
 .spacer {

--- a/src/features/board-builder/ShareModal.module.css
+++ b/src/features/board-builder/ShareModal.module.css
@@ -1,5 +1,5 @@
 .wrap {
-  padding: 28px 28px 24px;
+  padding: var(--tal-space-7) var(--tal-space-7) var(--tal-space-6);
   max-width: 520px;
   width: 100%;
   margin: 0 auto;
@@ -7,12 +7,12 @@
 
 .section {
   border-top: 1px solid var(--tal-line-soft);
-  padding: 16px 0;
+  padding: var(--tal-space-4) 0;
 }
 
 .section:first-of-type {
   border-top: none;
-  padding-top: 4px;
+  padding-top: var(--tal-space-1);
 }
 
 .sectionLabel {
@@ -22,13 +22,13 @@
   text-transform: uppercase;
   letter-spacing: 0.5px;
   color: var(--tal-ink-muted);
-  margin: 0 0 8px;
+  margin: 0 0 var(--tal-space-2);
 }
 
 .idRow {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--tal-space-2);
 }
 
 .idValue {
@@ -39,7 +39,7 @@
   background: var(--tal-bg);
   border: 1px solid var(--tal-line-soft);
   border-radius: var(--tal-r-md);
-  padding: 8px 10px;
+  padding: var(--tal-space-2) var(--tal-space-3);
   overflow-x: auto;
   white-space: nowrap;
 }
@@ -52,7 +52,7 @@
   background: var(--tal-surface);
   border: 1px solid var(--tal-line);
   border-radius: var(--tal-r-md);
-  padding: 8px 12px;
+  padding: var(--tal-space-2) var(--tal-space-3);
   cursor: pointer;
 }
 
@@ -69,7 +69,7 @@
 .memberList {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--tal-space-2);
   list-style: none;
   padding: 0;
   margin: 0;
@@ -79,8 +79,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  padding: 8px 10px;
+  gap: var(--tal-space-2);
+  padding: var(--tal-space-2) var(--tal-space-3);
   background: var(--tal-bg);
   border-radius: var(--tal-r-md);
 }
@@ -102,7 +102,7 @@
   letter-spacing: 0.4px;
   color: var(--tal-ink-muted);
   background: var(--tal-surface);
-  padding: 2px 8px;
+  padding: 2px var(--tal-space-2);
   border-radius: var(--tal-r-pill);
   flex-shrink: 0;
 }
@@ -128,14 +128,14 @@
 
 .addRow {
   display: flex;
-  gap: 8px;
+  gap: var(--tal-space-2);
 }
 
 .input {
   flex: 1 1 auto;
   font-family: ui-monospace, SFMono-Regular, monospace;
   font-size: 13px;
-  padding: 8px 10px;
+  padding: var(--tal-space-2) var(--tal-space-3);
   border: 1px solid var(--tal-line);
   border-radius: var(--tal-r-md);
   background: var(--tal-surface);
@@ -148,7 +148,7 @@
 }
 
 .error {
-  margin: 8px 0 0;
+  margin: var(--tal-space-2) 0 0;
   font-size: 13px;
   color: var(--tal-coral-ink);
 }

--- a/src/features/board-builder/StepTile.module.css
+++ b/src/features/board-builder/StepTile.module.css
@@ -1,6 +1,6 @@
 .step {
   position: relative;
-  padding: 8px;
+  padding: var(--tal-space-2);
   border-radius: var(--tal-r-md);
   cursor: grab;
   transition: background 0.15s;
@@ -24,7 +24,7 @@
 }
 
 .body {
-  padding-top: 14px;
+  padding-top: var(--tal-space-4);
 }
 
 .remove {

--- a/src/features/board-builder/pictogram-picker/PictoPicker.module.css
+++ b/src/features/board-builder/pictogram-picker/PictoPicker.module.css
@@ -1,5 +1,5 @@
 .header {
-  padding: 22px 28px;
+  padding: var(--tal-space-6) var(--tal-space-7);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -15,7 +15,7 @@
 }
 
 .subtitle {
-  margin: 4px 0 0;
+  margin: var(--tal-space-1) 0 0;
   font-size: 13px;
   color: var(--tal-ink-soft);
   font-weight: 500;
@@ -33,13 +33,13 @@
 }
 
 .tabs {
-  padding: 16px 28px 0;
+  padding: var(--tal-space-4) var(--tal-space-7) 0;
   display: flex;
-  gap: 4px;
+  gap: var(--tal-space-1);
 }
 
 .tab {
-  padding: 12px 18px;
+  padding: var(--tal-space-3) var(--tal-space-4);
   border-radius: 12px 12px 0 0;
   background: transparent;
   color: var(--tal-ink-soft);
@@ -55,7 +55,7 @@
 }
 
 .tabSub {
-  margin-left: 8px;
+  margin-left: var(--tal-space-2);
   font-size: 12px;
   color: var(--tal-ink-muted);
   font-weight: 600;
@@ -69,7 +69,7 @@
 }
 
 .footer {
-  padding: 16px 28px;
+  padding: var(--tal-space-4) var(--tal-space-7);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -85,5 +85,5 @@
 
 .footerActions {
   display: flex;
-  gap: 10px;
+  gap: var(--tal-space-3);
 }

--- a/src/features/board-builder/pictogram-picker/VoiceRecorderDialog.module.css
+++ b/src/features/board-builder/pictogram-picker/VoiceRecorderDialog.module.css
@@ -2,15 +2,15 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 16px;
-  padding: 24px 28px 12px;
+  gap: var(--tal-space-4);
+  padding: var(--tal-space-6) var(--tal-space-7) var(--tal-space-3);
 }
 
 .title {
   font-size: 22px;
   font-weight: 800;
   color: var(--tal-ink);
-  margin: 0 0 4px;
+  margin: 0 0 var(--tal-space-1);
 }
 
 .subtitle {
@@ -37,8 +37,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 16px;
-  padding: 8px 28px 4px;
+  gap: var(--tal-space-4);
+  padding: var(--tal-space-2) var(--tal-space-7) var(--tal-space-1);
 }
 
 .preview {
@@ -55,7 +55,7 @@
   color: var(--tal-danger);
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--tal-space-2);
 }
 
 .recDot::before {
@@ -96,14 +96,14 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 12px;
-  padding: 16px 28px 24px;
+  gap: var(--tal-space-3);
+  padding: var(--tal-space-4) var(--tal-space-7) var(--tal-space-6);
   border-top: 1px solid var(--tal-line);
-  margin-top: 12px;
+  margin-top: var(--tal-space-3);
 }
 
 .footerLeft,
 .footerRight {
   display: flex;
-  gap: 8px;
+  gap: var(--tal-space-2);
 }

--- a/src/features/board-builder/pictogram-picker/tabs/LibraryTab.module.css
+++ b/src/features/board-builder/pictogram-picker/tabs/LibraryTab.module.css
@@ -1,16 +1,16 @@
 .wrap {
-  padding: 28px;
+  padding: var(--tal-space-7);
 }
 
 .searchRow {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--tal-space-3);
   background: var(--tal-surface);
-  padding: 12px 16px;
+  padding: var(--tal-space-3) var(--tal-space-4);
   border-radius: var(--tal-r-pill);
   border: 1px solid var(--tal-line);
-  margin-bottom: 20px;
+  margin-bottom: var(--tal-space-5);
 }
 
 .searchInput {
@@ -25,13 +25,13 @@
 
 .filters {
   display: flex;
-  gap: 6px;
+  gap: var(--tal-space-2);
 }
 
 .grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-  gap: 16px;
+  gap: var(--tal-space-4);
 }
 
 .entry {

--- a/src/features/board-builder/pictogram-picker/tabs/UploadTab.module.css
+++ b/src/features/board-builder/pictogram-picker/tabs/UploadTab.module.css
@@ -1,12 +1,12 @@
 .wrap {
-  padding: 28px;
+  padding: var(--tal-space-7);
 }
 
 .dropzone {
   border: 2px dashed var(--tal-line);
   border-radius: var(--tal-r-lg);
   background: var(--tal-surface);
-  padding: 56px 28px;
+  padding: var(--tal-space-12) var(--tal-space-7);
   text-align: center;
   width: 100%;
   cursor: pointer;
@@ -29,12 +29,12 @@
 
 .preview {
   display: flex;
-  gap: 24px;
+  gap: var(--tal-space-6);
   align-items: stretch;
   background: var(--tal-surface);
   border: 1px solid var(--tal-line);
   border-radius: var(--tal-r-lg);
-  padding: 20px;
+  padding: var(--tal-space-5);
 }
 
 .previewImg {
@@ -49,13 +49,13 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: var(--tal-space-4);
 }
 
 .labelField {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--tal-space-2);
 }
 
 .labelHint {
@@ -68,7 +68,7 @@
 
 .labelInput {
   font: inherit;
-  padding: 10px 12px;
+  padding: var(--tal-space-3);
   border: 1px solid var(--tal-line);
   border-radius: var(--tal-r-md);
   background: var(--tal-bg);
@@ -82,7 +82,7 @@
 
 .previewActions {
   display: flex;
-  gap: 10px;
+  gap: var(--tal-space-3);
   margin-top: auto;
   justify-content: flex-end;
 }
@@ -91,7 +91,7 @@
   font-size: 13px;
   color: var(--tal-coral-ink, var(--tal-ink));
   background: var(--tal-coral, var(--tal-surface-alt));
-  padding: 8px 12px;
+  padding: var(--tal-space-2) var(--tal-space-3);
   border-radius: var(--tal-r-md);
 }
 
@@ -99,7 +99,7 @@
   width: 64px;
   height: 64px;
   border-radius: 20px;
-  margin: 0 auto 14px;
+  margin: 0 auto var(--tal-space-4);
   background: var(--tal-sky);
   color: var(--tal-sky-ink);
   display: flex;
@@ -116,7 +116,7 @@
 .hint {
   font-size: 14px;
   color: var(--tal-ink-soft);
-  margin-top: 4px;
+  margin-top: var(--tal-space-1);
 }
 
 .recentHeading {
@@ -125,11 +125,11 @@
   color: var(--tal-ink-soft);
   letter-spacing: 0.4px;
   text-transform: uppercase;
-  margin: 24px 0 12px;
+  margin: var(--tal-space-6) 0 var(--tal-space-3);
 }
 
 .recentRow {
   display: flex;
-  gap: 14px;
+  gap: var(--tal-space-4);
   flex-wrap: wrap;
 }


### PR DESCRIPTION
## Summary

10 files swept across `src/features/board-builder/` (builder, picker, tabs, voice recorder, share modal). Off-scale snaps:

- 6 → 8: share button, back button, addTile gap, retry/dismiss padding
- 10 → 12: breadcrumb gap, rail padding-bottom, footer gaps, share-modal idValue/copyBtn padding, library searchRow gap, upload previewActions gap
- 14 → 16: addTile margin-top, connector margin-top, quickAdd grid gap + header margin-bottom, picker tab vertical padding, upload previewSide/recentRow gaps
- 18 → 16: picker tab horizontal padding
- 22 → 24: picker header vertical padding
- 56 → 48: UploadTab dropzone vertical padding (-14%)

On-scale literals tokenized without pixel change. Border widths (1px, 2px) and sizing left raw.

**One holdout** (commented):
- `BoardBuilder.breadcrumb` keeps `margin-top: -4px` — negative pull alignment doesn't fit the scale.

Refs #134. Builds on #160.

## Test plan

- [x] `npm run lint && npm run lint:css && npm run typecheck && npm run test` — clean (273/273).
- [ ] Visual smoke: builder grid, picker tabs (library + upload), share modal, voice recorder.