### PR TITLE
ci: regenerate supabase types and fail on drift (#132)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           version: latest
       - run: supabase start
+      - name: Regenerate supabase types and fail on drift (#132)
+        run: |
+          npm run types:db
+          git diff --exit-code src/types/supabase.ts
       - run: npm run test:db
       - name: Serve function in background
         run: |


### PR DESCRIPTION
## Summary
- Adds a CI step after `supabase start` that regenerates `src/types/supabase.ts` and fails the job if it differs from the committed file.
- Closes #132. Author still regenerates locally per README; CI just enforces the workflow.

## Test plan
- [x] Locally: `supabase start` + `npm run types:db` produces no diff against current main.
- [ ] CI run on this PR is green (proves the step doesn't false-positive against the current schema).
- [ ] Future migration without a types regeneration trips this step (negative path covered by design).

Closes #132