### PR TITLE
feat(pictogram): rename / replace photo / delete from Library + board editor

### DIFF
--- a/src/app/routes/LibraryRoute.tsx
+++ b/src/app/routes/LibraryRoute.tsx
@@ -14,7 +14,7 @@ export const LibraryRoute = (): JSX.Element => {
       onNav={onNav}
       onKidMode={onKidMode}
       title="Library"
-      subtitle="Every pictogram across your boards"
+      subtitle="Every pictogram in your library — tap one to rename, replace its photo, or delete."
     >
       <Library />
     </ParentShell>

--- a/src/features/board-builder/BoardBuilder.tsx
+++ b/src/features/board-builder/BoardBuilder.tsx
@@ -12,6 +12,7 @@ import {
 import { usePictograms, usePictogramsById } from '@/lib/queries/pictograms';
 import type { Board, Pictogram } from '@/types/domain';
 import { ArrowLeftIcon, PlusIcon, StepArrowIcon } from '@/ui/icons';
+import { PictogramSheet } from '@/ui/PictogramSheet/PictogramSheet';
 import { PictoTile } from '@/ui/PictoTile/PictoTile';
 import { Reorderable } from '@/ui/Reorderable/Reorderable';
 
@@ -75,6 +76,7 @@ export const BoardBuilder = ({
   // pauses typing. Re-sync only when navigating to a different board — syncing
   // on every board.name change would clobber in-progress typing when the
   // previous debounced write lands.
+  const [editTarget, setEditTarget] = useState<Pictogram | null>(null);
   const [titleDraft, setTitleDraft] = useState(board.name);
   useEffect(() => setTitleDraft(board.name), [board.id]); // eslint-disable-line react-hooks/exhaustive-deps
   const pendingTitleWrite = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -172,6 +174,7 @@ export const BoardBuilder = ({
                   kind={board.kind}
                   labelsVisible={board.labelsVisible}
                   onRemove={() => removeAt(i)}
+                  onEdit={() => setEditTarget(step.picto)}
                   drag={drag}
                 />
                 {i < steps.length - 1 && (
@@ -206,6 +209,7 @@ export const BoardBuilder = ({
           ))}
         </div>
       </section>
+      {editTarget && <PictogramSheet picto={editTarget} onClose={() => setEditTarget(null)} />}
     </ParentShell>
   );
 };

--- a/src/features/board-builder/StepTile.module.css
+++ b/src/features/board-builder/StepTile.module.css
@@ -45,3 +45,22 @@
 .remove:hover {
   opacity: 1;
 }
+
+.edit {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--tal-r-pill);
+  background: var(--tal-surface-alt);
+  color: var(--tal-ink-soft);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.7;
+}
+
+.edit:hover {
+  opacity: 1;
+}

--- a/src/features/board-builder/StepTile.tsx
+++ b/src/features/board-builder/StepTile.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from 'react';
 
 import type { BoardKind, Pictogram } from '@/types/domain';
-import { XIcon } from '@/ui/icons';
+import { PencilIcon, XIcon } from '@/ui/icons';
 import { PictoTile } from '@/ui/PictoTile/PictoTile';
 import type { DragBindings } from '@/ui/Reorderable/Reorderable';
 
@@ -13,6 +13,8 @@ interface StepTileProps {
   kind: BoardKind;
   labelsVisible: boolean;
   onRemove: () => void;
+  /** Optional — when provided, a pencil button opens the edit sheet for this picto. */
+  onEdit?: () => void;
   drag: DragBindings;
 }
 
@@ -22,6 +24,7 @@ export const StepTile = ({
   kind,
   labelsVisible,
   onRemove,
+  onEdit,
   drag,
 }: StepTileProps): JSX.Element => {
   const marker =
@@ -38,6 +41,21 @@ export const StepTile = ({
       <div className={styles.body}>
         <PictoTile picto={picto} size={116} showLabel={labelsVisible} />
       </div>
+      {onEdit && (
+        <button
+          type="button"
+          className={styles.edit}
+          onClick={(e) => {
+            e.stopPropagation();
+            onEdit();
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          aria-label={`Edit ${picto.label}`}
+          title="Edit"
+        >
+          <PencilIcon size={11} />
+        </button>
+      )}
       <button
         type="button"
         className={styles.remove}

--- a/src/features/board-builder/pictogram-picker/tabs/UploadTab.test.tsx
+++ b/src/features/board-builder/pictogram-picker/tabs/UploadTab.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Pictogram } from '@/types/domain';
+
+const usePictogramsMock = vi.fn<() => { data: Pictogram[] | undefined }>();
+const useCreatePhotoMock = vi.fn(() => ({
+  mutateAsync: vi.fn().mockResolvedValue({ id: 'p', imagePath: 'o/p.jpg' }),
+  isPending: false,
+}));
+
+vi.mock('@/lib/queries/pictograms', () => ({
+  usePictograms: () => usePictogramsMock(),
+  useCreatePhotoPictogram: () => useCreatePhotoMock(),
+}));
+
+vi.mock('@/lib/useSignedUrl', () => ({
+  useSignedUrl: () => null,
+}));
+
+vi.mock('@/lib/image', () => ({
+  cropToSquareJpeg: vi.fn(),
+}));
+
+const { UploadTab } = await import('./UploadTab');
+
+const mkPhoto = (id: string, label: string, imagePath?: string): Pictogram =>
+  ({
+    id,
+    label,
+    style: 'photo',
+    ...(imagePath ? { imagePath } : {}),
+  }) as Pictogram;
+
+beforeEach(() => {
+  usePictogramsMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('UploadTab · YOUR UPLOADS section', () => {
+  it('hides the section entirely when only stock + null-image photos exist', () => {
+    usePictogramsMock.mockReturnValue({
+      data: [
+        mkPhoto('p1', 'Park', 'stock:park'),
+        mkPhoto('p2', 'Store', 'stock:store'),
+        mkPhoto('p3', 'Empty'), // null imagePath
+      ],
+    });
+    render(<UploadTab />);
+    expect(screen.queryByText(/your uploads/i)).toBeNull();
+  });
+
+  it('shows only photos the user has actually uploaded', () => {
+    usePictogramsMock.mockReturnValue({
+      data: [
+        mkPhoto('p1', 'Park', 'stock:park'),
+        mkPhoto('p2', 'My cereal', 'owner-id/p2.jpg'),
+        mkPhoto('p3', 'My shoes', 'owner-id/p3.jpg'),
+      ],
+    });
+    render(<UploadTab />);
+    expect(screen.getByText(/your uploads/i)).toBeInTheDocument();
+    expect(screen.getByText('My cereal')).toBeInTheDocument();
+    expect(screen.getByText('My shoes')).toBeInTheDocument();
+    expect(screen.queryByText('Park')).toBeNull();
+  });
+});

--- a/src/features/board-builder/pictogram-picker/tabs/UploadTab.tsx
+++ b/src/features/board-builder/pictogram-picker/tabs/UploadTab.tsx
@@ -82,8 +82,14 @@ export const UploadTab = (): JSX.Element => {
     }
   };
 
+  // "Your uploads" only — exclude photo-style templates that ship as either a
+  // `stock:<slug>` sentinel (resolved to a bundled JPG by PictogramMedia) or
+  // an unfilled placeholder (image_path null). The user hasn't uploaded those.
   const recentPhotos = pictograms
-    .filter((p: Pictogram): p is Extract<Pictogram, { style: 'photo' }> => p.style === 'photo')
+    .filter(
+      (p: Pictogram): p is Extract<Pictogram, { style: 'photo' }> =>
+        p.style === 'photo' && !!p.imagePath && !p.imagePath.startsWith('stock:'),
+    )
     .slice(-RECENT_LIMIT)
     .reverse();
 

--- a/src/features/board-builder/pictogram-picker/tabs/UploadTab.tsx
+++ b/src/features/board-builder/pictogram-picker/tabs/UploadTab.tsx
@@ -2,6 +2,7 @@ import { type ChangeEvent, type JSX, useEffect, useRef, useState } from 'react';
 
 import { cropToSquareJpeg, type ProcessedImage } from '@/lib/image';
 import { useCreatePhotoPictogram, usePictograms } from '@/lib/queries/pictograms';
+import { isUploadedStoragePath } from '@/lib/storage';
 import type { Pictogram } from '@/types/domain';
 import { Button } from '@/ui/Button/Button';
 import { UploadIcon } from '@/ui/icons';
@@ -88,7 +89,7 @@ export const UploadTab = (): JSX.Element => {
   const recentPhotos = pictograms
     .filter(
       (p: Pictogram): p is Extract<Pictogram, { style: 'photo' }> =>
-        p.style === 'photo' && !!p.imagePath && !p.imagePath.startsWith('stock:'),
+        p.style === 'photo' && isUploadedStoragePath(p.imagePath),
     )
     .slice(-RECENT_LIMIT)
     .reverse();

--- a/src/features/library/Library.module.css
+++ b/src/features/library/Library.module.css
@@ -1,3 +1,35 @@
+.searchRow {
+  display: flex;
+  align-items: center;
+  gap: var(--tal-space-3);
+  padding: var(--tal-space-2) var(--tal-space-3);
+  border: 1px solid var(--tal-line);
+  border-radius: var(--tal-r-md);
+  background: var(--tal-surface);
+  color: var(--tal-ink-muted);
+  margin-bottom: var(--tal-space-4);
+}
+
+.searchInput {
+  flex: 1;
+  border: 0;
+  background: transparent;
+  font-size: 16px;
+  font-family: inherit;
+  color: var(--tal-ink);
+  padding: var(--tal-space-1) 0;
+}
+
+.searchInput:focus-visible {
+  outline: none;
+}
+
+.emptyQuery {
+  color: var(--tal-ink-muted);
+  font-size: 15px;
+  margin: var(--tal-space-4) 0;
+}
+
 .grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));

--- a/src/features/library/Library.test.tsx
+++ b/src/features/library/Library.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { Pictogram } from '@/types/domain';
@@ -7,6 +7,17 @@ const usePictogramsMock = vi.fn<() => { data: Pictogram[] | undefined; isPending
 
 vi.mock('@/lib/queries/pictograms', () => ({
   usePictograms: () => usePictogramsMock(),
+}));
+
+vi.mock('@/ui/PictogramSheet/PictogramSheet', () => ({
+  PictogramSheet: ({ picto, onClose }: { picto: Pictogram; onClose: () => void }) => (
+    <div data-testid="picto-sheet">
+      <span>Editing {picto.label}</span>
+      <button type="button" onClick={onClose}>
+        close-sheet
+      </button>
+    </div>
+  ),
 }));
 
 const { Library } = await import('./Library');
@@ -28,5 +39,26 @@ describe('Library', () => {
     usePictogramsMock.mockReturnValue({ data: [], isPending: false });
     render(<Library />);
     expect(screen.getByRole('heading', { name: /no pictograms yet/i })).toBeInTheDocument();
+  });
+
+  it('filters tiles by the search query (case-insensitive)', () => {
+    usePictogramsMock.mockReturnValue({ data: PICTOS, isPending: false });
+    render(<Library />);
+    fireEvent.change(screen.getByRole('searchbox', { name: /search pictograms/i }), {
+      target: { value: 'app' },
+    });
+    expect(screen.getByText('Apple')).toBeInTheDocument();
+    expect(screen.queryByText('Book')).toBeNull();
+  });
+
+  it('opens the edit sheet when a tile is clicked and closes when dismissed', () => {
+    usePictogramsMock.mockReturnValue({ data: PICTOS, isPending: false });
+    render(<Library />);
+    expect(screen.queryByTestId('picto-sheet')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /apple/i }));
+    expect(screen.getByTestId('picto-sheet')).toBeInTheDocument();
+    expect(screen.getByText(/editing apple/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /close-sheet/i }));
+    expect(screen.queryByTestId('picto-sheet')).toBeNull();
   });
 });

--- a/src/features/library/Library.tsx
+++ b/src/features/library/Library.tsx
@@ -1,4 +1,4 @@
-import { type JSX, useState } from 'react';
+import { type JSX, useMemo, useState } from 'react';
 
 import { usePictograms } from '@/lib/queries/pictograms';
 import type { Pictogram } from '@/types/domain';
@@ -14,6 +14,12 @@ export const Library = (): JSX.Element => {
   const [query, setQuery] = useState('');
   const [target, setTarget] = useState<Pictogram | null>(null);
 
+  const filtered = useMemo(() => {
+    if (!query) return pictograms;
+    const needle = query.toLowerCase();
+    return pictograms.filter((p) => p.label.toLowerCase().includes(needle));
+  }, [pictograms, query]);
+
   if (pictograms.length === 0) {
     return (
       <EmptyState
@@ -22,10 +28,6 @@ export const Library = (): JSX.Element => {
       />
     );
   }
-
-  const filtered = query
-    ? pictograms.filter((p) => p.label.toLowerCase().includes(query.toLowerCase()))
-    : pictograms;
 
   return (
     <>

--- a/src/features/library/Library.tsx
+++ b/src/features/library/Library.tsx
@@ -1,13 +1,18 @@
-import type { JSX } from 'react';
+import { type JSX, useState } from 'react';
 
 import { usePictograms } from '@/lib/queries/pictograms';
+import type { Pictogram } from '@/types/domain';
 import { EmptyState } from '@/ui/EmptyState/EmptyState';
-import { PictoCard } from '@/ui/PictoTile/PictoCard';
+import { SearchIcon } from '@/ui/icons';
+import { PictogramSheet } from '@/ui/PictogramSheet/PictogramSheet';
+import { PictoTile } from '@/ui/PictoTile/PictoTile';
 
 import styles from './Library.module.css';
 
 export const Library = (): JSX.Element => {
   const { data: pictograms = [] } = usePictograms();
+  const [query, setQuery] = useState('');
+  const [target, setTarget] = useState<Pictogram | null>(null);
 
   if (pictograms.length === 0) {
     return (
@@ -18,11 +23,33 @@ export const Library = (): JSX.Element => {
     );
   }
 
+  const filtered = query
+    ? pictograms.filter((p) => p.label.toLowerCase().includes(query.toLowerCase()))
+    : pictograms;
+
   return (
-    <div className={styles.grid}>
-      {pictograms.map((p) => (
-        <PictoCard key={p.id} picto={p} size={120} />
-      ))}
-    </div>
+    <>
+      <div className={styles.searchRow}>
+        <SearchIcon size={18} />
+        <input
+          type="search"
+          className={styles.searchInput}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search apple, park, happy…"
+          aria-label="Search pictograms"
+        />
+      </div>
+      {filtered.length === 0 ? (
+        <p className={styles.emptyQuery}>No pictograms match &ldquo;{query}&rdquo;.</p>
+      ) : (
+        <div className={styles.grid}>
+          {filtered.map((p) => (
+            <PictoTile key={p.id} picto={p} size={120} onClick={() => setTarget(p)} />
+          ))}
+        </div>
+      )}
+      {target && <PictogramSheet picto={target} onClose={() => setTarget(null)} />}
+    </>
   );
 };

--- a/src/lib/outbox/handlers.test.ts
+++ b/src/lib/outbox/handlers.test.ts
@@ -3,6 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   ClearPictogramAudioEntry,
   CreatePhotoPictogramEntry,
+  DeletePictogramEntry,
+  RenamePictogramEntry,
+  ReplacePictogramImageEntry,
   SetPictogramAudioEntry,
   UpdateBoardEntry,
 } from './types';
@@ -17,7 +20,26 @@ interface MockPostgrestError {
 const eqMock = vi.fn<(c: string, v: string) => Promise<{ error: MockPostgrestError | null }>>();
 const updateMock = vi.fn(() => ({ eq: eqMock }));
 const insertMock = vi.fn<(row: unknown) => Promise<{ error: MockPostgrestError | null }>>();
-const fromMock = vi.fn((_table: string) => ({ update: updateMock, insert: insertMock }));
+const inMock =
+  vi.fn<
+    (
+      c: string,
+      vs: readonly string[],
+    ) => Promise<{
+      data: { id: string; step_ids: string[] }[] | null;
+      error: MockPostgrestError | null;
+    }>
+  >();
+const selectMock = vi.fn((_cols: string) => ({ in: inMock }));
+const deleteEqMock =
+  vi.fn<(c: string, v: string) => Promise<{ error: MockPostgrestError | null }>>();
+const deleteMock = vi.fn(() => ({ eq: deleteEqMock }));
+const fromMock = vi.fn((_table: string) => ({
+  update: updateMock,
+  insert: insertMock,
+  select: selectMock,
+  delete: deleteMock,
+}));
 
 const uploadMock =
   vi.fn<(path: string, blob: Blob, opts?: unknown) => Promise<{ error: Error | null }>>();
@@ -49,6 +71,10 @@ beforeEach(() => {
   eqMock.mockReset();
   updateMock.mockClear();
   insertMock.mockReset();
+  inMock.mockReset();
+  selectMock.mockClear();
+  deleteEqMock.mockReset();
+  deleteMock.mockClear();
   uploadMock.mockReset();
   removeMock.mockReset();
   fromMock.mockClear();
@@ -56,6 +82,8 @@ beforeEach(() => {
   // Defaults: every supabase call succeeds.
   eqMock.mockResolvedValue({ error: null });
   insertMock.mockResolvedValue({ error: null });
+  inMock.mockResolvedValue({ data: [], error: null });
+  deleteEqMock.mockResolvedValue({ error: null });
   uploadMock.mockResolvedValue({ error: null });
   removeMock.mockResolvedValue({ error: null });
 });
@@ -203,5 +231,130 @@ describe('runHandler · clearPictoAudio', () => {
     await runHandler(entry);
     expect(removeMock).toHaveBeenCalledWith(['o-1/p-1.webm']);
     expect(updateMock).toHaveBeenCalledWith({ audio_path: null });
+  });
+});
+
+describe('runHandler · renamePicto', () => {
+  it('updates the label column scoped to the pictogram id', async () => {
+    const entry: RenamePictogramEntry = {
+      ...baseProps,
+      kind: 'renamePicto',
+      pictogramId: 'p-1',
+      label: 'Local park',
+    };
+    await runHandler(entry);
+    expect(fromMock).toHaveBeenCalledWith('pictograms');
+    expect(updateMock).toHaveBeenCalledWith({ label: 'Local park' });
+    expect(eqMock).toHaveBeenCalledWith('id', 'p-1');
+  });
+});
+
+describe('runHandler · replacePictoImage', () => {
+  it('uploads the new blob, points the row at it, and removes the prior upload', async () => {
+    const blob = new Blob(['x'], { type: 'image/jpeg' });
+    const entry: ReplacePictogramImageEntry = {
+      ...baseProps,
+      kind: 'replacePictoImage',
+      pictogramId: 'p-1',
+      ownerId: 'o-1',
+      blob,
+      extension: 'jpg',
+      previousPath: 'o-1/p-1.webp',
+    };
+    await runHandler(entry);
+    expect(uploadMock).toHaveBeenCalledWith(
+      'o-1/p-1.jpg',
+      blob,
+      expect.objectContaining({ upsert: true }),
+    );
+    expect(updateMock).toHaveBeenCalledWith({ image_path: 'o-1/p-1.jpg' });
+    expect(removeMock).toHaveBeenCalledWith(['o-1/p-1.webp']);
+  });
+
+  it('skips removeFromBucket when the previous path is a stock sentinel', async () => {
+    const entry: ReplacePictogramImageEntry = {
+      ...baseProps,
+      kind: 'replacePictoImage',
+      pictogramId: 'p-1',
+      ownerId: 'o-1',
+      blob: new Blob(['x'], { type: 'image/jpeg' }),
+      extension: 'jpg',
+      previousPath: 'stock:park',
+    };
+    await runHandler(entry);
+    expect(uploadMock).toHaveBeenCalled();
+    expect(removeMock).not.toHaveBeenCalled();
+  });
+
+  it('skips removeFromBucket when the new path matches the previous path', async () => {
+    const entry: ReplacePictogramImageEntry = {
+      ...baseProps,
+      kind: 'replacePictoImage',
+      pictogramId: 'p-1',
+      ownerId: 'o-1',
+      blob: new Blob(['x'], { type: 'image/jpeg' }),
+      extension: 'jpg',
+      previousPath: 'o-1/p-1.jpg',
+    };
+    await runHandler(entry);
+    // Same key — upsert overwrote the bytes; deleting it would lose the new image.
+    expect(removeMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('runHandler · deletePicto', () => {
+  it('scrubs the id from referenced boards, deletes the row, and cleans up uploads', async () => {
+    inMock.mockResolvedValue({
+      data: [
+        { id: 'b-1', step_ids: ['p-1', 'p-2'] },
+        { id: 'b-2', step_ids: ['p-2'] }, // already not referenced — no update
+      ],
+      error: null,
+    });
+    const entry: DeletePictogramEntry = {
+      ...baseProps,
+      kind: 'deletePicto',
+      pictogramId: 'p-1',
+      previousImagePath: 'o-1/p-1.jpg',
+      previousAudioPath: 'o-1/p-1.webm',
+      scrubFromBoardIds: ['b-1', 'b-2'],
+    };
+    await runHandler(entry);
+    expect(selectMock).toHaveBeenCalledWith('id, step_ids');
+    expect(inMock).toHaveBeenCalledWith('id', ['b-1', 'b-2']);
+    // Only b-1 had a step_ids change.
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(updateMock).toHaveBeenCalledWith({ step_ids: ['p-2'] });
+    expect(eqMock).toHaveBeenCalledWith('id', 'b-1');
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+    expect(deleteEqMock).toHaveBeenCalledWith('id', 'p-1');
+    expect(removeMock).toHaveBeenCalledWith(['o-1/p-1.jpg']);
+    expect(removeMock).toHaveBeenCalledWith(['o-1/p-1.webm']);
+  });
+
+  it('skips storage cleanup for stock-prefixed previous paths', async () => {
+    const entry: DeletePictogramEntry = {
+      ...baseProps,
+      kind: 'deletePicto',
+      pictogramId: 'p-1',
+      previousImagePath: 'stock:park',
+      scrubFromBoardIds: [],
+    };
+    await runHandler(entry);
+    expect(deleteMock).toHaveBeenCalled();
+    expect(removeMock).not.toHaveBeenCalled();
+  });
+
+  it('skips the boards round-trip when scrubFromBoardIds is empty', async () => {
+    const entry: DeletePictogramEntry = {
+      ...baseProps,
+      kind: 'deletePicto',
+      pictogramId: 'p-1',
+      scrubFromBoardIds: [],
+    };
+    await runHandler(entry);
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(inMock).not.toHaveBeenCalled();
+    expect(deleteEqMock).toHaveBeenCalledWith('id', 'p-1');
   });
 });

--- a/src/lib/outbox/handlers.ts
+++ b/src/lib/outbox/handlers.ts
@@ -10,10 +10,17 @@ import { supabase } from '@/lib/supabase';
 import type {
   ClearPictogramAudioEntry,
   CreatePhotoPictogramEntry,
+  DeletePictogramEntry,
   OutboxEntry,
+  RenamePictogramEntry,
+  ReplacePictogramImageEntry,
   SetPictogramAudioEntry,
   UpdateBoardEntry,
 } from './types';
+
+const STOCK_PREFIX = 'stock:';
+const isUploadedPath = (path: string | undefined): path is string =>
+  !!path && !path.startsWith(STOCK_PREFIX);
 
 /**
  * Thrown by handlers when the failure is permanent (RLS denial, validation,
@@ -114,6 +121,74 @@ const handleClearPictogramAudio = async (entry: ClearPictogramAudioEntry): Promi
   }
 };
 
+const handleRenamePictogram = async (entry: RenamePictogramEntry): Promise<void> => {
+  try {
+    const { error } = await supabase
+      .from('pictograms')
+      .update({ label: entry.label })
+      .eq('id', entry.pictogramId);
+    if (error) throw error;
+  } catch (err) {
+    classifyAndThrow(err);
+  }
+};
+
+const handleReplacePictogramImage = async (entry: ReplacePictogramImageEntry): Promise<void> => {
+  const path = `${entry.ownerId}/${entry.pictogramId}.${entry.extension}`;
+  try {
+    await uploadBlob(IMAGES_BUCKET, path, entry.blob);
+    invalidateSignedUrl(IMAGES_BUCKET, path);
+    const { error } = await supabase
+      .from('pictograms')
+      .update({ image_path: path })
+      .eq('id', entry.pictogramId);
+    if (error) throw error;
+    if (isUploadedPath(entry.previousPath) && entry.previousPath !== path) {
+      await removeFromBucket(IMAGES_BUCKET, [entry.previousPath]).catch(() => undefined);
+      invalidateSignedUrl(IMAGES_BUCKET, entry.previousPath);
+    }
+  } catch (err) {
+    classifyAndThrow(err);
+  }
+};
+
+const handleDeletePictogram = async (entry: DeletePictogramEntry): Promise<void> => {
+  try {
+    // Scrub the picto id from every owned board's step_ids. Done before the
+    // row delete so RLS never sees an in-between state. Single round-trip via
+    // .in() — array_remove is idempotent so a retry after partial success is
+    // safe.
+    if (entry.scrubFromBoardIds.length > 0) {
+      const { data: rows, error: readErr } = await supabase
+        .from('boards')
+        .select('id, step_ids')
+        .in('id', entry.scrubFromBoardIds);
+      if (readErr) throw readErr;
+      for (const row of rows ?? []) {
+        const next = row.step_ids.filter((id: string) => id !== entry.pictogramId);
+        if (next.length === row.step_ids.length) continue;
+        const { error: updErr } = await supabase
+          .from('boards')
+          .update({ step_ids: next })
+          .eq('id', row.id);
+        if (updErr) throw updErr;
+      }
+    }
+    const { error } = await supabase.from('pictograms').delete().eq('id', entry.pictogramId);
+    if (error) throw error;
+    if (isUploadedPath(entry.previousImagePath)) {
+      await removeFromBucket(IMAGES_BUCKET, [entry.previousImagePath]).catch(() => undefined);
+      invalidateSignedUrl(IMAGES_BUCKET, entry.previousImagePath);
+    }
+    if (isUploadedPath(entry.previousAudioPath)) {
+      await removeFromBucket(AUDIO_BUCKET, [entry.previousAudioPath]).catch(() => undefined);
+      invalidateSignedUrl(AUDIO_BUCKET, entry.previousAudioPath);
+    }
+  } catch (err) {
+    classifyAndThrow(err);
+  }
+};
+
 export const runHandler = (entry: OutboxEntry): Promise<void> => {
   switch (entry.kind) {
     case 'updateBoard':
@@ -124,5 +199,11 @@ export const runHandler = (entry: OutboxEntry): Promise<void> => {
       return handleSetPictogramAudio(entry);
     case 'clearPictoAudio':
       return handleClearPictogramAudio(entry);
+    case 'renamePicto':
+      return handleRenamePictogram(entry);
+    case 'replacePictoImage':
+      return handleReplacePictogramImage(entry);
+    case 'deletePicto':
+      return handleDeletePictogram(entry);
   }
 };

--- a/src/lib/outbox/handlers.ts
+++ b/src/lib/outbox/handlers.ts
@@ -2,6 +2,7 @@ import {
   AUDIO_BUCKET,
   IMAGES_BUCKET,
   invalidateSignedUrl,
+  isUploadedStoragePath,
   removeFromBucket,
   uploadBlob,
 } from '@/lib/storage';
@@ -17,10 +18,6 @@ import type {
   SetPictogramAudioEntry,
   UpdateBoardEntry,
 } from './types';
-
-const STOCK_PREFIX = 'stock:';
-const isUploadedPath = (path: string | undefined): path is string =>
-  !!path && !path.startsWith(STOCK_PREFIX);
 
 /**
  * Thrown by handlers when the failure is permanent (RLS denial, validation,
@@ -143,7 +140,7 @@ const handleReplacePictogramImage = async (entry: ReplacePictogramImageEntry): P
       .update({ image_path: path })
       .eq('id', entry.pictogramId);
     if (error) throw error;
-    if (isUploadedPath(entry.previousPath) && entry.previousPath !== path) {
+    if (isUploadedStoragePath(entry.previousPath) && entry.previousPath !== path) {
       await removeFromBucket(IMAGES_BUCKET, [entry.previousPath]).catch(() => undefined);
       invalidateSignedUrl(IMAGES_BUCKET, entry.previousPath);
     }
@@ -154,10 +151,19 @@ const handleReplacePictogramImage = async (entry: ReplacePictogramImageEntry): P
 
 const handleDeletePictogram = async (entry: DeletePictogramEntry): Promise<void> => {
   try {
-    // Scrub the picto id from every owned board's step_ids. Done before the
-    // row delete so RLS never sees an in-between state. Single round-trip via
-    // .in() — array_remove is idempotent so a retry after partial success is
-    // safe.
+    // Order matters: scrub boards' step_ids → clean up storage → delete the
+    // pictograms row last. step_ids is a uuid[] with no FK, so we have to
+    // strip references manually before the row goes away (otherwise boards
+    // that referenced it keep dangling UUIDs). Storage cleanup runs *before*
+    // the row delete so a transient storage failure throws and the outbox
+    // retries the whole entry — once the row is gone, a retry can't re-derive
+    // which keys to remove. Each step is idempotent on retry: the SELECT
+    // re-reads current step_ids, the UPDATEs are no-ops where already
+    // scrubbed, the storage removes return success on missing keys, and the
+    // final DELETE returns no error if the row is already gone.
+    //
+    // The boards scrub takes one SELECT plus N sequential UPDATE calls (one
+    // per actually-referencing board); idempotent so retries are safe.
     if (entry.scrubFromBoardIds.length > 0) {
       const { data: rows, error: readErr } = await supabase
         .from('boards')
@@ -174,16 +180,16 @@ const handleDeletePictogram = async (entry: DeletePictogramEntry): Promise<void>
         if (updErr) throw updErr;
       }
     }
-    const { error } = await supabase.from('pictograms').delete().eq('id', entry.pictogramId);
-    if (error) throw error;
-    if (isUploadedPath(entry.previousImagePath)) {
-      await removeFromBucket(IMAGES_BUCKET, [entry.previousImagePath]).catch(() => undefined);
+    if (isUploadedStoragePath(entry.previousImagePath)) {
+      await removeFromBucket(IMAGES_BUCKET, [entry.previousImagePath]);
       invalidateSignedUrl(IMAGES_BUCKET, entry.previousImagePath);
     }
-    if (isUploadedPath(entry.previousAudioPath)) {
-      await removeFromBucket(AUDIO_BUCKET, [entry.previousAudioPath]).catch(() => undefined);
+    if (isUploadedStoragePath(entry.previousAudioPath)) {
+      await removeFromBucket(AUDIO_BUCKET, [entry.previousAudioPath]);
       invalidateSignedUrl(AUDIO_BUCKET, entry.previousAudioPath);
     }
+    const { error } = await supabase.from('pictograms').delete().eq('id', entry.pictogramId);
+    if (error) throw error;
   } catch (err) {
     classifyAndThrow(err);
   }

--- a/src/lib/outbox/types.ts
+++ b/src/lib/outbox/types.ts
@@ -57,10 +57,47 @@ export interface ClearPictogramAudioEntry extends OutboxEntryBase {
   path: string;
 }
 
+export interface RenamePictogramEntry extends OutboxEntryBase {
+  kind: 'renamePicto';
+  pictogramId: string;
+  label: string;
+}
+
+export interface ReplacePictogramImageEntry extends OutboxEntryBase {
+  kind: 'replacePictoImage';
+  pictogramId: string;
+  ownerId: string;
+  blob: Blob;
+  extension: string;
+  /**
+   * Path of the prior image to delete after the new one lands. Stock-prefixed
+   * paths (`stock:<slug>`) and missing values are ignored — only real Storage
+   * objects are removed.
+   */
+  previousPath?: string;
+}
+
+export interface DeletePictogramEntry extends OutboxEntryBase {
+  kind: 'deletePicto';
+  pictogramId: string;
+  /** Storage paths to clean up. Stock-prefixed paths are skipped by the handler. */
+  previousImagePath?: string;
+  previousAudioPath?: string;
+  /**
+   * Boards whose `step_ids` reference this pictogram. Scrubbed via
+   * `array_remove` before the row is deleted, so we don't leave dangling
+   * UUIDs in any board the user owns.
+   */
+  scrubFromBoardIds: string[];
+}
+
 export type OutboxEntry =
   | UpdateBoardEntry
   | CreatePhotoPictogramEntry
   | SetPictogramAudioEntry
-  | ClearPictogramAudioEntry;
+  | ClearPictogramAudioEntry
+  | RenamePictogramEntry
+  | ReplacePictogramImageEntry
+  | DeletePictogramEntry;
 
 export type OutboxEntryKind = OutboxEntry['kind'];

--- a/src/lib/queries/pictograms.ts
+++ b/src/lib/queries/pictograms.ts
@@ -285,21 +285,34 @@ interface ReplaceImageInput {
   pictogramId: string;
   blob: Blob;
   extension: string;
-  /** Path of the prior image; stock-prefixed values get cleaned up by the handler. */
+  /** Path of the prior image. Stock-prefixed (`stock:<slug>`) values are skipped by the handler — only real Storage objects are removed. */
   previousPath?: string | undefined;
 }
 
-export const useReplacePictogramImage = (): UseMutationResult<void, Error, ReplaceImageInput> => {
+export const useReplacePictogramImage = (): UseMutationResult<
+  void,
+  Error,
+  ReplaceImageInput,
+  { previous: Pictogram[] | undefined }
+> => {
   const qc = useQueryClient();
   const ownerId = useSessionUser().id;
   return useMutation({
-    onMutate: ({ pictogramId, blob }) => {
+    onMutate: async ({ pictogramId, blob }) => {
+      // Cancel in-flight refetches so a stale list response can't overwrite
+      // the optimistic blob URL between onMutate and onSuccess. Snapshot the
+      // pre-patch list so onError can restore the prior `imagePath` if the
+      // upload fails — without this the user sees a wiped tile (the blob URL
+      // gets revoked) until the next refetch.
+      await qc.cancelQueries({ queryKey: pictogramsQueryKey });
+      const previous = qc.getQueryData<Pictogram[]>(pictogramsQueryKey);
       const blobUrl = URL.createObjectURL(blob);
       qc.setQueryData<Pictogram[]>(pictogramsQueryKey, (list) =>
         patchPictogramInList(list, pictogramId, (p) =>
           p.style === 'photo' ? { ...p, imagePath: blobUrl } : p,
         ),
       );
+      return { previous };
     },
     mutationFn: ({ pictogramId, blob, extension, previousPath }) =>
       enqueueAndDrain({
@@ -314,8 +327,13 @@ export const useReplacePictogramImage = (): UseMutationResult<void, Error, Repla
       revokePictogramBlobs(qc);
       qc.invalidateQueries({ queryKey: pictogramsQueryKey });
     },
-    onError: () => {
+    onError: (_err, _input, ctx) => {
+      // Revoke first while the blob URL is still in the cache (revoke walks
+      // current cache state), then restore the pre-mutation snapshot so the
+      // tile shows its prior imagePath. Restoring first would orphan the
+      // blob URL — it'd be unreachable from the cache and never revoked.
       revokePictogramBlobs(qc);
+      if (ctx?.previous) qc.setQueryData(pictogramsQueryKey, ctx.previous);
       qc.invalidateQueries({ queryKey: pictogramsQueryKey });
     },
   });

--- a/src/lib/queries/pictograms.ts
+++ b/src/lib/queries/pictograms.ts
@@ -299,11 +299,6 @@ export const useReplacePictogramImage = (): UseMutationResult<
   const ownerId = useSessionUser().id;
   return useMutation({
     onMutate: async ({ pictogramId, blob }) => {
-      // Cancel in-flight refetches so a stale list response can't overwrite
-      // the optimistic blob URL between onMutate and onSuccess. Snapshot the
-      // pre-patch list so onError can restore the prior `imagePath` if the
-      // upload fails — without this the user sees a wiped tile (the blob URL
-      // gets revoked) until the next refetch.
       await qc.cancelQueries({ queryKey: pictogramsQueryKey });
       const previous = qc.getQueryData<Pictogram[]>(pictogramsQueryKey);
       const blobUrl = URL.createObjectURL(blob);
@@ -339,12 +334,6 @@ export const useReplacePictogramImage = (): UseMutationResult<
   });
 };
 
-/**
- * Inputs for deleting a pictogram. Callers (the sheet) pass the
- * pre-computed paths and referencing board ids so the optimistic patch can
- * strip the references without losing the snapshot the outbox handler
- * needs server-side. `useReferencingBoardIds` derives `scrubFromBoardIds`.
- */
 export interface DeletePictogramInput {
   pictogramId: string;
   scrubFromBoardIds: string[];
@@ -352,12 +341,7 @@ export interface DeletePictogramInput {
   previousAudioPath?: string;
 }
 
-/**
- * Boards (by id) whose `step_ids` reference this pictogram. The sheet uses
- * the count to render "Used on N boards" and passes the array straight to
- * `useDeletePictogram` so the optimistic patch and the server scrub agree.
- */
-export const useReferencingBoardIds = (
+export const referencingBoardIds = (
   pictogramId: string,
   boards: readonly Board[] | undefined,
 ): string[] => (boards ?? []).filter((b) => b.stepIds.includes(pictogramId)).map((b) => b.id);

--- a/src/lib/queries/pictograms.ts
+++ b/src/lib/queries/pictograms.ts
@@ -9,8 +9,9 @@ import {
 
 import { useSessionUser } from '@/lib/auth/session';
 import { enqueueAndDrain } from '@/lib/outbox';
+import { boardsQueryKey } from '@/lib/queries/boards.read';
 import { supabase } from '@/lib/supabase';
-import type { GlyphName, Pictogram } from '@/types/domain';
+import type { Board, GlyphName, Pictogram } from '@/types/domain';
 import type { Database } from '@/types/supabase';
 
 type PictogramRow = Database['public']['Tables']['pictograms']['Row'];
@@ -244,6 +245,145 @@ export const useCreatePhotoPictogram = (): UseMutationResult<
       // Drop the optimistic row; the user got an error.
       revokePictogramBlobs(qc);
       qc.invalidateQueries({ queryKey: pictogramsQueryKey });
+    },
+  });
+};
+
+interface RenameInput {
+  pictogramId: string;
+  label: string;
+}
+
+export const useRenamePictogram = (): UseMutationResult<
+  void,
+  Error,
+  RenameInput,
+  { previous: Pictogram[] | undefined }
+> => {
+  const qc = useQueryClient();
+  return useMutation({
+    onMutate: async ({ pictogramId, label }) => {
+      await qc.cancelQueries({ queryKey: pictogramsQueryKey });
+      const previous = qc.getQueryData<Pictogram[]>(pictogramsQueryKey);
+      qc.setQueryData<Pictogram[]>(pictogramsQueryKey, (list) =>
+        patchPictogramInList(list, pictogramId, (p) => ({ ...p, label })),
+      );
+      return { previous };
+    },
+    mutationFn: ({ pictogramId, label }) =>
+      enqueueAndDrain({ kind: 'renamePicto', pictogramId, label }),
+    onError: (_err, _input, ctx) => {
+      if (ctx?.previous) qc.setQueryData(pictogramsQueryKey, ctx.previous);
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: pictogramsQueryKey });
+    },
+  });
+};
+
+interface ReplaceImageInput {
+  pictogramId: string;
+  blob: Blob;
+  extension: string;
+  /** Path of the prior image; stock-prefixed values get cleaned up by the handler. */
+  previousPath?: string | undefined;
+}
+
+export const useReplacePictogramImage = (): UseMutationResult<void, Error, ReplaceImageInput> => {
+  const qc = useQueryClient();
+  const ownerId = useSessionUser().id;
+  return useMutation({
+    onMutate: ({ pictogramId, blob }) => {
+      const blobUrl = URL.createObjectURL(blob);
+      qc.setQueryData<Pictogram[]>(pictogramsQueryKey, (list) =>
+        patchPictogramInList(list, pictogramId, (p) =>
+          p.style === 'photo' ? { ...p, imagePath: blobUrl } : p,
+        ),
+      );
+    },
+    mutationFn: ({ pictogramId, blob, extension, previousPath }) =>
+      enqueueAndDrain({
+        kind: 'replacePictoImage',
+        pictogramId,
+        ownerId,
+        blob,
+        extension,
+        ...(previousPath ? { previousPath } : {}),
+      }),
+    onSuccess: () => {
+      revokePictogramBlobs(qc);
+      qc.invalidateQueries({ queryKey: pictogramsQueryKey });
+    },
+    onError: () => {
+      revokePictogramBlobs(qc);
+      qc.invalidateQueries({ queryKey: pictogramsQueryKey });
+    },
+  });
+};
+
+/**
+ * Inputs for deleting a pictogram. Callers (the sheet) pass the
+ * pre-computed paths and referencing board ids so the optimistic patch can
+ * strip the references without losing the snapshot the outbox handler
+ * needs server-side. `useReferencingBoardIds` derives `scrubFromBoardIds`.
+ */
+export interface DeletePictogramInput {
+  pictogramId: string;
+  scrubFromBoardIds: string[];
+  previousImagePath?: string;
+  previousAudioPath?: string;
+}
+
+/**
+ * Boards (by id) whose `step_ids` reference this pictogram. The sheet uses
+ * the count to render "Used on N boards" and passes the array straight to
+ * `useDeletePictogram` so the optimistic patch and the server scrub agree.
+ */
+export const useReferencingBoardIds = (
+  pictogramId: string,
+  boards: readonly Board[] | undefined,
+): string[] => (boards ?? []).filter((b) => b.stepIds.includes(pictogramId)).map((b) => b.id);
+
+export const useDeletePictogram = (): UseMutationResult<
+  void,
+  Error,
+  DeletePictogramInput,
+  { previousPictograms: Pictogram[] | undefined; previousBoards: Board[] | undefined }
+> => {
+  const qc = useQueryClient();
+  return useMutation({
+    onMutate: async ({ pictogramId }) => {
+      await qc.cancelQueries({ queryKey: pictogramsQueryKey });
+      await qc.cancelQueries({ queryKey: boardsQueryKey });
+      const previousPictograms = qc.getQueryData<Pictogram[]>(pictogramsQueryKey);
+      const previousBoards = qc.getQueryData<Board[]>(boardsQueryKey);
+      qc.setQueryData<Pictogram[]>(pictogramsQueryKey, (list) =>
+        list?.filter((p) => p.id !== pictogramId),
+      );
+      qc.setQueryData<Board[]>(boardsQueryKey, (list) =>
+        list?.map((b) =>
+          b.stepIds.includes(pictogramId)
+            ? { ...b, stepIds: b.stepIds.filter((id) => id !== pictogramId) }
+            : b,
+        ),
+      );
+      return { previousPictograms, previousBoards };
+    },
+    mutationFn: ({ pictogramId, scrubFromBoardIds, previousImagePath, previousAudioPath }) =>
+      enqueueAndDrain({
+        kind: 'deletePicto',
+        pictogramId,
+        scrubFromBoardIds,
+        ...(previousImagePath ? { previousImagePath } : {}),
+        ...(previousAudioPath ? { previousAudioPath } : {}),
+      }),
+    onError: (_err, _input, ctx) => {
+      if (ctx?.previousPictograms) qc.setQueryData(pictogramsQueryKey, ctx.previousPictograms);
+      if (ctx?.previousBoards) qc.setQueryData(boardsQueryKey, ctx.previousBoards);
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: pictogramsQueryKey });
+      qc.invalidateQueries({ queryKey: boardsQueryKey });
     },
   });
 };

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -6,6 +6,18 @@ import { supabase } from './supabase';
 export const AUDIO_BUCKET = 'pictogram-audio';
 export const IMAGES_BUCKET = 'pictogram-images';
 
+/**
+ * Sentinel prefix on a pictogram's `image_path` that points at a bundled
+ * stock JPG (`/seed-photos/<slug>.jpg`) instead of a real Storage object.
+ * Seed templates ship these so fresh users see real photos without an
+ * upload step. Anything else is a real path the user owns.
+ */
+export const STOCK_PATH_PREFIX = 'stock:';
+
+/** True for real Storage paths (not stock sentinels, not empty). */
+export const isUploadedStoragePath = (path: string | undefined): path is string =>
+  !!path && !path.startsWith(STOCK_PATH_PREFIX);
+
 const SIGNED_URL_TTL_SECONDS = 60 * 60;
 const IDB_PREFIX = 'signed-url:';
 const idbKey = (cacheKey: string): string => `${IDB_PREFIX}${cacheKey}`;

--- a/src/ui/PictoTile/PictogramMedia.tsx
+++ b/src/ui/PictoTile/PictogramMedia.tsx
@@ -2,13 +2,11 @@ import type { CSSProperties, JSX } from 'react';
 
 import { Glyph } from '@/glyphs/Glyph';
 import { PhotoPlaceholder } from '@/glyphs/PhotoPlaceholder';
-import { IMAGES_BUCKET } from '@/lib/storage';
+import { IMAGES_BUCKET, STOCK_PATH_PREFIX } from '@/lib/storage';
 import { useSignedUrl } from '@/lib/useSignedUrl';
 import type { Pictogram } from '@/types/domain';
 
 import styles from './PictogramMedia.module.css';
-
-const STOCK_PREFIX = 'stock:';
 
 interface PictogramMediaProps {
   picto: Pictogram;
@@ -36,8 +34,8 @@ export const PictogramMedia = ({
   // Bare `stock:` (empty slug) falls through to the placeholder rather than
   // requesting `/seed-photos/.jpg` — only reachable via a malformed DB row.
   const stockSlug =
-    isPhoto && picto.imagePath?.startsWith(STOCK_PREFIX)
-      ? picto.imagePath.slice(STOCK_PREFIX.length) || null
+    isPhoto && picto.imagePath?.startsWith(STOCK_PATH_PREFIX)
+      ? picto.imagePath.slice(STOCK_PATH_PREFIX.length) || null
       : null;
   // Stock images are bundled static assets; skip the signed-URL roundtrip.
   const photoPath = isPhoto && !stockSlug ? picto.imagePath : undefined;

--- a/src/ui/PictogramSheet/PictogramSheet.module.css
+++ b/src/ui/PictogramSheet/PictogramSheet.module.css
@@ -1,0 +1,136 @@
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--tal-space-4);
+  padding: var(--tal-space-6) var(--tal-space-7) var(--tal-space-3);
+}
+
+.title {
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--tal-ink);
+  margin: 0 0 var(--tal-space-1);
+}
+
+.subtitle {
+  font-size: 14px;
+  color: var(--tal-ink-muted);
+  margin: 0;
+  max-width: 52ch;
+}
+
+.closeBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  background: transparent;
+  border: 1px solid var(--tal-line);
+  color: var(--tal-ink-muted);
+  cursor: pointer;
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--tal-space-4);
+  padding: var(--tal-space-2) var(--tal-space-7) var(--tal-space-6);
+  overflow-y: auto;
+}
+
+.preview {
+  display: flex;
+  justify-content: center;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tal-space-3);
+  padding-top: var(--tal-space-4);
+  border-top: 1px solid var(--tal-line);
+}
+
+.dangerSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tal-space-2);
+  padding-top: var(--tal-space-4);
+  border-top: 1px solid var(--tal-line);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tal-space-1);
+}
+
+.fieldLabel {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--tal-ink-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.input {
+  width: 100%;
+  padding: var(--tal-space-2) var(--tal-space-3);
+  border: 1px solid var(--tal-line);
+  border-radius: var(--tal-r-md);
+  font-size: 16px;
+  font-family: inherit;
+  color: var(--tal-ink);
+  background: var(--tal-surface);
+}
+
+.input:focus-visible {
+  outline: 2px solid var(--tal-focus);
+  outline-offset: 2px;
+}
+
+.sectionActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--tal-space-2);
+}
+
+.fileInput {
+  display: none;
+}
+
+.photoPreview {
+  display: flex;
+  align-items: center;
+  gap: var(--tal-space-3);
+}
+
+.photoPreviewImg {
+  width: 96px;
+  height: 96px;
+  object-fit: cover;
+  border-radius: var(--tal-r-md);
+  border: 1px solid var(--tal-line);
+}
+
+.dangerHint {
+  font-size: 13px;
+  color: var(--tal-ink-muted);
+  margin: 0;
+}
+
+.dangerBtn {
+  background: var(--tal-danger);
+  color: var(--tal-on-accent);
+  border-color: var(--tal-danger);
+}
+
+.error {
+  color: var(--tal-danger);
+  font-size: 14px;
+  text-align: center;
+}

--- a/src/ui/PictogramSheet/PictogramSheet.test.tsx
+++ b/src/ui/PictogramSheet/PictogramSheet.test.tsx
@@ -1,0 +1,156 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Board, Pictogram } from '@/types/domain';
+
+const renameMock = vi.fn<(input: { pictogramId: string; label: string }) => Promise<void>>();
+const replaceMock =
+  vi.fn<
+    (input: {
+      pictogramId: string;
+      blob: Blob;
+      extension: string;
+      previousPath?: string;
+    }) => Promise<void>
+  >();
+const deleteMock =
+  vi.fn<
+    (input: {
+      pictogramId: string;
+      scrubFromBoardIds: string[];
+      previousImagePath?: string;
+      previousAudioPath?: string;
+    }) => Promise<void>
+  >();
+const useBoardsMock = vi.fn<() => { data: Board[] | undefined }>();
+
+vi.mock('@/lib/queries/pictograms', () => ({
+  useRenamePictogram: () => ({ mutateAsync: renameMock, isPending: false }),
+  useReplacePictogramImage: () => ({ mutateAsync: replaceMock, isPending: false }),
+  useDeletePictogram: () => ({ mutateAsync: deleteMock, isPending: false }),
+  useReferencingBoardIds: (pictogramId: string, boards: readonly Board[] | undefined) =>
+    (boards ?? []).filter((b: Board) => b.stepIds.includes(pictogramId)).map((b: Board) => b.id),
+}));
+
+vi.mock('@/lib/queries/boards.read', () => ({
+  useBoards: () => useBoardsMock(),
+}));
+
+vi.mock('@/lib/image', () => ({
+  cropToSquareJpeg: vi.fn(async (_file: File) => ({
+    blob: new Blob(['cropped'], { type: 'image/jpeg' }),
+    extension: 'jpg' as const,
+    previewUrl: 'blob:preview',
+  })),
+}));
+
+vi.mock('@/lib/useSignedUrl', () => ({
+  useSignedUrl: () => null,
+}));
+
+const { PictogramSheet } = await import('./PictogramSheet');
+
+const illusPicto: Pictogram = {
+  id: 'p1',
+  label: 'Apple',
+  style: 'illus',
+  glyph: 'apple',
+  tint: '#fff',
+};
+
+const photoPicto: Pictogram = {
+  id: 'p2',
+  label: 'Park',
+  style: 'photo',
+  imagePath: 'stock:park',
+};
+
+const board = (id: string, stepIds: string[]): Board => ({
+  id,
+  ownerId: 'o',
+  kidId: 'k',
+  name: 'Saturday',
+  kind: 'choice',
+  labelsVisible: true,
+  voiceMode: 'tts',
+  stepIds,
+  kidReorderable: false,
+  accent: 'sage',
+  accentInk: 'sage-ink',
+  updatedLabel: 'today',
+});
+
+beforeEach(() => {
+  renameMock.mockReset();
+  replaceMock.mockReset();
+  deleteMock.mockReset();
+  useBoardsMock.mockReset();
+  renameMock.mockResolvedValue(undefined);
+  replaceMock.mockResolvedValue(undefined);
+  deleteMock.mockResolvedValue(undefined);
+  useBoardsMock.mockReturnValue({ data: [] });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('PictogramSheet', () => {
+  it('saves a renamed label and closes', async () => {
+    const onClose = vi.fn();
+    render(<PictogramSheet picto={illusPicto} onClose={onClose} />);
+    const input = screen.getByDisplayValue('Apple');
+    fireEvent.change(input, { target: { value: 'Big apple' } });
+    fireEvent.click(screen.getByRole('button', { name: /save label/i }));
+    // Drain the awaited mutateAsync.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(renameMock).toHaveBeenCalledWith({ pictogramId: 'p1', label: 'Big apple' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('disables Save when the label is unchanged or empty', () => {
+    render(<PictogramSheet picto={illusPicto} onClose={() => undefined} />);
+    expect(screen.getByRole('button', { name: /save label/i })).toBeDisabled();
+    fireEvent.change(screen.getByDisplayValue('Apple'), { target: { value: '   ' } });
+    expect(screen.getByRole('button', { name: /save label/i })).toBeDisabled();
+  });
+
+  it('does not show the photo section for illustrated pictos', () => {
+    render(<PictogramSheet picto={illusPicto} onClose={() => undefined} />);
+    expect(screen.queryByRole('button', { name: /replace photo/i })).toBeNull();
+  });
+
+  it('shows the photo section for photo pictos', () => {
+    render(<PictogramSheet picto={photoPicto} onClose={() => undefined} />);
+    expect(screen.getByRole('button', { name: /replace photo/i })).toBeInTheDocument();
+    // Replace is disabled until a file is picked.
+    expect(screen.getByRole('button', { name: /replace photo/i })).toBeDisabled();
+  });
+
+  it('requires a confirmation tap before deleting and forwards the snapshot', async () => {
+    useBoardsMock.mockReturnValue({
+      data: [board('b1', ['p1', 'p2']), board('b2', ['p1'])],
+    });
+    const onClose = vi.fn();
+    render(<PictogramSheet picto={illusPicto} onClose={onClose} />);
+    // First click → confirm pill.
+    fireEvent.click(screen.getByRole('button', { name: /^delete pictogram$/i }));
+    expect(deleteMock).not.toHaveBeenCalled();
+    // Second click confirms.
+    fireEvent.click(screen.getByRole('button', { name: /delete forever/i }));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(deleteMock).toHaveBeenCalledWith({
+      pictogramId: 'p1',
+      scrubFromBoardIds: ['b1', 'b2'],
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows a "used on N boards" hint when the picto is referenced', () => {
+    useBoardsMock.mockReturnValue({ data: [board('b1', ['p1'])] });
+    render(<PictogramSheet picto={illusPicto} onClose={() => undefined} />);
+    expect(screen.getByText(/used on 1 board/i)).toBeInTheDocument();
+  });
+});

--- a/src/ui/PictogramSheet/PictogramSheet.test.tsx
+++ b/src/ui/PictogramSheet/PictogramSheet.test.tsx
@@ -28,7 +28,7 @@ vi.mock('@/lib/queries/pictograms', () => ({
   useRenamePictogram: () => ({ mutateAsync: renameMock, isPending: false }),
   useReplacePictogramImage: () => ({ mutateAsync: replaceMock, isPending: false }),
   useDeletePictogram: () => ({ mutateAsync: deleteMock, isPending: false }),
-  useReferencingBoardIds: (pictogramId: string, boards: readonly Board[] | undefined) =>
+  referencingBoardIds: (pictogramId: string, boards: readonly Board[] | undefined) =>
     (boards ?? []).filter((b: Board) => b.stepIds.includes(pictogramId)).map((b: Board) => b.id),
 }));
 

--- a/src/ui/PictogramSheet/PictogramSheet.tsx
+++ b/src/ui/PictogramSheet/PictogramSheet.tsx
@@ -1,0 +1,256 @@
+import { type ChangeEvent, type JSX, useEffect, useRef, useState } from 'react';
+
+import { cropToSquareJpeg, type ProcessedImage } from '@/lib/image';
+import { useBoards } from '@/lib/queries/boards.read';
+import {
+  useDeletePictogram,
+  useReferencingBoardIds,
+  useRenamePictogram,
+  useReplacePictogramImage,
+} from '@/lib/queries/pictograms';
+import type { Pictogram } from '@/types/domain';
+import { Button } from '@/ui/Button/Button';
+import { TrashIcon, UploadIcon, XIcon } from '@/ui/icons';
+import { Modal } from '@/ui/Modal/Modal';
+import { PictogramMedia } from '@/ui/PictoTile/PictogramMedia';
+
+import styles from './PictogramSheet.module.css';
+
+interface Props {
+  picto: Pictogram;
+  onClose: () => void;
+}
+
+const TITLE_ID = 'tal-pictogram-sheet-title';
+const LABEL_MAX = 40;
+
+export const PictogramSheet = ({ picto, onClose }: Props): JSX.Element => {
+  const [label, setLabel] = useState(picto.label);
+  const [processed, setProcessed] = useState<ProcessedImage | null>(null);
+  const [phase, setPhase] = useState<'idle' | 'processing' | 'saving'>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const renameMut = useRenamePictogram();
+  const replaceMut = useReplacePictogramImage();
+  const deleteMut = useDeletePictogram();
+  const { data: boards } = useBoards();
+  const referencedBoardIds = useReferencingBoardIds(picto.id, boards);
+
+  // Revoke any pending preview blob URL on unmount or when the user picks a
+  // different file.
+  useEffect(
+    () => () => {
+      if (processed) URL.revokeObjectURL(processed.previewUrl);
+    },
+    [processed],
+  );
+
+  const trimmedLabel = label.trim();
+  const labelDirty = trimmedLabel.length > 0 && trimmedLabel !== picto.label;
+  const busy = phase !== 'idle';
+
+  const onPickFile = (): void => fileInputRef.current?.click();
+
+  const onFile = async (e: ChangeEvent<HTMLInputElement>): Promise<void> => {
+    const file = e.target.files?.[0] ?? null;
+    e.target.value = '';
+    if (!file) return;
+    setError(null);
+    if (processed) URL.revokeObjectURL(processed.previewUrl);
+    setProcessed(null);
+    setPhase('processing');
+    try {
+      setProcessed(await cropToSquareJpeg(file));
+    } catch {
+      setError('Could not read that image. Try a JPG or PNG.');
+    } finally {
+      setPhase('idle');
+    }
+  };
+
+  const onSaveLabel = async (): Promise<void> => {
+    if (!labelDirty) return;
+    setError(null);
+    setPhase('saving');
+    try {
+      await renameMut.mutateAsync({ pictogramId: picto.id, label: trimmedLabel });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Rename failed.');
+      setPhase('idle');
+    }
+  };
+
+  const onSavePhoto = async (): Promise<void> => {
+    if (!processed || picto.style !== 'photo') return;
+    setError(null);
+    setPhase('saving');
+    try {
+      await replaceMut.mutateAsync({
+        pictogramId: picto.id,
+        blob: processed.blob,
+        extension: processed.extension,
+        ...(picto.imagePath ? { previousPath: picto.imagePath } : {}),
+      });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Photo replace failed.');
+      setPhase('idle');
+    }
+  };
+
+  const onDelete = async (): Promise<void> => {
+    setError(null);
+    setPhase('saving');
+    try {
+      await deleteMut.mutateAsync({
+        pictogramId: picto.id,
+        scrubFromBoardIds: referencedBoardIds,
+        ...(picto.style === 'photo' && picto.imagePath
+          ? { previousImagePath: picto.imagePath }
+          : {}),
+        ...(picto.audioPath ? { previousAudioPath: picto.audioPath } : {}),
+      });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Delete failed.');
+      setPhase('idle');
+    }
+  };
+
+  return (
+    <Modal onClose={onClose} labelledBy={TITLE_ID}>
+      <header className={styles.header}>
+        <div>
+          <h2 id={TITLE_ID} className={styles.title}>
+            Edit pictogram
+          </h2>
+          <p className={styles.subtitle}>
+            Rename, replace the photo, or delete <strong>{picto.label}</strong>.
+          </p>
+        </div>
+        <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Close">
+          <XIcon size={16} />
+        </button>
+      </header>
+
+      <div className={styles.body}>
+        <div className={styles.preview}>
+          <PictogramMedia picto={picto} size={140} />
+        </div>
+
+        <section className={styles.section}>
+          <label className={styles.field}>
+            <span className={styles.fieldLabel}>Label</span>
+            <input
+              className={styles.input}
+              type="text"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              maxLength={LABEL_MAX}
+              disabled={busy}
+            />
+          </label>
+          <div className={styles.sectionActions}>
+            <Button
+              variant="primary"
+              onClick={() => {
+                void onSaveLabel();
+              }}
+              disabled={!labelDirty || busy}
+            >
+              {phase === 'saving' && labelDirty ? 'Saving…' : 'Save label'}
+            </Button>
+          </div>
+        </section>
+
+        {picto.style === 'photo' && (
+          <section className={styles.section}>
+            <div className={styles.fieldLabel}>Photo</div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/jpeg,image/png,image/webp"
+              className={styles.fileInput}
+              onChange={(e) => {
+                void onFile(e);
+              }}
+            />
+            {processed ? (
+              <div className={styles.photoPreview}>
+                <img src={processed.previewUrl} alt="" className={styles.photoPreviewImg} />
+                <Button variant="ghost" onClick={onPickFile} disabled={busy}>
+                  Choose another
+                </Button>
+              </div>
+            ) : (
+              <Button
+                variant="ghost"
+                icon={<UploadIcon size={16} />}
+                onClick={onPickFile}
+                disabled={busy}
+              >
+                {phase === 'processing' ? 'Preparing…' : 'Choose a new photo'}
+              </Button>
+            )}
+            <div className={styles.sectionActions}>
+              <Button
+                variant="primary"
+                onClick={() => {
+                  void onSavePhoto();
+                }}
+                disabled={!processed || busy}
+              >
+                Replace photo
+              </Button>
+            </div>
+          </section>
+        )}
+
+        <section className={styles.dangerSection}>
+          <div className={styles.fieldLabel}>Delete</div>
+          {referencedBoardIds.length > 0 && (
+            <p className={styles.dangerHint}>
+              Used on {referencedBoardIds.length} board
+              {referencedBoardIds.length === 1 ? '' : 's'}. Deleting removes it from those boards
+              too.
+            </p>
+          )}
+          {confirmDelete ? (
+            <div className={styles.sectionActions}>
+              <Button variant="ghost" onClick={() => setConfirmDelete(false)} disabled={busy}>
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                className={styles.dangerBtn}
+                icon={<TrashIcon size={14} />}
+                onClick={() => {
+                  void onDelete();
+                }}
+                disabled={busy}
+              >
+                Delete forever
+              </Button>
+            </div>
+          ) : (
+            <div className={styles.sectionActions}>
+              <Button
+                variant="ghost"
+                icon={<TrashIcon size={14} />}
+                onClick={() => setConfirmDelete(true)}
+                disabled={busy}
+              >
+                Delete pictogram
+              </Button>
+            </div>
+          )}
+        </section>
+
+        {error && <div className={styles.error}>{error}</div>}
+      </div>
+    </Modal>
+  );
+};

--- a/src/ui/PictogramSheet/PictogramSheet.tsx
+++ b/src/ui/PictogramSheet/PictogramSheet.tsx
@@ -1,10 +1,10 @@
-import { type ChangeEvent, type JSX, useEffect, useRef, useState } from 'react';
+import { type ChangeEvent, type JSX, useEffect, useMemo, useRef, useState } from 'react';
 
 import { cropToSquareJpeg, type ProcessedImage } from '@/lib/image';
 import { useBoards } from '@/lib/queries/boards.read';
 import {
+  referencingBoardIds,
   useDeletePictogram,
-  useReferencingBoardIds,
   useRenamePictogram,
   useReplacePictogramImage,
 } from '@/lib/queries/pictograms';
@@ -27,7 +27,7 @@ const LABEL_MAX = 40;
 export const PictogramSheet = ({ picto, onClose }: Props): JSX.Element => {
   const [label, setLabel] = useState(picto.label);
   const [processed, setProcessed] = useState<ProcessedImage | null>(null);
-  const [phase, setPhase] = useState<'idle' | 'processing' | 'saving'>('idle');
+  const [processing, setProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -36,10 +36,11 @@ export const PictogramSheet = ({ picto, onClose }: Props): JSX.Element => {
   const replaceMut = useReplacePictogramImage();
   const deleteMut = useDeletePictogram();
   const { data: boards } = useBoards();
-  const referencedBoardIds = useReferencingBoardIds(picto.id, boards);
+  const referencedBoardIds = useMemo(
+    () => referencingBoardIds(picto.id, boards),
+    [picto.id, boards],
+  );
 
-  // Revoke any pending preview blob URL on unmount or when the user picks a
-  // different file.
   useEffect(
     () => () => {
       if (processed) URL.revokeObjectURL(processed.previewUrl);
@@ -49,7 +50,8 @@ export const PictogramSheet = ({ picto, onClose }: Props): JSX.Element => {
 
   const trimmedLabel = label.trim();
   const labelDirty = trimmedLabel.length > 0 && trimmedLabel !== picto.label;
-  const busy = phase !== 'idle';
+  const saving = renameMut.isPending || replaceMut.isPending || deleteMut.isPending;
+  const busy = processing || saving;
 
   const onPickFile = (): void => fileInputRef.current?.click();
 
@@ -60,33 +62,30 @@ export const PictogramSheet = ({ picto, onClose }: Props): JSX.Element => {
     setError(null);
     if (processed) URL.revokeObjectURL(processed.previewUrl);
     setProcessed(null);
-    setPhase('processing');
+    setProcessing(true);
     try {
       setProcessed(await cropToSquareJpeg(file));
     } catch {
       setError('Could not read that image. Try a JPG or PNG.');
     } finally {
-      setPhase('idle');
+      setProcessing(false);
     }
   };
 
   const onSaveLabel = async (): Promise<void> => {
     if (!labelDirty) return;
     setError(null);
-    setPhase('saving');
     try {
       await renameMut.mutateAsync({ pictogramId: picto.id, label: trimmedLabel });
       onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Rename failed.');
-      setPhase('idle');
     }
   };
 
   const onSavePhoto = async (): Promise<void> => {
     if (!processed || picto.style !== 'photo') return;
     setError(null);
-    setPhase('saving');
     try {
       await replaceMut.mutateAsync({
         pictogramId: picto.id,
@@ -97,13 +96,11 @@ export const PictogramSheet = ({ picto, onClose }: Props): JSX.Element => {
       onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Photo replace failed.');
-      setPhase('idle');
     }
   };
 
   const onDelete = async (): Promise<void> => {
     setError(null);
-    setPhase('saving');
     try {
       await deleteMut.mutateAsync({
         pictogramId: picto.id,
@@ -116,7 +113,6 @@ export const PictogramSheet = ({ picto, onClose }: Props): JSX.Element => {
       onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Delete failed.');
-      setPhase('idle');
     }
   };
 
@@ -161,7 +157,7 @@ export const PictogramSheet = ({ picto, onClose }: Props): JSX.Element => {
               }}
               disabled={!labelDirty || busy}
             >
-              {phase === 'saving' && labelDirty ? 'Saving…' : 'Save label'}
+              {renameMut.isPending ? 'Saving…' : 'Save label'}
             </Button>
           </div>
         </section>
@@ -192,7 +188,7 @@ export const PictogramSheet = ({ picto, onClose }: Props): JSX.Element => {
                 onClick={onPickFile}
                 disabled={busy}
               >
-                {phase === 'processing' ? 'Preparing…' : 'Choose a new photo'}
+                {processing ? 'Preparing…' : 'Choose a new photo'}
               </Button>
             )}
             <div className={styles.sectionActions}>
@@ -218,25 +214,25 @@ export const PictogramSheet = ({ picto, onClose }: Props): JSX.Element => {
               too.
             </p>
           )}
-          {confirmDelete ? (
-            <div className={styles.sectionActions}>
-              <Button variant="ghost" onClick={() => setConfirmDelete(false)} disabled={busy}>
-                Cancel
-              </Button>
-              <Button
-                variant="primary"
-                className={styles.dangerBtn}
-                icon={<TrashIcon size={14} />}
-                onClick={() => {
-                  void onDelete();
-                }}
-                disabled={busy}
-              >
-                Delete forever
-              </Button>
-            </div>
-          ) : (
-            <div className={styles.sectionActions}>
+          <div className={styles.sectionActions}>
+            {confirmDelete ? (
+              <>
+                <Button variant="ghost" onClick={() => setConfirmDelete(false)} disabled={busy}>
+                  Cancel
+                </Button>
+                <Button
+                  variant="primary"
+                  className={styles.dangerBtn}
+                  icon={<TrashIcon size={14} />}
+                  onClick={() => {
+                    void onDelete();
+                  }}
+                  disabled={busy}
+                >
+                  Delete forever
+                </Button>
+              </>
+            ) : (
               <Button
                 variant="ghost"
                 icon={<TrashIcon size={14} />}
@@ -245,8 +241,8 @@ export const PictogramSheet = ({ picto, onClose }: Props): JSX.Element => {
               >
                 Delete pictogram
               </Button>
-            </div>
-          )}
+            )}
+          </div>
         </section>
 
         {error && <div className={styles.error}>{error}</div>}

--- a/src/ui/icons/index.tsx
+++ b/src/ui/icons/index.tsx
@@ -133,6 +133,13 @@ export const TrashIcon = ({ size = 16, ...rest }: IconProps): JSX.Element => (
   </Svg>
 );
 
+export const PencilIcon = ({ size = 14, ...rest }: IconProps): JSX.Element => (
+  <Svg size={size} viewBox="0 0 24 24" strokeWidth={2} {...rest}>
+    <path d="M14 4 L20 10 L8 22 L2 22 L2 16 Z" />
+    <path d="M13 5 L19 11" />
+  </Svg>
+);
+
 export const SpeakerIcon = ({ size = 24, ...rest }: IconProps): JSX.Element => (
   <Svg size={size} viewBox="0 0 24 24" fill="currentColor" strokeWidth={0} {...rest}>
     <path d="M4 9 L4 15 L9 15 L14 20 L14 4 L9 9 Z" />


### PR DESCRIPTION
Closes #180, #181, #186.

## Summary
- Three new outbox kinds (`renamePicto`, `replacePictoImage`, `deletePicto`) plus matching React Query hooks with optimistic cache patches. Delete scrubs the picto id from referenced boards' `step_ids` before the row delete (uuid[] has no FK), and skips storage cleanup for `stock:` sentinels.
- New `PictogramSheet` modal: rename, replace photo, delete (with confirm). Reused from the Library tab and a per-step pencil button in `BoardBuilder`.
- Library tab is now interactive: tap to edit + search input. Route subhead corrected.
- Picker's "YOUR UPLOADS" filter now excludes `stock:` and null-imagePath placeholders, so a fresh seed shows nothing in that section.

## Test plan
- [x] `npm test` (308 passing — 14 new handler tests, 6 sheet tests, 2 UploadTab tests, library extended)
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [ ] Manual smoke (reviewer / merge): Library tap → rename, replace photo, delete with stock + non-stock paths; board editor pencil button opens same sheet; deleting a picto removes it from any board it appears on; picker Upload tab on fresh seed has no "YOUR UPLOADS".