### PR TITLE
chore: stylelint guard against raw px in spacing properties (closes #134)

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,14 +1,23 @@
 {
   "rules": {
     "color-no-hex": true,
-    "function-disallowed-list": ["rgb", "rgba", "hsl", "hsla"]
+    "function-disallowed-list": ["rgb", "rgba", "hsl", "hsla"],
+    "declaration-property-value-disallowed-list": [
+      {
+        "/^(padding|padding-.+|margin|margin-.+|gap|row-gap|column-gap)$/": ["/[0-9]+px/"]
+      },
+      {
+        "message": "Spacing values must use --tal-space-N tokens (or a stylelint-disable comment for documented holdouts like negative pulls or border-compensated paddings)."
+      }
+    ]
   },
   "overrides": [
     {
       "files": ["src/theme/**/*.css"],
       "rules": {
         "color-no-hex": null,
-        "function-disallowed-list": null
+        "function-disallowed-list": null,
+        "declaration-property-value-disallowed-list": null
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -61,7 +61,11 @@ Features never call `supabase.from(...)` or `supabase.storage` directly —
 both are pinned by `no-restricted-imports` / `no-restricted-syntax` rules.
 
 Colors in `*.module.css` outside `src/theme/` must come from theme tokens —
-hex/rgb/hsl literals are blocked by `npm run lint:css` (stylelint).
+hex/rgb/hsl literals are blocked by `npm run lint:css` (stylelint). The same
+guard blocks raw `px` in `padding`, `margin`, `gap`, and their longhand
+variants — use `--tal-space-N` tokens instead. Documented holdouts (negative
+pulls, border-compensated paddings, sub-scale 2px hairlines) carry an
+inline `stylelint-disable-next-line` comment naming the reason.
 
 ## Auth
 

--- a/src/app/AuthGate.module.css
+++ b/src/app/AuthGate.module.css
@@ -3,8 +3,8 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
-  padding: 32px;
+  gap: var(--tal-space-4);
+  padding: var(--tal-space-8);
   text-align: center;
   height: 100vh;
 }
@@ -14,7 +14,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
+  gap: var(--tal-space-4);
   height: 100vh;
 }
 
@@ -38,7 +38,7 @@
 }
 
 .errorRetry {
-  padding: 10px 20px;
+  padding: var(--tal-space-3) var(--tal-space-5);
   font-size: 15px;
   font-weight: 700;
   border-radius: var(--tal-r-pill);

--- a/src/app/SwUpdatePrompt.module.css
+++ b/src/app/SwUpdatePrompt.module.css
@@ -5,8 +5,8 @@
   z-index: 9999;
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 10px 14px;
+  gap: var(--tal-space-3);
+  padding: var(--tal-space-3) var(--tal-space-4);
   background: var(--tal-surface);
   color: var(--tal-ink);
   border-radius: var(--tal-r-md);
@@ -24,7 +24,7 @@
   background: var(--tal-sage);
   color: var(--tal-sage-ink);
   border-radius: var(--tal-r-pill);
-  padding: 6px 12px;
+  padding: var(--tal-space-2) var(--tal-space-3);
   font-weight: 600;
   cursor: pointer;
 }
@@ -41,7 +41,7 @@
   color: var(--tal-ink-muted);
   font-size: 18px;
   line-height: 1;
-  padding: 4px 6px;
+  padding: var(--tal-space-1) var(--tal-space-2);
   cursor: pointer;
 }
 

--- a/src/features/board-builder/BoardBuilder.module.css
+++ b/src/features/board-builder/BoardBuilder.module.css
@@ -4,6 +4,7 @@
   gap: var(--tal-space-3);
   margin-bottom: var(--tal-space-2);
   /* Negative pull to align breadcrumb above the title row. */
+  /* stylelint-disable-next-line declaration-property-value-disallowed-list */
   margin-top: -4px;
 }
 

--- a/src/features/board-builder/ShareModal.module.css
+++ b/src/features/board-builder/ShareModal.module.css
@@ -102,6 +102,8 @@
   letter-spacing: 0.4px;
   color: var(--tal-ink-muted);
   background: var(--tal-surface);
+  /* Sub-scale 2px vertical padding tightens the role pill against its label. */
+  /* stylelint-disable-next-line declaration-property-value-disallowed-list */
   padding: 2px var(--tal-space-2);
   border-radius: var(--tal-r-pill);
   flex-shrink: 0;

--- a/src/features/parent-home/BoardCard.module.css
+++ b/src/features/parent-home/BoardCard.module.css
@@ -65,6 +65,7 @@
 .previewArrow {
   align-self: center;
   /* Negative pull to center the arrow against the preview row above. */
+  /* stylelint-disable-next-line declaration-property-value-disallowed-list */
   margin-top: -8px;
   color: var(--tal-ink-muted);
 }

--- a/src/layouts/KidModeLayout.module.css
+++ b/src/layouts/KidModeLayout.module.css
@@ -31,6 +31,8 @@
   font-size: 18px;
   font-weight: 800;
   color: var(--tal-ink);
+  /* Sub-scale negative pull to optically align the title baseline. */
+  /* stylelint-disable-next-line declaration-property-value-disallowed-list */
   margin-top: -2px;
 }
 

--- a/src/layouts/ParentShell.module.css
+++ b/src/layouts/ParentShell.module.css
@@ -32,6 +32,8 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  /* Sub-scale gap between icon and label inside the 56px nav item. */
+  /* stylelint-disable-next-line declaration-property-value-disallowed-list */
   gap: 2px;
   color: var(--tal-ink-soft);
   font-size: 10px;
@@ -82,6 +84,8 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  /* Sub-scale gap between icon and label inside the 56px button. */
+  /* stylelint-disable-next-line declaration-property-value-disallowed-list */
   gap: 2px;
   font-size: 10px;
   font-weight: 800;

--- a/src/ui/Button/Button.module.css
+++ b/src/ui/Button/Button.module.css
@@ -31,6 +31,7 @@
 .ghost {
   /* 1px less than .primary to compensate for the 1px border so both
      buttons render at the same outside dimensions. */
+  /* stylelint-disable-next-line declaration-property-value-disallowed-list */
   padding: 11px 17px;
   background: var(--tal-surface);
   color: var(--tal-ink);

--- a/src/ui/DialogHeader/DialogHeader.module.css
+++ b/src/ui/DialogHeader/DialogHeader.module.css
@@ -10,6 +10,8 @@
   font-size: 22px;
   font-weight: 800;
   color: var(--tal-ink);
+  /* Sub-scale 2px gap below title tightens it against subtitle baseline. */
+  /* stylelint-disable-next-line declaration-property-value-disallowed-list */
   margin: 0 0 2px;
 }
 

--- a/src/ui/OfflineIndicator/OfflineIndicator.module.css
+++ b/src/ui/OfflineIndicator/OfflineIndicator.module.css
@@ -53,6 +53,8 @@
   color: inherit;
   font-size: 13px;
   font-weight: 600;
+  /* Sub-scale 2px vertical padding keeps the inline action compact. */
+  /* stylelint-disable-next-line declaration-property-value-disallowed-list */
   padding: 2px var(--tal-space-2);
   cursor: pointer;
   text-decoration: underline;

--- a/src/ui/Segmented/Segmented.module.css
+++ b/src/ui/Segmented/Segmented.module.css
@@ -3,6 +3,8 @@
   background: var(--tal-surface-alt);
   padding: var(--tal-space-1);
   border-radius: var(--tal-r-pill);
+  /* Sub-scale 2px hairline gap between segment options. */
+  /* stylelint-disable-next-line declaration-property-value-disallowed-list */
   gap: 2px;
 }
 


### PR DESCRIPTION
## Summary

Adds `declaration-property-value-disallowed-list` to `.stylelintrc.json` banning `/[0-9]+px/` in `padding`, `padding-*`, `margin`, `margin-*`, `gap`, `row-gap`, and `column-gap`. `src/theme/**` is overridden so tokens can still be defined with literal values.

Positioning offsets (`top`, `right`, `bottom`, `left`, `inset`) are intentionally out of scope — they're often arbitrary pixel-perfect alignments (e.g. badge offsets, dropdown positioning), not spacing.

## Sweep cleanup

Picked up two `src/app/` files the earlier sweeps missed:
- `AuthGate.module.css` (loading + error fallback)
- `SwUpdatePrompt.module.css` (banner + buttons)

## Documented holdouts (10)

Each carries an inline `/* stylelint-disable-next-line declaration-property-value-disallowed-list */` and a one-line reason:

- 3 **negative pulls**: BoardBuilder breadcrumb (-4), BoardCard previewArrow (-8), KidModeLayout title (-2)
- 1 **border-compensated padding**: Button `.ghost` (11/17 = 1px less than .primary on each side)
- 6 **sub-scale 2px hairlines / tightenings**: Segmented inner gap, ParentShell navItem/kidBtn icon-label gaps, DialogHeader title margin-bottom, ShareModal memberRole padding-y, OfflineIndicator action padding-y

These are real visual choices that don't fit the 4px-base scale. Inline disables make the exception explicit at the call site.

Closes #134. With this merged, every spacing literal in `*.module.css` outside `src/theme/` either uses a token or carries a documented exception.

## Test plan

- [x] `npm run lint && npm run lint:css && npm run typecheck && npm run test` — clean (273/273).
- [x] Sanity: `padding: 13px` in a non-theme file fails `lint:css`. Theme override clean.
- [ ] Visual smoke: full app walkthrough. AuthGate loading + error + retry.