### PR TITLE
fix(tests): clear idb-keyval and signed-url memCache between tests (#144)

### DIFF
--- a/src/lib/storage-cache.ts
+++ b/src/lib/storage-cache.ts
@@ -1,0 +1,15 @@
+// Hot-path in-process cache backing `signedUrlFor`. Lives in its own module
+// (no Supabase import) so vitest.setup.ts can dynamic-import the reset hook
+// without dragging the runtime client through tsconfig.node.json.
+export interface SignedUrlEntry {
+  url: string;
+  expiresAt: number;
+}
+
+export const signedUrlMemCache = new Map<string, SignedUrlEntry>();
+
+// Test-only: vitest.setup.ts calls this in a global afterEach so module-level
+// state cannot leak between tests. Pairs with idb-keyval's `clear()`.
+export const __resetSignedUrlCache = (): void => {
+  signedUrlMemCache.clear();
+};

--- a/src/lib/storage.pollution.test.ts
+++ b/src/lib/storage.pollution.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const createSignedUrlMock = vi.fn<
+  (
+    path: string,
+    expiresIn: number,
+  ) => Promise<{
+    data: { signedUrl: string } | null;
+    error: Error | null;
+  }>
+>();
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    storage: {
+      from: () => ({ createSignedUrl: createSignedUrlMock }),
+    },
+  },
+}));
+
+const { signedUrlFor } = await import('./storage');
+
+describe('signedUrlFor cross-test isolation', () => {
+  it('first test populates the cache', async () => {
+    createSignedUrlMock.mockResolvedValue({
+      data: { signedUrl: 'https://example.test/first' },
+      error: null,
+    });
+    const url = await signedUrlFor('pictogram-images', 'pollution/probe.jpg');
+    expect(url).toBe('https://example.test/first');
+    expect(createSignedUrlMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('second test must re-mint a fresh URL — no carryover from prior test', async () => {
+    createSignedUrlMock.mockReset();
+    createSignedUrlMock.mockResolvedValue({
+      data: { signedUrl: 'https://example.test/second' },
+      error: null,
+    });
+    const url = await signedUrlFor('pictogram-images', 'pollution/probe.jpg');
+    expect(createSignedUrlMock).toHaveBeenCalledTimes(1);
+    expect(url).toBe('https://example.test/second');
+  });
+});

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -1,5 +1,5 @@
-import { clear, set } from 'idb-keyval';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { set } from 'idb-keyval';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const createSignedUrlMock = vi.fn<
   (
@@ -19,15 +19,12 @@ vi.mock('@/lib/supabase', () => ({
   supabase: { storage: { from: (bucket: string) => fromMock(bucket) } },
 }));
 
-const { invalidateSignedUrl, signedUrlFor } = await import('./storage');
+const { signedUrlFor } = await import('./storage');
 
-beforeEach(async () => {
-  await clear();
+// idb-keyval and the in-process memCache are wiped by the global afterEach in
+// vitest.setup.ts (#144) — only the per-test mock counter needs resetting here.
+beforeEach(() => {
   createSignedUrlMock.mockReset();
-});
-
-afterEach(() => {
-  invalidateSignedUrl('pictogram-images', 'a/test.jpg');
 });
 
 describe('signedUrlFor', () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,24 +1,12 @@
 import { del, get, set } from 'idb-keyval';
 
+import { type SignedUrlEntry, signedUrlMemCache as memCache } from './storage-cache';
 import { supabase } from './supabase';
 
 export const AUDIO_BUCKET = 'pictogram-audio';
 export const IMAGES_BUCKET = 'pictogram-images';
 
 const SIGNED_URL_TTL_SECONDS = 60 * 60;
-
-interface SignedUrlEntry {
-  url: string;
-  expiresAt: number;
-}
-
-/**
- * Hot-path in-process cache. Mirrors what's persisted to IndexedDB; persists
- * across reloads via `loadPersisted()`. The two layers exist because IDB IO
- * is async and `signedUrlFor` is awaited on every render of an image tile —
- * the synchronous `Map` lookup short-circuits the common case.
- */
-const memCache = new Map<string, SignedUrlEntry>();
 const IDB_PREFIX = 'signed-url:';
 const idbKey = (cacheKey: string): string => `${IDB_PREFIX}${cacheKey}`;
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -7,6 +7,8 @@ import 'fake-indexeddb/auto';
 import { clear } from 'idb-keyval';
 import { afterEach, vi } from 'vitest';
 
+import { __resetSignedUrlCache } from './src/lib/storage-cache';
+
 // Default-stub the Supabase client for every test file. #24 was a warm-vs-cold
 // flake: a test seeded the React Query cache but didn't mock @/lib/supabase,
 // so useQuery's mount-time refetch raced against the seeded data and replaced
@@ -50,7 +52,6 @@ Object.defineProperty(window, 'sessionStorage', {
 // global reset, a future test file that mounts a hook touching signedUrlFor
 // inherits cached entries from prior tests in the same worker — a flake whose
 // failure mode depends on test order.
-import { __resetSignedUrlCache } from './src/lib/storage-cache';
 afterEach(async () => {
   await clear();
   __resetSignedUrlCache();

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -4,7 +4,8 @@ import '@testing-library/jest-dom/vitest';
 // touches the persistence layer.
 import 'fake-indexeddb/auto';
 
-import { vi } from 'vitest';
+import { clear } from 'idb-keyval';
+import { afterEach, vi } from 'vitest';
 
 // Default-stub the Supabase client for every test file. #24 was a warm-vs-cold
 // flake: a test seeded the React Query cache but didn't mock @/lib/supabase,
@@ -43,4 +44,14 @@ Object.defineProperty(window, 'localStorage', {
 Object.defineProperty(window, 'sessionStorage', {
   value: memoryStorage(),
   configurable: true,
+});
+
+// #144: signedUrlFor persists to idb-keyval and an in-process Map. Without a
+// global reset, a future test file that mounts a hook touching signedUrlFor
+// inherits cached entries from prior tests in the same worker — a flake whose
+// failure mode depends on test order.
+import { __resetSignedUrlCache } from './src/lib/storage-cache';
+afterEach(async () => {
+  await clear();
+  __resetSignedUrlCache();
 });


### PR DESCRIPTION
## Summary
- `signedUrlFor` persists to `idb-keyval` and a module-level `Map`. With no global reset, a future test file that touches `signedUrlFor` would inherit cached entries from prior tests in the same worker — order-dependent flake.
- Extract `memCache` + reset into `src/lib/storage-cache.ts` (no Supabase import) so vitest setup can pull the reset hook without dragging the supabase chain through `tsconfig.node.json`.
- Add a global `afterEach` in `vitest.setup.ts` that calls `clear()` (idb-keyval) and `__resetSignedUrlCache()`.
- New `storage.pollution.test.ts` is a 2-test repro that fails without the fix (memCache hit makes test 2 see 0 mints instead of 1) and pins the contract going forward.

Closes #144.

## Test plan
- [x] `npx vitest run src/lib/storage.pollution.test.ts` passes (was failing before the fix)
- [x] `npx vitest run src/lib/storage.test.ts` still passes (existing per-file cleanup is now redundant but harmless)
- [x] `npm test` — 275 passed
- [x] `npm run lint` — clean
- [x] `npx tsc -b` — clean