### PR TITLE
refactor(parent-home): adopt spacing scale (#134)

### DIFF
--- a/src/features/parent-home/BoardCard.module.css
+++ b/src/features/parent-home/BoardCard.module.css
@@ -2,11 +2,11 @@
   text-align: left;
   background: var(--tal-surface);
   border-radius: var(--tal-r-lg);
-  padding: 18px;
+  padding: var(--tal-space-4);
   box-shadow: var(--tal-shadow-1);
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: var(--tal-space-4);
   border: 1px solid var(--tal-line-soft);
   transition:
     transform 0.15s,
@@ -30,8 +30,8 @@
 .pill {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 5px 11px;
+  gap: var(--tal-space-2);
+  padding: var(--tal-space-1) var(--tal-space-3);
   border-radius: var(--tal-r-pill);
   font-size: 11px;
   font-weight: 800;
@@ -54,8 +54,8 @@
 
 .preview {
   display: flex;
-  gap: 10px;
-  padding: 14px 14px 10px;
+  gap: var(--tal-space-3);
+  padding: var(--tal-space-4) var(--tal-space-4) var(--tal-space-3);
   background: var(--tal-bg);
   border-radius: var(--tal-r-md);
   align-items: flex-start;
@@ -64,6 +64,7 @@
 
 .previewArrow {
   align-self: center;
+  /* Negative pull to center the arrow against the preview row above. */
   margin-top: -8px;
   color: var(--tal-ink-muted);
 }

--- a/src/features/parent-home/NewBoardModal.module.css
+++ b/src/features/parent-home/NewBoardModal.module.css
@@ -1,5 +1,5 @@
 .wrap {
-  padding: 28px 28px 24px;
+  padding: var(--tal-space-7) var(--tal-space-7) var(--tal-space-6);
   max-width: 480px;
   width: 100%;
   margin: 0 auto;
@@ -8,7 +8,7 @@
 .form {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--tal-space-4);
   border: 0;
   padding: 0;
   margin: 0;
@@ -17,7 +17,7 @@
 .field {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--tal-space-2);
   border: 0;
   padding: 0;
   margin: 0;
@@ -34,7 +34,7 @@
 .input {
   font: inherit;
   font-size: 15px;
-  padding: 10px 12px;
+  padding: var(--tal-space-3);
   border: 1px solid var(--tal-line);
   border-radius: var(--tal-r-md);
   background: var(--tal-surface);
@@ -58,15 +58,15 @@
 
 .kindGroup {
   flex-direction: row;
-  gap: 8px;
+  gap: var(--tal-space-2);
 }
 
 .kindOption {
   flex: 1 1 0;
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 10px 12px;
+  gap: var(--tal-space-2);
+  padding: var(--tal-space-3);
   border: 1px solid var(--tal-line);
   border-radius: var(--tal-r-md);
   background: var(--tal-surface);

--- a/src/features/parent-home/ParentHome.module.css
+++ b/src/features/parent-home/ParentHome.module.css
@@ -1,13 +1,13 @@
 .rightActions {
   display: flex;
-  gap: 10px;
+  gap: var(--tal-space-3);
 }
 
 .grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 20px;
-  margin-top: 8px;
+  gap: var(--tal-space-5);
+  margin-top: var(--tal-space-2);
 }
 
 .newTile {
@@ -20,7 +20,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 10px;
+  gap: var(--tal-space-3);
   font-size: 15px;
   font-weight: 700;
 }
@@ -37,14 +37,14 @@
 }
 
 .recent {
-  margin-top: 36px;
+  margin-top: var(--tal-space-8);
 }
 
 .recentHeader {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  margin-bottom: 14px;
+  margin-bottom: var(--tal-space-4);
 }
 
 .recentHeading {
@@ -62,9 +62,9 @@
 
 .recentStrip {
   display: flex;
-  gap: 16px;
+  gap: var(--tal-space-4);
   overflow-x: auto;
-  padding-bottom: 8px;
+  padding-bottom: var(--tal-space-2);
 }
 
 .recentItem {


### PR DESCRIPTION
## Summary

3 files swept across `src/features/parent-home/`. Off-scale snaps:

- 5 → 4 (BoardCard pill vertical padding)
- 6 → 8 (NewBoardModal field gap)
- 10 → 12 (BoardCard preview gap, NewBoardModal input/kindOption padding, ParentHome rightActions/newTile gap)
- 11 → 12 (BoardCard pill horizontal padding)
- 14 → 16 (BoardCard preview padding, recentHeader margin-bottom, card gap)
- 18 → 16 (BoardCard padding)
- 36 → 32 (ParentHome .recent margin-top)

On-scale literals (8, 16, 20, 28) tokenized without pixel change.

**One holdout** (commented):
- `BoardCard.previewArrow` keeps `margin-top: -8px` — negative pull alignment doesn't fit the scale.

Refs #134. Builds on #160.

## Test plan

- [x] `npm run lint && npm run lint:css && npm run typecheck && npm run test` — clean (273/273).
- [ ] Visual smoke: home grid + board cards + new-board modal.