### PR TITLE
refactor(features): adopt spacing scale across remaining features (#134)

### DIFF
--- a/src/features/kid-choice/KidChoice.module.css
+++ b/src/features/kid-choice/KidChoice.module.css
@@ -3,20 +3,20 @@
   min-height: 0;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 22px;
-  padding: 12px 40px 20px;
+  gap: var(--tal-space-6);
+  padding: var(--tal-space-3) var(--tal-space-10) var(--tal-space-5);
 }
 
 .choice {
   background: var(--tal-surface);
   border-radius: var(--tal-r-xl);
-  padding: 24px;
+  padding: var(--tal-space-6);
   box-shadow: var(--tal-shadow-1);
   border: 3px solid var(--tal-line-soft);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 20px;
+  gap: var(--tal-space-5);
   transition: all 0.25s cubic-bezier(0.2, 0.8, 0.3, 1.1);
   font-family: inherit;
   color: inherit;
@@ -35,7 +35,7 @@
   font-size: 18px;
   font-weight: 800;
   letter-spacing: 2px;
-  padding: 6px 16px;
+  padding: var(--tal-space-2) var(--tal-space-4);
   border-radius: var(--tal-r-pill);
 }
 
@@ -50,8 +50,8 @@
 
 .pickedBadge {
   position: absolute;
-  top: 14px;
-  right: 14px;
+  top: var(--tal-space-4);
+  right: var(--tal-space-4);
   width: 52px;
   height: 52px;
   border-radius: var(--tal-r-pill);
@@ -71,14 +71,14 @@
 }
 
 .bottom {
-  padding: 12px 40px 28px;
+  padding: var(--tal-space-3) var(--tal-space-10) var(--tal-space-7);
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
 .confirmBtn {
-  padding: 20px 40px;
+  padding: var(--tal-space-5) var(--tal-space-10);
   border-radius: var(--tal-r-pill);
   background: var(--tal-ink);
   color: var(--tal-on-accent);
@@ -86,7 +86,7 @@
   font-weight: 800;
   display: inline-flex;
   align-items: center;
-  gap: 14px;
+  gap: var(--tal-space-4);
   box-shadow: var(--tal-shadow-2);
 }
 
@@ -105,7 +105,7 @@
   font-size: 16px;
   font-weight: 700;
   color: var(--tal-ink-muted);
-  padding: 16px 24px;
+  padding: var(--tal-space-4) var(--tal-space-6);
   border-radius: var(--tal-r-pill);
   background: var(--tal-surface);
   border: 1px dashed var(--tal-line);

--- a/src/features/kid-sequence/KidSequence.module.css
+++ b/src/features/kid-sequence/KidSequence.module.css
@@ -5,8 +5,8 @@
   align-items: center;
   justify-content: center;
   flex-wrap: wrap;
-  gap: 20px;
-  padding: 0 40px 40px;
+  gap: var(--tal-space-5);
+  padding: 0 var(--tal-space-10) var(--tal-space-10);
 }
 
 .tile {
@@ -15,13 +15,13 @@
   max-width: 220px;
   background: var(--tal-surface);
   border-radius: var(--tal-r-xl);
-  padding: 18px;
+  padding: var(--tal-space-4);
   box-shadow: var(--tal-shadow-1);
   border: 2px solid var(--tal-line-soft);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 14px;
+  gap: var(--tal-space-4);
   font-family: inherit;
   color: inherit;
   transition:
@@ -49,8 +49,8 @@
 
 .speakBadge {
   position: absolute;
-  bottom: 10px;
-  right: 10px;
+  bottom: var(--tal-space-3);
+  right: var(--tal-space-3);
   width: 42px;
   height: 42px;
   border-radius: var(--tal-r-pill);

--- a/src/features/kids/Kids.module.css
+++ b/src/features/kids/Kids.module.css
@@ -1,16 +1,16 @@
 .list {
   list-style: none;
-  margin: 8px 0 0;
+  margin: var(--tal-space-2) 0 0;
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--tal-space-2);
 }
 
 .row {
   display: flex;
   align-items: center;
-  padding: 16px 20px;
+  padding: var(--tal-space-4) var(--tal-space-5);
   border: 1px solid var(--tal-line);
   border-radius: var(--tal-r-md);
   background: var(--tal-surface);

--- a/src/features/library/Library.module.css
+++ b/src/features/library/Library.module.css
@@ -1,6 +1,6 @@
 .grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-  gap: 20px;
-  margin-top: 8px;
+  gap: var(--tal-space-5);
+  margin-top: var(--tal-space-2);
 }

--- a/src/features/login/Login.module.css
+++ b/src/features/login/Login.module.css
@@ -3,7 +3,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 24px;
+  padding: var(--tal-space-6);
   background:
     radial-gradient(circle at 15% 10%, var(--tal-sky) 0%, transparent 45%),
     radial-gradient(circle at 85% 90%, var(--tal-sun) 0%, transparent 45%), var(--tal-bg);
@@ -15,7 +15,7 @@
   background: var(--tal-surface);
   border: 1px solid var(--tal-line);
   border-radius: var(--tal-r-lg);
-  padding: 36px 32px 32px;
+  padding: var(--tal-space-8);
   box-shadow: var(--tal-shadow-1);
 }
 
@@ -23,8 +23,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 12px;
-  margin-bottom: 24px;
+  gap: var(--tal-space-3);
+  margin-bottom: var(--tal-space-6);
 }
 
 .mark {
@@ -50,7 +50,7 @@
 .form {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--tal-space-4);
 }
 
 .otp {
@@ -65,13 +65,13 @@
   font-size: 14px;
   color: var(--tal-ink-soft);
   background: var(--tal-surface-alt);
-  padding: 10px 12px;
+  padding: var(--tal-space-3);
   border-radius: var(--tal-r-md);
 }
 
 .row {
   display: flex;
-  gap: 10px;
+  gap: var(--tal-space-3);
   justify-content: flex-end;
 }
 
@@ -79,7 +79,7 @@
   font-size: 13px;
   color: var(--tal-coral-ink);
   background: var(--tal-coral);
-  padding: 8px 12px;
+  padding: var(--tal-space-2) var(--tal-space-3);
   border-radius: var(--tal-r-md);
 }
 
@@ -87,7 +87,7 @@
   font-size: 13px;
   background: var(--tal-surface-alt);
   color: var(--tal-ink-soft);
-  padding: 10px 12px;
+  padding: var(--tal-space-3);
   border-radius: var(--tal-r-md);
-  margin-bottom: 16px;
+  margin-bottom: var(--tal-space-4);
 }

--- a/src/features/settings/AccountSection.module.css
+++ b/src/features/settings/AccountSection.module.css
@@ -10,11 +10,11 @@
 }
 
 .signOut {
-  margin-top: 12px;
+  margin-top: var(--tal-space-3);
   font: inherit;
   font-size: 14px;
   font-weight: 600;
-  padding: 10px 18px;
+  padding: var(--tal-space-3) var(--tal-space-4);
   border-radius: var(--tal-r-pill);
   background: var(--tal-surface);
   color: var(--tal-ink);

--- a/src/features/settings/DeleteAccountDialog.module.css
+++ b/src/features/settings/DeleteAccountDialog.module.css
@@ -1,11 +1,11 @@
 .wrap {
-  padding: 28px 28px 24px;
+  padding: var(--tal-space-7) var(--tal-space-7) var(--tal-space-6);
   max-width: 480px;
   width: 100%;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: var(--tal-space-4);
 }
 
 .lead {
@@ -16,7 +16,7 @@
 
 .list {
   margin: 0;
-  padding-left: 20px;
+  padding-left: var(--tal-space-5);
   font-size: 14px;
   color: var(--tal-ink-soft);
   line-height: 1.6;
@@ -24,7 +24,7 @@
 
 .toast {
   margin: 0;
-  padding: 10px 12px;
+  padding: var(--tal-space-3);
   border: 1px solid var(--tal-coral-ink);
   background: var(--tal-coral);
   color: var(--tal-coral-ink);
@@ -37,7 +37,7 @@
   font: inherit;
   font-size: 14px;
   font-weight: 600;
-  padding: 10px 18px;
+  padding: var(--tal-space-3) var(--tal-space-4);
   border-radius: var(--tal-r-pill);
   background: var(--tal-surface);
   color: var(--tal-ink);
@@ -53,11 +53,11 @@
 .destructive {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--tal-space-2);
   font: inherit;
   font-size: 14px;
   font-weight: 700;
-  padding: 10px 18px;
+  padding: var(--tal-space-3) var(--tal-space-4);
   border-radius: var(--tal-r-pill);
   background: var(--tal-coral-ink);
   color: var(--tal-surface);


### PR DESCRIPTION
## Summary

7 files swept across kid-choice, kid-sequence, kids, library, login, and settings. Off-scale snaps:

- 6 → 8 (KidChoice marker padding-y)
- 10 → 12 (speakBadge offsets, Login row gap, Login hint/offline padding, AccountSection/DeleteAccountDialog button padding-y)
- 14 → 16 (confirmBtn gap, KidSequence tile gap, DeleteAccountDialog wrap gap)
- 18 → 16 (KidSequence tile padding, AccountSection/DeleteAccountDialog button padding-x)
- 22 → 24 (KidChoice choices grid gap)
- 36 → 32 (Login card padding, -4px)

On-scale literals tokenized without pixel change. After this lands, all `src/features/*` is on the scale.

Refs #134. Builds on #160. Stylelint guard (PR G) closes the issue next.

## Test plan

- [x] `npm run lint && npm run lint:css && npm run typecheck && npm run test` — clean (273/273).
- [ ] Visual smoke: kid mode (choice grid, sequence strip), login card, settings sign-out + delete dialog.