### PR TITLE
fix(tests): global afterEach resets drain + speech module state (#168)

### DIFF
--- a/src/lib/outbox/drain-state.ts
+++ b/src/lib/outbox/drain-state.ts
@@ -1,0 +1,42 @@
+// Module-level state backing `./drain.ts`. Lives in its own file (no Supabase
+// or `@/*` imports) so vitest.setup.ts can import the reset hook without
+// dragging the runtime client through tsconfig.node.json. Same pattern as
+// `src/lib/storage-cache.ts`.
+
+export interface OutboxStatus {
+  online: boolean;
+  pendingCount: number;
+  failedCount: number;
+  draining: boolean;
+}
+
+interface DrainState {
+  draining: boolean;
+  pendingDrain: boolean;
+  listenersAttached: boolean;
+  lastStatus: OutboxStatus;
+}
+
+const initialStatus = (): OutboxStatus => ({
+  online: typeof navigator === 'undefined' ? true : navigator.onLine,
+  pendingCount: 0,
+  failedCount: 0,
+  draining: false,
+});
+
+export const drainState: DrainState = {
+  draining: false,
+  pendingDrain: false,
+  listenersAttached: false,
+  lastStatus: initialStatus(),
+};
+
+export const drainSubscribers = new Set<(s: OutboxStatus) => void>();
+
+export const __resetDrainForTests = (): void => {
+  drainState.draining = false;
+  drainState.pendingDrain = false;
+  drainState.listenersAttached = false;
+  drainState.lastStatus = initialStatus();
+  drainSubscribers.clear();
+};

--- a/src/lib/outbox/drain.pollution.test.ts
+++ b/src/lib/outbox/drain.pollution.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { putEntry } from './store';
+import type { UpdateBoardEntry } from './types';
+
+const { getStatus, refreshStatus, subscribeStatus } = await import('./drain');
+
+const baseEntry = (over: Partial<UpdateBoardEntry> = {}): UpdateBoardEntry => ({
+  id: '01HZZZZZZZZZZZZZZZZZZZZZZZ',
+  kind: 'updateBoard',
+  boardId: 'board-1',
+  patch: { name: 'New name' },
+  enqueuedAt: 0,
+  attemptCount: 0,
+  status: 'pending',
+  ...over,
+});
+
+describe('drain module-state cross-test isolation', () => {
+  it('first test populates lastStatus and leaves a subscriber registered', async () => {
+    await putEntry(baseEntry({ id: '01HZZA' }));
+    subscribeStatus(() => {
+      // Intentionally never unsubscribed — proves the global afterEach clears
+      // the subscribers Set even when a test forgets to clean up.
+    });
+    await refreshStatus();
+    expect(getStatus().pendingCount).toBe(1);
+  });
+
+  it('second test must see clean lastStatus and an empty subscriber set', () => {
+    expect(getStatus().pendingCount).toBe(0);
+
+    let pushes = 0;
+    const unsub = subscribeStatus(() => {
+      pushes += 1;
+    });
+    // subscribeStatus pushes lastStatus to the new subscriber synchronously.
+    // If the prior subscriber leaked, the Set still contains it but that's
+    // not directly observable here — pendingCount === 0 is the load-bearing
+    // assertion. Counting our own pushes guards against subscribeStatus
+    // regressing its initial-emit contract.
+    expect(pushes).toBe(1);
+    unsub();
+  });
+});

--- a/src/lib/outbox/drain.pollution.test.ts
+++ b/src/lib/outbox/drain.pollution.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { drainSubscribers } from './drain-state';
 import { putEntry } from './store';
 import type { UpdateBoardEntry } from './types';
 
@@ -29,17 +30,18 @@ describe('drain module-state cross-test isolation', () => {
 
   it('second test must see clean lastStatus and an empty subscriber set', () => {
     expect(getStatus().pendingCount).toBe(0);
+    // Direct probe: if the prior test's subscriber leaked, drainSubscribers
+    // would still contain it. Asserting on the Set directly (rather than via
+    // observable behavior) closes the gap that pendingCount alone can't see.
+    expect(drainSubscribers.size).toBe(0);
 
     let pushes = 0;
     const unsub = subscribeStatus(() => {
       pushes += 1;
     });
     // subscribeStatus pushes lastStatus to the new subscriber synchronously.
-    // If the prior subscriber leaked, the Set still contains it but that's
-    // not directly observable here — pendingCount === 0 is the load-bearing
-    // assertion. Counting our own pushes guards against subscribeStatus
-    // regressing its initial-emit contract.
     expect(pushes).toBe(1);
+    expect(drainSubscribers.size).toBe(1);
     unsub();
   });
 });

--- a/src/lib/outbox/drain.ts
+++ b/src/lib/outbox/drain.ts
@@ -1,26 +1,12 @@
+import { drainState, drainSubscribers, type OutboxStatus } from './drain-state';
 import { runHandler, UnretryableOutboxError } from './handlers';
 import { deleteEntry, listEntries, putEntry } from './store';
 import type { OutboxEntry } from './types';
 
 const MAX_ATTEMPTS_BEFORE_FAILED = 3;
 
-let draining = false;
-let pendingDrain = false;
-
-export interface OutboxStatus {
-  online: boolean;
-  pendingCount: number;
-  failedCount: number;
-  draining: boolean;
-}
-
-const subscribers = new Set<(s: OutboxStatus) => void>();
-let lastStatus: OutboxStatus = {
-  online: typeof navigator === 'undefined' ? true : navigator.onLine,
-  pendingCount: 0,
-  failedCount: 0,
-  draining: false,
-};
+export type { OutboxStatus };
+export { __resetDrainForTests } from './drain-state';
 
 const emit = async (): Promise<void> => {
   const entries = await listEntries();
@@ -28,10 +14,10 @@ const emit = async (): Promise<void> => {
     online: typeof navigator === 'undefined' ? true : navigator.onLine,
     pendingCount: entries.filter((e) => e.status === 'pending').length,
     failedCount: entries.filter((e) => e.status === 'failed').length,
-    draining,
+    draining: drainState.draining,
   };
-  lastStatus = next;
-  subscribers.forEach((fn) => fn(next));
+  drainState.lastStatus = next;
+  drainSubscribers.forEach((fn) => fn(next));
 };
 
 /**
@@ -43,14 +29,14 @@ const emit = async (): Promise<void> => {
 export const refreshStatus = (): Promise<void> => emit();
 
 export const subscribeStatus = (fn: (s: OutboxStatus) => void): (() => void) => {
-  subscribers.add(fn);
-  fn(lastStatus);
+  drainSubscribers.add(fn);
+  fn(drainState.lastStatus);
   return () => {
-    subscribers.delete(fn);
+    drainSubscribers.delete(fn);
   };
 };
 
-export const getStatus = (): OutboxStatus => lastStatus;
+export const getStatus = (): OutboxStatus => drainState.lastStatus;
 
 const runOne = async (entry: OutboxEntry): Promise<'ok' | 'transient' | 'failed'> => {
   try {
@@ -76,15 +62,15 @@ const runOne = async (entry: OutboxEntry): Promise<'ok' | 'transient' | 'failed'
  * marked and skipped so a single bad entry can't dam the queue.
  */
 export const drain = async (): Promise<void> => {
-  if (draining) {
-    pendingDrain = true;
+  if (drainState.draining) {
+    drainState.pendingDrain = true;
     return;
   }
   if (typeof navigator !== 'undefined' && !navigator.onLine) {
     await emit();
     return;
   }
-  draining = true;
+  drainState.draining = true;
   await emit();
   try {
     let stop = false;
@@ -100,20 +86,19 @@ export const drain = async (): Promise<void> => {
       }
     }
   } finally {
-    draining = false;
+    drainState.draining = false;
     await emit();
-    if (pendingDrain) {
-      pendingDrain = false;
+    if (drainState.pendingDrain) {
+      drainState.pendingDrain = false;
       void drain();
     }
   }
 };
 
-let listenersAttached = false;
 /** Wires `online` events + does an initial drain. Idempotent — call once at app boot. */
 export const startOutbox = (): void => {
-  if (listenersAttached) return;
-  listenersAttached = true;
+  if (drainState.listenersAttached) return;
+  drainState.listenersAttached = true;
   // Prime lastStatus from IDB before any subscribe() call lands a stale zero
   // pendingCount on a cold boot with persisted entries (#29). emit() is async,
   // but we'd rather race a microtask than render a "synced" indicator that
@@ -131,22 +116,3 @@ export const startOutbox = (): void => {
 };
 
 export const kick = (): Promise<void> => drain();
-
-/**
- * Test-only: reset the module-level state that startOutbox accumulates so a
- * second test in the same file can re-exercise the cold-boot prime path.
- * Production code never calls this; the listenersAttached flag is a one-shot
- * guard against double-registering window listeners during normal app boot.
- */
-export const __test_resetOutbox = (): void => {
-  draining = false;
-  pendingDrain = false;
-  listenersAttached = false;
-  subscribers.clear();
-  lastStatus = {
-    online: typeof navigator === 'undefined' ? true : navigator.onLine,
-    pendingCount: 0,
-    failedCount: 0,
-    draining: false,
-  };
-};

--- a/src/lib/outbox/outbox.test.ts
+++ b/src/lib/outbox/outbox.test.ts
@@ -18,8 +18,7 @@ vi.mock('@/lib/supabase', () => ({
 }));
 
 const { deleteEntry, listEntries, putEntry } = await import('./store');
-const { __test_resetOutbox, drain, getStatus, startOutbox, subscribeStatus } =
-  await import('./drain');
+const { drain, getStatus, startOutbox, subscribeStatus } = await import('./drain');
 const { enqueueAndDrain } = await import('./index');
 
 const baseEntry = (over: Partial<UpdateBoardEntry> = {}): UpdateBoardEntry => ({
@@ -194,13 +193,6 @@ describe('enqueueAndDrain', () => {
 });
 
 describe('startOutbox', () => {
-  beforeEach(() => {
-    // startOutbox is one-shot in production (window listeners must not
-    // register twice). Reset module state so each test in this block exercises
-    // the cold-boot prime path on its own terms.
-    __test_resetOutbox();
-  });
-
   it('primes lastStatus from IDB so cold-boot subscribers see real counts (#29)', async () => {
     setOnline(false); // drain is offline-noop; emit() is the only source updating lastStatus.
     await putEntry(baseEntry({ id: '01HZZP' }));

--- a/src/lib/speech.test.ts
+++ b/src/lib/speech.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { __resetSpeechForTests, isSpeechSupported, speak } from './speech';
+import { isSpeechSupported, speak } from './speech';
 
 interface FakeVoice {
   name: string;
@@ -40,7 +40,6 @@ class StubUtterance {
 
 beforeEach(() => {
   (globalThis as { SpeechSynthesisUtterance: unknown }).SpeechSynthesisUtterance = StubUtterance;
-  __resetSpeechForTests();
 });
 
 afterEach(() => {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -7,6 +7,8 @@ import 'fake-indexeddb/auto';
 import { clear } from 'idb-keyval';
 import { afterEach, vi } from 'vitest';
 
+import { __resetDrainForTests } from './src/lib/outbox/drain-state';
+import { __resetSpeechForTests } from './src/lib/speech';
 import { __resetSignedUrlCache } from './src/lib/storage-cache';
 
 // Default-stub the Supabase client for every test file. #24 was a warm-vs-cold
@@ -48,11 +50,14 @@ Object.defineProperty(window, 'sessionStorage', {
   configurable: true,
 });
 
-// #144: signedUrlFor persists to idb-keyval and an in-process Map. Without a
-// global reset, a future test file that mounts a hook touching signedUrlFor
-// inherits cached entries from prior tests in the same worker — a flake whose
-// failure mode depends on test order.
+// #144 / #168: module-level caches in storage, outbox/drain, and speech persist
+// across `it()` blocks within the same worker — a flake class whose failure
+// mode depends on test order. Reset all three globally; pairs with idb-keyval's
+// `clear()`. drain state lives in `./drain-state.ts` (no Supabase deps) for
+// the same tsconfig.node.json reason as `storage-cache.ts`.
 afterEach(async () => {
   await clear();
   __resetSignedUrlCache();
+  __resetSpeechForTests();
+  __resetDrainForTests();
 });


### PR DESCRIPTION
Closes #168.

## Summary

- Extends #144's global `afterEach` pattern (signed-URL cache reset) to two more module-level state offenders.
- `src/lib/outbox/drain.ts` — state extracted into a new `drain-state.ts` (no `@/*` imports) so `vitest.setup.ts` can import the reset hook without dragging `@/lib/supabase` through `tsconfig.node.json`. Mirrors the `storage-cache.ts` design.
- `src/lib/speech.ts` — already had `__resetSpeechForTests`, now wired into the global hook so any test (not just `speech.test.ts`) is covered.
- Renamed `__test_resetOutbox` -> `__resetDrainForTests` for naming consistency with `__resetSignedUrlCache` / `__resetSpeechForTests`.
- New `src/lib/outbox/drain.pollution.test.ts` mirrors `storage.pollution.test.ts`: two `it()`s that fail without the global reset.

## Test plan

- [x] `npm run test` — 277/277 pass (56 files)
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] Manually disabled the `__resetDrainForTests()` line in `vitest.setup.ts` and confirmed `drain.pollution.test.ts` second `it()` fails (pendingCount leaks as 1). Restored.