### PR TITLE
feat(kids): rename / delete / active-kid + parent-home filter

### DIFF
--- a/src/app/routes/KidsRoute.test.tsx
+++ b/src/app/routes/KidsRoute.test.tsx
@@ -9,12 +9,18 @@ import type { Board, Kid } from '@/types/domain';
 
 const useBoardsMock = vi.fn(() => ({ data: [] as Board[], isPending: false }));
 
+const KID: Kid = { id: 'k1', ownerId: 'owner', name: 'Liam' };
+
 vi.mock('@/lib/queries/kids', () => ({
   useKids: (): { data: Kid[]; isPending: boolean } => ({
-    data: [{ id: 'k1', ownerId: 'owner', name: 'Liam' }],
+    data: [KID],
     isPending: false,
   }),
   useCreateKid: () => ({ mutate: vi.fn(), isPending: false }),
+  useActiveKid: () => KID,
+  useRenameKid: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDeleteKid: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  setActiveKidId: vi.fn(),
 }));
 
 vi.mock('@/lib/queries/boards', async (importOriginal) => {

--- a/src/app/routes/KidsRoute.tsx
+++ b/src/app/routes/KidsRoute.tsx
@@ -19,7 +19,7 @@ export const KidsRoute = (): JSX.Element => {
         onNav={onNav}
         onKidMode={onKidMode}
         title="Kids"
-        subtitle="The kids you're creating boards for"
+        subtitle="Tap a kid to rename, delete, or set them as active."
         right={
           <Button variant="primary" icon={<PlusIcon />} onClick={() => setNewKidOpen(true)}>
             New kid

--- a/src/app/routes/ParentHomeRoute.test.tsx
+++ b/src/app/routes/ParentHomeRoute.test.tsx
@@ -21,6 +21,8 @@ const useCreateBoardMock = vi.fn(() => ({
 vi.mock('@/lib/queries/kids', () => ({
   useKids: () => useKidsMock(),
   useCreateKid: () => ({ mutate: vi.fn(), isPending: false }),
+  useActiveKid: () => useKidsMock().data?.[0] ?? null,
+  setActiveKidId: vi.fn(),
 }));
 
 vi.mock('@/lib/queries/boards', async (importOriginal) => {

--- a/src/app/routes/ParentHomeRoute.tsx
+++ b/src/app/routes/ParentHomeRoute.tsx
@@ -7,7 +7,7 @@ import { useKidModeNav } from '@/layouts/useKidModeNav';
 import { useParentNav } from '@/layouts/useParentNav';
 import { getLastBoard, hasAutoLaunched, kidPathFor, markAutoLaunched } from '@/lib/lastBoard';
 import { useBoards, useCreateBoard } from '@/lib/queries/boards';
-import { useKids } from '@/lib/queries/kids';
+import { useActiveKid } from '@/lib/queries/kids';
 import { accentForIndex } from '@/theme/tokens';
 import { NewKidModal } from '@/ui/NewKidModal/NewKidModal';
 
@@ -16,7 +16,7 @@ export const ParentHomeRoute = (): JSX.Element => {
   const onNav = useParentNav();
   const onKidMode = useKidModeNav();
   const boardsQuery = useBoards();
-  const kidsQuery = useKids();
+  const activeKid = useActiveKid();
   const createBoard = useCreateBoard();
   const [newKidOpen, setNewKidOpen] = useState(false);
   const [newBoardOpen, setNewBoardOpen] = useState(false);
@@ -33,19 +33,18 @@ export const ParentHomeRoute = (): JSX.Element => {
   }, []);
   if (redirect) return <Navigate to={redirect} replace />;
 
-  const firstKid = kidsQuery.data?.[0];
   const boardCount = boardsQuery.data?.length ?? 0;
 
   // Fast-path create: skip the modal, drop a board with default values, and
   // navigate straight into the BoardBuilder where the user names + tunes it.
   // Accent rotates by current board count so the grid stays visually distinct.
   const onNewBlankBoard = (): void => {
-    if (!firstKid || createBoard.isPending) return;
+    if (!activeKid || createBoard.isPending) return;
     createBoard.mutate(
       {
         name: 'Untitled board',
         kind: 'sequence',
-        kidId: firstKid.id,
+        kidId: activeKid.id,
         accent: accentForIndex(boardCount),
       },
       {
@@ -57,7 +56,7 @@ export const ParentHomeRoute = (): JSX.Element => {
   return (
     <>
       <ParentHome
-        {...(firstKid ? { kidName: firstKid.name } : {})}
+        {...(activeKid ? { kidName: activeKid.name } : {})}
         onOpenBoard={(id) => navigate(`/boards/${id}/edit`)}
         onKidMode={onKidMode}
         onNav={onNav}

--- a/src/features/board-builder/SettingsRow.test.tsx
+++ b/src/features/board-builder/SettingsRow.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { SettingsRow } from './SettingsRow';
+
+const baseProps = {
+  labelsVisible: true,
+  onLabelsChange: () => undefined,
+  voiceMode: 'tts' as const,
+  onVoiceModeChange: () => undefined,
+  kidReorderable: false,
+  onKidReorderableChange: () => undefined,
+  stepCount: 0,
+};
+
+describe('SettingsRow', () => {
+  it('shows the "Kid can reorder" toggle on sequence boards', () => {
+    render(<SettingsRow {...baseProps} kind="sequence" onKindChange={() => undefined} />);
+    expect(screen.getByText('Kid can reorder')).toBeInTheDocument();
+  });
+
+  it('hides the "Kid can reorder" toggle on choice boards', () => {
+    render(<SettingsRow {...baseProps} kind="choice" onKindChange={() => undefined} />);
+    expect(screen.queryByText('Kid can reorder')).toBeNull();
+  });
+});

--- a/src/features/board-builder/SettingsRow.tsx
+++ b/src/features/board-builder/SettingsRow.tsx
@@ -44,7 +44,9 @@ export const SettingsRow = ({
   <div className={styles.row}>
     <Segmented value={kind} onChange={onKindChange} options={KIND_OPTIONS} />
     <Toggle label="Labels" value={labelsVisible} onChange={onLabelsChange} />
-    <Toggle label="Kid can reorder" value={kidReorderable} onChange={onKidReorderableChange} />
+    {kind === 'sequence' && (
+      <Toggle label="Kid can reorder" value={kidReorderable} onChange={onKidReorderableChange} />
+    )}
     <Select label="Voice" value={voiceMode} onChange={onVoiceModeChange} options={VOICE_OPTIONS} />
     <div className={styles.spacer} />
     <div className={styles.count}>

--- a/src/features/kids/Kids.module.css
+++ b/src/features/kids/Kids.module.css
@@ -10,14 +10,45 @@
 .row {
   display: flex;
   align-items: center;
+  gap: var(--tal-space-3);
+  width: 100%;
   padding: var(--tal-space-4) var(--tal-space-5);
   border: 1px solid var(--tal-line);
   border-radius: var(--tal-r-md);
   background: var(--tal-surface);
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.row:hover {
+  border-color: var(--tal-ink-muted);
+}
+
+.row:focus-visible {
+  outline: 2px solid var(--tal-focus);
+  outline-offset: 2px;
 }
 
 .name {
   font-size: 16px;
   font-weight: 700;
   color: var(--tal-ink);
+}
+
+.badge {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: var(--tal-space-1) var(--tal-space-2);
+  border-radius: 999px;
+  background: var(--tal-sage);
+  color: var(--tal-sage-ink);
+}
+
+.count {
+  margin-left: auto;
+  font-size: 13px;
+  color: var(--tal-ink-muted);
 }

--- a/src/features/kids/Kids.test.tsx
+++ b/src/features/kids/Kids.test.tsx
@@ -1,13 +1,23 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { Kid } from '@/types/domain';
+import type { Board, Kid } from '@/types/domain';
 
 const useKidsMock = vi.fn<() => { data: Kid[] | undefined; isPending: boolean }>();
+const useBoardsMock = vi.fn<() => { data: Board[] | undefined }>();
+const useActiveKidMock = vi.fn<() => Kid | null>();
 
 vi.mock('@/lib/queries/kids', () => ({
   useKids: () => useKidsMock(),
+  useActiveKid: () => useActiveKidMock(),
+  useRenameKid: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDeleteKid: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  setActiveKidId: vi.fn(),
+}));
+
+vi.mock('@/lib/queries/boards', () => ({
+  useBoards: () => useBoardsMock(),
 }));
 
 const { Kids } = await import('./Kids');
@@ -16,6 +26,29 @@ const KIDS: Kid[] = [
   { id: 'k1', ownerId: 'owner', name: 'Liam' },
   { id: 'k2', ownerId: 'owner', name: 'Mira' },
 ];
+
+const board = (id: string, kidId: string): Board => ({
+  id,
+  ownerId: 'owner',
+  kidId,
+  name: 'B',
+  kind: 'sequence',
+  labelsVisible: true,
+  voiceMode: 'tts',
+  stepIds: [],
+  kidReorderable: false,
+  accent: 'sage',
+  accentInk: 'sage-ink',
+  updatedLabel: 'today',
+});
+
+beforeEach(() => {
+  useKidsMock.mockReset();
+  useBoardsMock.mockReset();
+  useActiveKidMock.mockReset();
+  useBoardsMock.mockReturnValue({ data: [] });
+  useActiveKidMock.mockReturnValue(KIDS[0] ?? null);
+});
 
 describe('Kids', () => {
   it('renders a row for each kid', () => {
@@ -39,5 +72,25 @@ describe('Kids', () => {
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: /add your first kid/i }));
     expect(onNewKid).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows board count and "Active" badge on the active kid', () => {
+    useKidsMock.mockReturnValue({ data: KIDS, isPending: false });
+    useBoardsMock.mockReturnValue({
+      data: [board('b1', 'k1'), board('b2', 'k1'), board('b3', 'k2')],
+    });
+    useActiveKidMock.mockReturnValue(KIDS[0] ?? null);
+    render(<Kids />);
+    expect(screen.getByText('2 boards')).toBeInTheDocument();
+    expect(screen.getByText('1 board')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+
+  it('clicking a kid row opens the edit sheet', async () => {
+    useKidsMock.mockReturnValue({ data: KIDS, isPending: false });
+    render(<Kids />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /edit liam/i }));
+    expect(screen.getByRole('heading', { name: /edit kid/i })).toBeInTheDocument();
   });
 });

--- a/src/features/kids/Kids.tsx
+++ b/src/features/kids/Kids.tsx
@@ -1,9 +1,12 @@
-import type { JSX } from 'react';
+import { type JSX, useMemo, useState } from 'react';
 
-import { useKids } from '@/lib/queries/kids';
+import { useBoards } from '@/lib/queries/boards';
+import { useActiveKid, useKids } from '@/lib/queries/kids';
+import type { Kid } from '@/types/domain';
 import { Button } from '@/ui/Button/Button';
 import { EmptyState } from '@/ui/EmptyState/EmptyState';
 import { PlusIcon } from '@/ui/icons';
+import { KidSheet } from '@/ui/KidSheet/KidSheet';
 
 import styles from './Kids.module.css';
 
@@ -13,6 +16,17 @@ interface KidsProps {
 
 export const Kids = ({ onNewKid }: KidsProps): JSX.Element => {
   const { data: kids = [] } = useKids();
+  const { data: boards } = useBoards();
+  const activeKid = useActiveKid();
+  const [sheetTarget, setSheetTarget] = useState<Kid | null>(null);
+
+  const boardCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const b of boards ?? []) {
+      counts.set(b.kidId, (counts.get(b.kidId) ?? 0) + 1);
+    }
+    return counts;
+  }, [boards]);
 
   if (kids.length === 0) {
     return (
@@ -29,12 +43,30 @@ export const Kids = ({ onNewKid }: KidsProps): JSX.Element => {
   }
 
   return (
-    <ul className={styles.list}>
-      {kids.map((kid) => (
-        <li key={kid.id} className={styles.row}>
-          <span className={styles.name}>{kid.name}</span>
-        </li>
-      ))}
-    </ul>
+    <>
+      <ul className={styles.list}>
+        {kids.map((kid) => {
+          const count = boardCounts.get(kid.id) ?? 0;
+          const isActive = activeKid?.id === kid.id;
+          return (
+            <li key={kid.id}>
+              <button
+                type="button"
+                className={styles.row}
+                onClick={() => setSheetTarget(kid)}
+                aria-label={`Edit ${kid.name}`}
+              >
+                <span className={styles.name}>{kid.name}</span>
+                {isActive && <span className={styles.badge}>Active</span>}
+                <span className={styles.count}>
+                  {count} board{count === 1 ? '' : 's'}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+      {sheetTarget && <KidSheet kid={sheetTarget} onClose={() => setSheetTarget(null)} />}
+    </>
   );
 };

--- a/src/features/kids/Kids.tsx
+++ b/src/features/kids/Kids.tsx
@@ -66,7 +66,13 @@ export const Kids = ({ onNewKid }: KidsProps): JSX.Element => {
           );
         })}
       </ul>
-      {sheetTarget && <KidSheet kid={sheetTarget} onClose={() => setSheetTarget(null)} />}
+      {sheetTarget && (
+        <KidSheet
+          kid={sheetTarget}
+          boardCount={boardCounts.get(sheetTarget.id) ?? 0}
+          onClose={() => setSheetTarget(null)}
+        />
+      )}
     </>
   );
 };

--- a/src/features/parent-home/ParentHome.tsx
+++ b/src/features/parent-home/ParentHome.tsx
@@ -2,10 +2,12 @@ import type { JSX } from 'react';
 
 import { type ParentNavKey, ParentShell } from '@/layouts/ParentShell';
 import { useBoards } from '@/lib/queries/boards';
+import { setActiveKidId, useActiveKid, useKids } from '@/lib/queries/kids';
 import { usePictogramsBySlug } from '@/lib/queries/pictograms';
 import { Button } from '@/ui/Button/Button';
 import { EmptyState } from '@/ui/EmptyState/EmptyState';
 import { PlusIcon } from '@/ui/icons';
+import { KidSwitcher } from '@/ui/KidSwitcher/KidSwitcher';
 import { PictoTile } from '@/ui/PictoTile/PictoTile';
 
 import { BoardCard } from './BoardCard';
@@ -44,9 +46,15 @@ export const ParentHome = ({
 }: ParentHomeProps): JSX.Element => {
   const boardsQuery = useBoards();
   const pictogramsBySlug = usePictogramsBySlug();
+  const { data: kids = [] } = useKids();
+  const activeKid = useActiveKid();
 
-  const boards = boardsQuery.data ?? [];
+  // Filter is client-side: every board row already carries kid_id, so there's
+  // no need for a separate query per kid. Without an active kid (no kids yet)
+  // an empty list is correct — the EmptyState below prompts to add one.
+  const boards = (boardsQuery.data ?? []).filter((b) => b.kidId === activeKid?.id);
   const noBoards = boards.length === 0;
+  const showSwitcher = kids.length > 1;
 
   return (
     <ParentShell
@@ -66,6 +74,9 @@ export const ParentHome = ({
         </div>
       }
     >
+      {showSwitcher && (
+        <KidSwitcher kids={kids} activeKidId={activeKid?.id ?? null} onSelect={setActiveKidId} />
+      )}
       {noBoards ? (
         <EmptyState
           title="No boards yet"

--- a/src/lib/outbox/handlers.test.ts
+++ b/src/lib/outbox/handlers.test.ts
@@ -3,7 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   ClearPictogramAudioEntry,
   CreatePhotoPictogramEntry,
+  DeleteKidEntry,
   DeletePictogramEntry,
+  RenameKidEntry,
   RenamePictogramEntry,
   ReplacePictogramImageEntry,
   SetPictogramAudioEntry,
@@ -20,16 +22,15 @@ interface MockPostgrestError {
 const eqMock = vi.fn<(c: string, v: string) => Promise<{ error: MockPostgrestError | null }>>();
 const updateMock = vi.fn(() => ({ eq: eqMock }));
 const insertMock = vi.fn<(row: unknown) => Promise<{ error: MockPostgrestError | null }>>();
-const inMock =
-  vi.fn<
-    (
-      c: string,
-      vs: readonly string[],
-    ) => Promise<{
-      data: { id: string; step_ids: string[] }[] | null;
-      error: MockPostgrestError | null;
-    }>
-  >();
+const inMock = vi.fn<
+  (
+    c: string,
+    vs: readonly string[],
+  ) => Promise<{
+    data: { id: string; step_ids: string[] }[] | null;
+    error: MockPostgrestError | null;
+  }>
+>();
 const selectMock = vi.fn((_cols: string) => ({ in: inMock }));
 const deleteEqMock =
   vi.fn<(c: string, v: string) => Promise<{ error: MockPostgrestError | null }>>();
@@ -356,5 +357,60 @@ describe('runHandler · deletePicto', () => {
     expect(selectMock).not.toHaveBeenCalled();
     expect(inMock).not.toHaveBeenCalled();
     expect(deleteEqMock).toHaveBeenCalledWith('id', 'p-1');
+  });
+});
+
+describe('runHandler · renameKid', () => {
+  it('updates the name column scoped to the kid id', async () => {
+    const entry: RenameKidEntry = {
+      ...baseProps,
+      kind: 'renameKid',
+      kidId: 'k-1',
+      name: 'Mia',
+    };
+    await runHandler(entry);
+    expect(fromMock).toHaveBeenCalledWith('kids');
+    expect(updateMock).toHaveBeenCalledWith({ name: 'Mia' });
+    expect(eqMock).toHaveBeenCalledWith('id', 'k-1');
+  });
+
+  it('wraps coded DB errors in UnretryableOutboxError', async () => {
+    eqMock.mockResolvedValue({
+      error: { code: '42501', message: 'permission denied', details: '', hint: '' },
+    });
+    const entry: RenameKidEntry = {
+      ...baseProps,
+      kind: 'renameKid',
+      kidId: 'k-1',
+      name: 'Mia',
+    };
+    await expect(runHandler(entry)).rejects.toBeInstanceOf(UnretryableOutboxError);
+  });
+});
+
+describe('runHandler · deleteKid', () => {
+  it('deletes the kid row by id', async () => {
+    const entry: DeleteKidEntry = {
+      ...baseProps,
+      kind: 'deleteKid',
+      kidId: 'k-1',
+    };
+    await runHandler(entry);
+    expect(fromMock).toHaveBeenCalledWith('kids');
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+    expect(deleteEqMock).toHaveBeenCalledWith('id', 'k-1');
+  });
+
+  it('does not touch boards or storage — server-side cascade handles them', async () => {
+    const entry: DeleteKidEntry = {
+      ...baseProps,
+      kind: 'deleteKid',
+      kidId: 'k-1',
+    };
+    await runHandler(entry);
+    // No boards SELECT/UPDATE — the FK cascade strips boards on the server.
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(removeMock).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/outbox/handlers.ts
+++ b/src/lib/outbox/handlers.ts
@@ -11,8 +11,10 @@ import { supabase } from '@/lib/supabase';
 import type {
   ClearPictogramAudioEntry,
   CreatePhotoPictogramEntry,
+  DeleteKidEntry,
   DeletePictogramEntry,
   OutboxEntry,
+  RenameKidEntry,
   RenamePictogramEntry,
   ReplacePictogramImageEntry,
   SetPictogramAudioEntry,
@@ -195,6 +197,30 @@ const handleDeletePictogram = async (entry: DeletePictogramEntry): Promise<void>
   }
 };
 
+const handleRenameKid = async (entry: RenameKidEntry): Promise<void> => {
+  try {
+    const { error } = await supabase
+      .from('kids')
+      .update({ name: entry.name })
+      .eq('id', entry.kidId);
+    if (error) throw error;
+  } catch (err) {
+    classifyAndThrow(err);
+  }
+};
+
+const handleDeleteKid = async (entry: DeleteKidEntry): Promise<void> => {
+  try {
+    // boards.kid_id ON DELETE CASCADE handles board cleanup server-side.
+    // Pictograms are owner-scoped (not kid-scoped), so they survive — correct
+    // since they're shared across the owner's kids' boards.
+    const { error } = await supabase.from('kids').delete().eq('id', entry.kidId);
+    if (error) throw error;
+  } catch (err) {
+    classifyAndThrow(err);
+  }
+};
+
 export const runHandler = (entry: OutboxEntry): Promise<void> => {
   switch (entry.kind) {
     case 'updateBoard':
@@ -211,5 +237,9 @@ export const runHandler = (entry: OutboxEntry): Promise<void> => {
       return handleReplacePictogramImage(entry);
     case 'deletePicto':
       return handleDeletePictogram(entry);
+    case 'renameKid':
+      return handleRenameKid(entry);
+    case 'deleteKid':
+      return handleDeleteKid(entry);
   }
 };

--- a/src/lib/outbox/types.ts
+++ b/src/lib/outbox/types.ts
@@ -91,6 +91,17 @@ export interface DeletePictogramEntry extends OutboxEntryBase {
   scrubFromBoardIds: string[];
 }
 
+export interface RenameKidEntry extends OutboxEntryBase {
+  kind: 'renameKid';
+  kidId: string;
+  name: string;
+}
+
+export interface DeleteKidEntry extends OutboxEntryBase {
+  kind: 'deleteKid';
+  kidId: string;
+}
+
 export type OutboxEntry =
   | UpdateBoardEntry
   | CreatePhotoPictogramEntry
@@ -98,6 +109,8 @@ export type OutboxEntry =
   | ClearPictogramAudioEntry
   | RenamePictogramEntry
   | ReplacePictogramImageEntry
-  | DeletePictogramEntry;
+  | DeletePictogramEntry
+  | RenameKidEntry
+  | DeleteKidEntry;
 
 export type OutboxEntryKind = OutboxEntry['kind'];

--- a/src/lib/queries/kids.ts
+++ b/src/lib/queries/kids.ts
@@ -5,10 +5,13 @@ import {
   useQueryClient,
   type UseQueryResult,
 } from '@tanstack/react-query';
+import { useSyncExternalStore } from 'react';
 
 import { useSessionUser } from '@/lib/auth/session';
+import { enqueueAndDrain } from '@/lib/outbox';
+import { boardsQueryKey } from '@/lib/queries/boards.read';
 import { supabase } from '@/lib/supabase';
-import type { Kid } from '@/types/domain';
+import type { Board, Kid } from '@/types/domain';
 import type { Database } from '@/types/supabase';
 
 type KidRow = Database['public']['Tables']['kids']['Row'];
@@ -58,6 +61,146 @@ export const useCreateKid = (): UseMutationResult<Kid, Error, CreateKidInput> =>
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: kidsQueryKey });
+    },
+  });
+};
+
+const ACTIVE_KID_KEY = 'talrum:active-kid-id';
+const activeKidListeners = new Set<() => void>();
+let activeKidStorageBound = false;
+
+const bindActiveKidStorageListener = (): void => {
+  if (activeKidStorageBound || typeof window === 'undefined') return;
+  activeKidStorageBound = true;
+  // Only one listener for the whole app — fan out to every subscriber. The
+  // `storage` event fires only on cross-tab writes; same-tab writes notify
+  // synchronously via setActiveKidId itself.
+  window.addEventListener('storage', (e) => {
+    if (e.key === ACTIVE_KID_KEY) {
+      for (const cb of activeKidListeners) cb();
+    }
+  });
+};
+
+const subscribeActiveKid = (cb: () => void): (() => void) => {
+  bindActiveKidStorageListener();
+  activeKidListeners.add(cb);
+  return () => {
+    activeKidListeners.delete(cb);
+  };
+};
+
+const getStoredActiveKidId = (): string | null => {
+  try {
+    return localStorage.getItem(ACTIVE_KID_KEY);
+  } catch {
+    return null;
+  }
+};
+
+const getStoredActiveKidIdSSR = (): string | null => null;
+
+/**
+ * Set the per-device active-kid id. Pass `null` to clear (e.g. when the
+ * active kid is deleted — `useActiveKid` then falls back to the first kid).
+ * Notifies all subscribers synchronously so consumers re-render immediately.
+ */
+export const setActiveKidId = (id: string | null): void => {
+  try {
+    if (id == null) localStorage.removeItem(ACTIVE_KID_KEY);
+    else localStorage.setItem(ACTIVE_KID_KEY, id);
+  } catch {
+    // ignore quota / privacy mode — feature is best-effort
+  }
+  for (const cb of activeKidListeners) cb();
+};
+
+/**
+ * Returns the currently-active kid for parent-home filtering. Backed by
+ * localStorage (`talrum:active-kid-id`) so the choice survives reloads but
+ * stays per-device — appropriate for a single-family-device app.
+ *
+ * Self-healing: if the stored id no longer matches a kid (deleted, swapped
+ * accounts), falls back to the first kid in `useKids()`. Returns `null`
+ * only when there are no kids at all.
+ */
+export const useActiveKid = (): Kid | null => {
+  const { data: kids } = useKids();
+  const storedId = useSyncExternalStore(
+    subscribeActiveKid,
+    getStoredActiveKidId,
+    getStoredActiveKidIdSSR,
+  );
+  if (!kids || kids.length === 0) return null;
+  return kids.find((k) => k.id === storedId) ?? kids[0] ?? null;
+};
+
+interface RenameKidInput {
+  kidId: string;
+  name: string;
+}
+
+export const useRenameKid = (): UseMutationResult<
+  void,
+  Error,
+  RenameKidInput,
+  { previous: Kid[] | undefined }
+> => {
+  const qc = useQueryClient();
+  return useMutation({
+    onMutate: async ({ kidId, name }) => {
+      await qc.cancelQueries({ queryKey: kidsQueryKey });
+      const previous = qc.getQueryData<Kid[]>(kidsQueryKey);
+      qc.setQueryData<Kid[]>(kidsQueryKey, (list) =>
+        list?.map((k) => (k.id === kidId ? { ...k, name } : k)),
+      );
+      return { previous };
+    },
+    mutationFn: ({ kidId, name }) => enqueueAndDrain({ kind: 'renameKid', kidId, name }),
+    onError: (_err, _input, ctx) => {
+      if (ctx?.previous) qc.setQueryData(kidsQueryKey, ctx.previous);
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: kidsQueryKey });
+    },
+  });
+};
+
+interface DeleteKidInput {
+  kidId: string;
+}
+
+export const useDeleteKid = (): UseMutationResult<
+  void,
+  Error,
+  DeleteKidInput,
+  { previousKids: Kid[] | undefined; previousBoards: Board[] | undefined }
+> => {
+  const qc = useQueryClient();
+  return useMutation({
+    onMutate: async ({ kidId }) => {
+      await qc.cancelQueries({ queryKey: kidsQueryKey });
+      await qc.cancelQueries({ queryKey: boardsQueryKey });
+      const previousKids = qc.getQueryData<Kid[]>(kidsQueryKey);
+      const previousBoards = qc.getQueryData<Board[]>(boardsQueryKey);
+      qc.setQueryData<Kid[]>(kidsQueryKey, (list) => list?.filter((k) => k.id !== kidId));
+      qc.setQueryData<Board[]>(boardsQueryKey, (list) => list?.filter((b) => b.kidId !== kidId));
+      // If the deleted kid was active, drop the stored id — useActiveKid's
+      // first-kid fallback then picks up a remaining one. Cleared on the
+      // optimistic step so the UI updates immediately; the rollback in
+      // onError doesn't restore it (the worst case is a transient flicker
+      // back to the prior active kid on the next render, which is fine).
+      if (getStoredActiveKidId() === kidId) setActiveKidId(null);
+      return { previousKids, previousBoards };
+    },
+    mutationFn: ({ kidId }) => enqueueAndDrain({ kind: 'deleteKid', kidId }),
+    onError: (_err, _input, ctx) => {
+      if (ctx?.previousKids) qc.setQueryData(kidsQueryKey, ctx.previousKids);
+      if (ctx?.previousBoards) qc.setQueryData(boardsQueryKey, ctx.previousBoards);
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: kidsQueryKey });
+      qc.invalidateQueries({ queryKey: boardsQueryKey });
     },
   });
 };

--- a/src/lib/queries/kids.ts
+++ b/src/lib/queries/kids.ts
@@ -38,19 +38,15 @@ interface CreateKidInput {
 }
 
 /**
- * Direct Supabase insert (no outbox), matching the `useAddBoardMember` pattern
- * in `board-members.ts`. Outbox would surface RLS denials only at drain — wrong
- * for create-then-react flows where the caller needs the row to actually exist
- * on the server (e.g. defaulting a new board's `kid_id`).
+ * Direct Supabase insert (no outbox): the caller needs the row to exist on
+ * the server before children can attach (e.g. defaulting a new board's
+ * `kid_id`). An outbox-queued insert would surface RLS denials only at drain.
  */
 export const useCreateKid = (): UseMutationResult<Kid, Error, CreateKidInput> => {
   const qc = useQueryClient();
   const ownerId = useSessionUser().id;
   return useMutation({
     mutationFn: async ({ name }) => {
-      // Input normalization (trimming, validation) is the modal layer's job;
-      // the query stays a thin DB wrapper so all create mutations behave
-      // identically (`useCreateBoard` already follows this).
       const { data, error } = await supabase
         .from('kids')
         .insert({ owner_id: ownerId, name })
@@ -67,23 +63,17 @@ export const useCreateKid = (): UseMutationResult<Kid, Error, CreateKidInput> =>
 
 const ACTIVE_KID_KEY = 'talrum:active-kid-id';
 const activeKidListeners = new Set<() => void>();
-let activeKidStorageBound = false;
 
-const bindActiveKidStorageListener = (): void => {
-  if (activeKidStorageBound || typeof window === 'undefined') return;
-  activeKidStorageBound = true;
-  // Only one listener for the whole app — fan out to every subscriber. The
-  // `storage` event fires only on cross-tab writes; same-tab writes notify
-  // synchronously via setActiveKidId itself.
+if (typeof window !== 'undefined') {
+  // Cross-tab writes hit `storage`; same-tab writes notify via setActiveKidId.
   window.addEventListener('storage', (e) => {
     if (e.key === ACTIVE_KID_KEY) {
       for (const cb of activeKidListeners) cb();
     }
   });
-};
+}
 
 const subscribeActiveKid = (cb: () => void): (() => void) => {
-  bindActiveKidStorageListener();
   activeKidListeners.add(cb);
   return () => {
     activeKidListeners.delete(cb);
@@ -98,14 +88,14 @@ const getStoredActiveKidId = (): string | null => {
   }
 };
 
-const getStoredActiveKidIdSSR = (): string | null => null;
-
 /**
  * Set the per-device active-kid id. Pass `null` to clear (e.g. when the
  * active kid is deleted — `useActiveKid` then falls back to the first kid).
- * Notifies all subscribers synchronously so consumers re-render immediately.
+ * Skips work and the fan-out when the value is unchanged so consumers don't
+ * re-render on no-op writes (e.g. tapping the already-active switcher pill).
  */
 export const setActiveKidId = (id: string | null): void => {
+  if (getStoredActiveKidId() === id) return;
   try {
     if (id == null) localStorage.removeItem(ACTIVE_KID_KEY);
     else localStorage.setItem(ACTIVE_KID_KEY, id);
@@ -126,11 +116,7 @@ export const setActiveKidId = (id: string | null): void => {
  */
 export const useActiveKid = (): Kid | null => {
   const { data: kids } = useKids();
-  const storedId = useSyncExternalStore(
-    subscribeActiveKid,
-    getStoredActiveKidId,
-    getStoredActiveKidIdSSR,
-  );
+  const storedId = useSyncExternalStore(subscribeActiveKid, getStoredActiveKidId, () => null);
   if (!kids || kids.length === 0) return null;
   return kids.find((k) => k.id === storedId) ?? kids[0] ?? null;
 };
@@ -179,17 +165,17 @@ export const useDeleteKid = (): UseMutationResult<
   const qc = useQueryClient();
   return useMutation({
     onMutate: async ({ kidId }) => {
-      await qc.cancelQueries({ queryKey: kidsQueryKey });
-      await qc.cancelQueries({ queryKey: boardsQueryKey });
+      await Promise.all([
+        qc.cancelQueries({ queryKey: kidsQueryKey }),
+        qc.cancelQueries({ queryKey: boardsQueryKey }),
+      ]);
       const previousKids = qc.getQueryData<Kid[]>(kidsQueryKey);
       const previousBoards = qc.getQueryData<Board[]>(boardsQueryKey);
       qc.setQueryData<Kid[]>(kidsQueryKey, (list) => list?.filter((k) => k.id !== kidId));
       qc.setQueryData<Board[]>(boardsQueryKey, (list) => list?.filter((b) => b.kidId !== kidId));
-      // If the deleted kid was active, drop the stored id — useActiveKid's
-      // first-kid fallback then picks up a remaining one. Cleared on the
-      // optimistic step so the UI updates immediately; the rollback in
-      // onError doesn't restore it (the worst case is a transient flicker
-      // back to the prior active kid on the next render, which is fine).
+      // Drop the stored id so useActiveKid's first-kid fallback picks up a
+      // remaining one. The error rollback doesn't restore it — at worst the
+      // active kid flickers back on the next render, which is fine.
       if (getStoredActiveKidId() === kidId) setActiveKidId(null);
       return { previousKids, previousBoards };
     },

--- a/src/ui/KidSheet/KidSheet.module.css
+++ b/src/ui/KidSheet/KidSheet.module.css
@@ -1,0 +1,113 @@
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--tal-space-4);
+  padding: var(--tal-space-6) var(--tal-space-7) var(--tal-space-3);
+}
+
+.title {
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--tal-ink);
+  margin: 0 0 var(--tal-space-1);
+}
+
+.subtitle {
+  font-size: 14px;
+  color: var(--tal-ink-muted);
+  margin: 0;
+  max-width: 52ch;
+}
+
+.closeBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  background: transparent;
+  border: 1px solid var(--tal-line);
+  color: var(--tal-ink-muted);
+  cursor: pointer;
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--tal-space-4);
+  padding: var(--tal-space-2) var(--tal-space-7) var(--tal-space-6);
+  overflow-y: auto;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tal-space-3);
+  padding-top: var(--tal-space-4);
+  border-top: 1px solid var(--tal-line);
+}
+
+.dangerSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tal-space-2);
+  padding-top: var(--tal-space-4);
+  border-top: 1px solid var(--tal-line);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tal-space-1);
+}
+
+.fieldLabel {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--tal-ink-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.input {
+  width: 100%;
+  padding: var(--tal-space-2) var(--tal-space-3);
+  border: 1px solid var(--tal-line);
+  border-radius: var(--tal-r-md);
+  font-size: 16px;
+  font-family: inherit;
+  color: var(--tal-ink);
+  background: var(--tal-surface);
+}
+
+.input:focus-visible {
+  outline: 2px solid var(--tal-focus);
+  outline-offset: 2px;
+}
+
+.sectionActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--tal-space-2);
+}
+
+.dangerHint {
+  font-size: 13px;
+  color: var(--tal-ink-muted);
+  margin: 0;
+}
+
+.dangerBtn {
+  background: var(--tal-danger);
+  color: var(--tal-on-accent);
+  border-color: var(--tal-danger);
+}
+
+.error {
+  color: var(--tal-danger);
+  font-size: 14px;
+  text-align: center;
+}

--- a/src/ui/KidSheet/KidSheet.test.tsx
+++ b/src/ui/KidSheet/KidSheet.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Board, Kid } from '@/types/domain';
+
+const renameMock = vi.fn<(input: { kidId: string; name: string }) => Promise<void>>();
+const deleteMock = vi.fn<(input: { kidId: string }) => Promise<void>>();
+const useKidsMock = vi.fn<() => { data: Kid[] | undefined }>();
+const useBoardsMock = vi.fn<() => { data: Board[] | undefined }>();
+const useActiveKidMock = vi.fn<() => Kid | null>();
+const setActiveKidIdMock = vi.fn<(id: string | null) => void>();
+
+vi.mock('@/lib/queries/kids', () => ({
+  useRenameKid: () => ({ mutateAsync: renameMock, isPending: false }),
+  useDeleteKid: () => ({ mutateAsync: deleteMock, isPending: false }),
+  useKids: () => useKidsMock(),
+  useActiveKid: () => useActiveKidMock(),
+  setActiveKidId: (id: string | null) => setActiveKidIdMock(id),
+}));
+
+vi.mock('@/lib/queries/boards', () => ({
+  useBoards: () => useBoardsMock(),
+}));
+
+const { KidSheet } = await import('./KidSheet');
+
+const kid = (id: string, name: string): Kid => ({ id, ownerId: 'o', name });
+
+const board = (id: string, kidId: string): Board => ({
+  id,
+  ownerId: 'o',
+  kidId,
+  name: 'B',
+  kind: 'choice',
+  labelsVisible: true,
+  voiceMode: 'tts',
+  stepIds: [],
+  kidReorderable: false,
+  accent: 'sage',
+  accentInk: 'sage-ink',
+  updatedLabel: 'today',
+});
+
+const liam = kid('k1', 'Liam');
+const mia = kid('k2', 'Mia');
+
+beforeEach(() => {
+  renameMock.mockReset();
+  deleteMock.mockReset();
+  useKidsMock.mockReset();
+  useBoardsMock.mockReset();
+  useActiveKidMock.mockReset();
+  setActiveKidIdMock.mockReset();
+  renameMock.mockResolvedValue(undefined);
+  deleteMock.mockResolvedValue(undefined);
+  useKidsMock.mockReturnValue({ data: [liam, mia] });
+  useBoardsMock.mockReturnValue({ data: [] });
+  useActiveKidMock.mockReturnValue(liam);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('KidSheet', () => {
+  it('saves a renamed kid and closes', async () => {
+    const onClose = vi.fn();
+    render(<KidSheet kid={liam} onClose={onClose} />);
+    fireEvent.change(screen.getByDisplayValue('Liam'), { target: { value: 'Liam Jr.' } });
+    fireEvent.click(screen.getByRole('button', { name: /save name/i }));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(renameMock).toHaveBeenCalledWith({ kidId: 'k1', name: 'Liam Jr.' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('disables Save when the name is unchanged or empty', () => {
+    render(<KidSheet kid={liam} onClose={() => undefined} />);
+    expect(screen.getByRole('button', { name: /save name/i })).toBeDisabled();
+    fireEvent.change(screen.getByDisplayValue('Liam'), { target: { value: '   ' } });
+    expect(screen.getByRole('button', { name: /save name/i })).toBeDisabled();
+  });
+
+  it('hides "set as active" when this kid is already active', () => {
+    useActiveKidMock.mockReturnValue(liam);
+    render(<KidSheet kid={liam} onClose={() => undefined} />);
+    expect(screen.queryByRole('button', { name: /set as active/i })).toBeNull();
+  });
+
+  it('shows "set as active" when another kid is active and forwards the click', () => {
+    useActiveKidMock.mockReturnValue(mia);
+    render(<KidSheet kid={liam} onClose={() => undefined} />);
+    fireEvent.click(screen.getByRole('button', { name: /set as active/i }));
+    expect(setActiveKidIdMock).toHaveBeenCalledWith('k1');
+  });
+
+  it('hides the active section entirely when there is only one kid', () => {
+    useKidsMock.mockReturnValue({ data: [liam] });
+    useActiveKidMock.mockReturnValue(liam);
+    render(<KidSheet kid={liam} onClose={() => undefined} />);
+    expect(screen.queryByText(/active kid/i)).toBeNull();
+  });
+
+  it('disables the Delete button when this is the last kid', () => {
+    useKidsMock.mockReturnValue({ data: [liam] });
+    render(<KidSheet kid={liam} onClose={() => undefined} />);
+    expect(screen.getByRole('button', { name: /^delete kid$/i })).toBeDisabled();
+    expect(screen.getByText(/at least one kid/i)).toBeInTheDocument();
+  });
+
+  it('shows the board count and requires confirm before deleting', async () => {
+    useBoardsMock.mockReturnValue({
+      data: [board('b1', 'k1'), board('b2', 'k1'), board('b3', 'k2')],
+    });
+    const onClose = vi.fn();
+    render(<KidSheet kid={liam} onClose={onClose} />);
+    expect(screen.getByText(/also deletes 2 boards/i)).toBeInTheDocument();
+    // First click → confirm pill.
+    fireEvent.click(screen.getByRole('button', { name: /^delete kid$/i }));
+    expect(deleteMock).not.toHaveBeenCalled();
+    // Second click confirms.
+    fireEvent.click(screen.getByRole('button', { name: /delete forever/i }));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(deleteMock).toHaveBeenCalledWith({ kidId: 'k1' });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/ui/KidSheet/KidSheet.test.tsx
+++ b/src/ui/KidSheet/KidSheet.test.tsx
@@ -1,12 +1,11 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { Board, Kid } from '@/types/domain';
+import type { Kid } from '@/types/domain';
 
 const renameMock = vi.fn<(input: { kidId: string; name: string }) => Promise<void>>();
 const deleteMock = vi.fn<(input: { kidId: string }) => Promise<void>>();
 const useKidsMock = vi.fn<() => { data: Kid[] | undefined }>();
-const useBoardsMock = vi.fn<() => { data: Board[] | undefined }>();
 const useActiveKidMock = vi.fn<() => Kid | null>();
 const setActiveKidIdMock = vi.fn<(id: string | null) => void>();
 
@@ -18,28 +17,9 @@ vi.mock('@/lib/queries/kids', () => ({
   setActiveKidId: (id: string | null) => setActiveKidIdMock(id),
 }));
 
-vi.mock('@/lib/queries/boards', () => ({
-  useBoards: () => useBoardsMock(),
-}));
-
 const { KidSheet } = await import('./KidSheet');
 
 const kid = (id: string, name: string): Kid => ({ id, ownerId: 'o', name });
-
-const board = (id: string, kidId: string): Board => ({
-  id,
-  ownerId: 'o',
-  kidId,
-  name: 'B',
-  kind: 'choice',
-  labelsVisible: true,
-  voiceMode: 'tts',
-  stepIds: [],
-  kidReorderable: false,
-  accent: 'sage',
-  accentInk: 'sage-ink',
-  updatedLabel: 'today',
-});
 
 const liam = kid('k1', 'Liam');
 const mia = kid('k2', 'Mia');
@@ -48,13 +28,11 @@ beforeEach(() => {
   renameMock.mockReset();
   deleteMock.mockReset();
   useKidsMock.mockReset();
-  useBoardsMock.mockReset();
   useActiveKidMock.mockReset();
   setActiveKidIdMock.mockReset();
   renameMock.mockResolvedValue(undefined);
   deleteMock.mockResolvedValue(undefined);
   useKidsMock.mockReturnValue({ data: [liam, mia] });
-  useBoardsMock.mockReturnValue({ data: [] });
   useActiveKidMock.mockReturnValue(liam);
 });
 
@@ -65,7 +43,7 @@ afterEach(() => {
 describe('KidSheet', () => {
   it('saves a renamed kid and closes', async () => {
     const onClose = vi.fn();
-    render(<KidSheet kid={liam} onClose={onClose} />);
+    render(<KidSheet kid={liam} boardCount={0} onClose={onClose} />);
     fireEvent.change(screen.getByDisplayValue('Liam'), { target: { value: 'Liam Jr.' } });
     fireEvent.click(screen.getByRole('button', { name: /save name/i }));
     await Promise.resolve();
@@ -75,7 +53,7 @@ describe('KidSheet', () => {
   });
 
   it('disables Save when the name is unchanged or empty', () => {
-    render(<KidSheet kid={liam} onClose={() => undefined} />);
+    render(<KidSheet kid={liam} boardCount={0} onClose={() => undefined} />);
     expect(screen.getByRole('button', { name: /save name/i })).toBeDisabled();
     fireEvent.change(screen.getByDisplayValue('Liam'), { target: { value: '   ' } });
     expect(screen.getByRole('button', { name: /save name/i })).toBeDisabled();
@@ -83,13 +61,13 @@ describe('KidSheet', () => {
 
   it('hides "set as active" when this kid is already active', () => {
     useActiveKidMock.mockReturnValue(liam);
-    render(<KidSheet kid={liam} onClose={() => undefined} />);
+    render(<KidSheet kid={liam} boardCount={0} onClose={() => undefined} />);
     expect(screen.queryByRole('button', { name: /set as active/i })).toBeNull();
   });
 
   it('shows "set as active" when another kid is active and forwards the click', () => {
     useActiveKidMock.mockReturnValue(mia);
-    render(<KidSheet kid={liam} onClose={() => undefined} />);
+    render(<KidSheet kid={liam} boardCount={0} onClose={() => undefined} />);
     fireEvent.click(screen.getByRole('button', { name: /set as active/i }));
     expect(setActiveKidIdMock).toHaveBeenCalledWith('k1');
   });
@@ -97,23 +75,20 @@ describe('KidSheet', () => {
   it('hides the active section entirely when there is only one kid', () => {
     useKidsMock.mockReturnValue({ data: [liam] });
     useActiveKidMock.mockReturnValue(liam);
-    render(<KidSheet kid={liam} onClose={() => undefined} />);
+    render(<KidSheet kid={liam} boardCount={0} onClose={() => undefined} />);
     expect(screen.queryByText(/active kid/i)).toBeNull();
   });
 
   it('disables the Delete button when this is the last kid', () => {
     useKidsMock.mockReturnValue({ data: [liam] });
-    render(<KidSheet kid={liam} onClose={() => undefined} />);
+    render(<KidSheet kid={liam} boardCount={0} onClose={() => undefined} />);
     expect(screen.getByRole('button', { name: /^delete kid$/i })).toBeDisabled();
     expect(screen.getByText(/at least one kid/i)).toBeInTheDocument();
   });
 
   it('shows the board count and requires confirm before deleting', async () => {
-    useBoardsMock.mockReturnValue({
-      data: [board('b1', 'k1'), board('b2', 'k1'), board('b3', 'k2')],
-    });
     const onClose = vi.fn();
-    render(<KidSheet kid={liam} onClose={onClose} />);
+    render(<KidSheet kid={liam} boardCount={2} onClose={onClose} />);
     expect(screen.getByText(/also deletes 2 boards/i)).toBeInTheDocument();
     // First click → confirm pill.
     fireEvent.click(screen.getByRole('button', { name: /^delete kid$/i }));

--- a/src/ui/KidSheet/KidSheet.tsx
+++ b/src/ui/KidSheet/KidSheet.tsx
@@ -1,0 +1,184 @@
+import { type JSX, useState } from 'react';
+
+import { useBoards } from '@/lib/queries/boards';
+import {
+  setActiveKidId,
+  useActiveKid,
+  useDeleteKid,
+  useKids,
+  useRenameKid,
+} from '@/lib/queries/kids';
+import type { Kid } from '@/types/domain';
+import { Button } from '@/ui/Button/Button';
+import { CheckIcon, TrashIcon, XIcon } from '@/ui/icons';
+import { Modal } from '@/ui/Modal/Modal';
+
+import styles from './KidSheet.module.css';
+
+interface Props {
+  kid: Kid;
+  onClose: () => void;
+}
+
+const TITLE_ID = 'tal-kid-sheet-title';
+const NAME_MAX = 40;
+
+export const KidSheet = ({ kid, onClose }: Props): JSX.Element => {
+  const [name, setName] = useState(kid.name);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const renameMut = useRenameKid();
+  const deleteMut = useDeleteKid();
+  const { data: kids = [] } = useKids();
+  const { data: boards } = useBoards();
+  const activeKid = useActiveKid();
+
+  const isLastKid = kids.length <= 1;
+  const isActive = activeKid?.id === kid.id;
+  const boardCount = (boards ?? []).filter((b) => b.kidId === kid.id).length;
+
+  const trimmedName = name.trim();
+  const nameDirty = trimmedName.length > 0 && trimmedName !== kid.name;
+  const saving = renameMut.isPending || deleteMut.isPending;
+
+  const onSaveName = async (): Promise<void> => {
+    if (!nameDirty) return;
+    setError(null);
+    try {
+      await renameMut.mutateAsync({ kidId: kid.id, name: trimmedName });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Rename failed.');
+    }
+  };
+
+  const onSetActive = (): void => {
+    setActiveKidId(kid.id);
+    onClose();
+  };
+
+  const onDelete = async (): Promise<void> => {
+    setError(null);
+    try {
+      await deleteMut.mutateAsync({ kidId: kid.id });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Delete failed.');
+    }
+  };
+
+  return (
+    <Modal onClose={onClose} labelledBy={TITLE_ID}>
+      <header className={styles.header}>
+        <div>
+          <h2 id={TITLE_ID} className={styles.title}>
+            Edit kid
+          </h2>
+          <p className={styles.subtitle}>
+            Rename, set active, or delete <strong>{kid.name}</strong>.
+          </p>
+        </div>
+        <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Close">
+          <XIcon size={16} />
+        </button>
+      </header>
+
+      <div className={styles.body}>
+        <section className={styles.section}>
+          <label className={styles.field}>
+            <span className={styles.fieldLabel}>Name</span>
+            <input
+              className={styles.input}
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              maxLength={NAME_MAX}
+              disabled={saving}
+            />
+          </label>
+          <div className={styles.sectionActions}>
+            <Button
+              variant="primary"
+              onClick={() => {
+                void onSaveName();
+              }}
+              disabled={!nameDirty || saving}
+            >
+              {renameMut.isPending ? 'Saving…' : 'Save name'}
+            </Button>
+          </div>
+        </section>
+
+        {!isLastKid && (
+          <section className={styles.section}>
+            <div className={styles.fieldLabel}>Active kid</div>
+            {isActive ? (
+              <p className={styles.dangerHint}>
+                <strong>{kid.name}</strong> is the active kid. Parent home shows their boards.
+              </p>
+            ) : (
+              <>
+                <p className={styles.dangerHint}>Parent home filters boards by active kid.</p>
+                <div className={styles.sectionActions}>
+                  <Button
+                    variant="ghost"
+                    icon={<CheckIcon size={14} />}
+                    onClick={onSetActive}
+                    disabled={saving}
+                  >
+                    Set as active
+                  </Button>
+                </div>
+              </>
+            )}
+          </section>
+        )}
+
+        <section className={styles.dangerSection}>
+          <div className={styles.fieldLabel}>Delete</div>
+          {isLastKid ? (
+            <p className={styles.dangerHint}>You need at least one kid.</p>
+          ) : (
+            boardCount > 0 && (
+              <p className={styles.dangerHint}>
+                Also deletes {boardCount} board{boardCount === 1 ? '' : 's'} for this kid.
+              </p>
+            )
+          )}
+          <div className={styles.sectionActions}>
+            {confirmDelete ? (
+              <>
+                <Button variant="ghost" onClick={() => setConfirmDelete(false)} disabled={saving}>
+                  Cancel
+                </Button>
+                <Button
+                  variant="primary"
+                  className={styles.dangerBtn}
+                  icon={<TrashIcon size={14} />}
+                  onClick={() => {
+                    void onDelete();
+                  }}
+                  disabled={saving}
+                >
+                  Delete forever
+                </Button>
+              </>
+            ) : (
+              <Button
+                variant="ghost"
+                icon={<TrashIcon size={14} />}
+                onClick={() => setConfirmDelete(true)}
+                disabled={saving || isLastKid}
+              >
+                Delete kid
+              </Button>
+            )}
+          </div>
+        </section>
+
+        {error && <div className={styles.error}>{error}</div>}
+      </div>
+    </Modal>
+  );
+};

--- a/src/ui/KidSheet/KidSheet.tsx
+++ b/src/ui/KidSheet/KidSheet.tsx
@@ -1,6 +1,5 @@
 import { type JSX, useState } from 'react';
 
-import { useBoards } from '@/lib/queries/boards';
 import {
   setActiveKidId,
   useActiveKid,
@@ -17,13 +16,15 @@ import styles from './KidSheet.module.css';
 
 interface Props {
   kid: Kid;
+  /** Number of boards owned by this kid, used in the delete-confirm hint. */
+  boardCount: number;
   onClose: () => void;
 }
 
 const TITLE_ID = 'tal-kid-sheet-title';
 const NAME_MAX = 40;
 
-export const KidSheet = ({ kid, onClose }: Props): JSX.Element => {
+export const KidSheet = ({ kid, boardCount, onClose }: Props): JSX.Element => {
   const [name, setName] = useState(kid.name);
   const [error, setError] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -31,12 +32,10 @@ export const KidSheet = ({ kid, onClose }: Props): JSX.Element => {
   const renameMut = useRenameKid();
   const deleteMut = useDeleteKid();
   const { data: kids = [] } = useKids();
-  const { data: boards } = useBoards();
   const activeKid = useActiveKid();
 
   const isLastKid = kids.length <= 1;
   const isActive = activeKid?.id === kid.id;
-  const boardCount = (boards ?? []).filter((b) => b.kidId === kid.id).length;
 
   const trimmedName = name.trim();
   const nameDirty = trimmedName.length > 0 && trimmedName !== kid.name;

--- a/src/ui/KidSwitcher/KidSwitcher.module.css
+++ b/src/ui/KidSwitcher/KidSwitcher.module.css
@@ -1,0 +1,28 @@
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--tal-space-2);
+  margin-bottom: var(--tal-space-4);
+}
+
+.pill {
+  padding: var(--tal-space-2) var(--tal-space-4);
+  border-radius: 999px;
+  border: 1px solid var(--tal-line);
+  background: var(--tal-surface);
+  color: var(--tal-ink-soft);
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.pill:hover {
+  border-color: var(--tal-ink-muted);
+}
+
+.pillActive {
+  background: var(--tal-sage);
+  border-color: var(--tal-sage);
+  color: var(--tal-sage-ink);
+}

--- a/src/ui/KidSwitcher/KidSwitcher.tsx
+++ b/src/ui/KidSwitcher/KidSwitcher.tsx
@@ -1,0 +1,37 @@
+import type { JSX } from 'react';
+
+import type { Kid } from '@/types/domain';
+
+import styles from './KidSwitcher.module.css';
+
+interface KidSwitcherProps {
+  kids: readonly Kid[];
+  activeKidId: string | null;
+  onSelect: (kidId: string) => void;
+}
+
+/**
+ * Pill row of kids — used in parent home when more than one kid exists, so
+ * the parent can flip the boards filter without leaving the page. Hidden
+ * entirely for single-kid families (the caller decides; this component
+ * always renders if mounted).
+ */
+export const KidSwitcher = ({ kids, activeKidId, onSelect }: KidSwitcherProps): JSX.Element => (
+  <div className={styles.row} role="tablist" aria-label="Switch active kid">
+    {kids.map((kid) => {
+      const isActive = kid.id === activeKidId;
+      return (
+        <button
+          key={kid.id}
+          type="button"
+          role="tab"
+          aria-selected={isActive}
+          className={[styles.pill, isActive && styles.pillActive].filter(Boolean).join(' ')}
+          onClick={() => onSelect(kid.id)}
+        >
+          {kid.name}
+        </button>
+      );
+    })}
+  </div>
+);

--- a/supabase/migrations/20260509174540_fix_bedtime_kid_reorderable.sql
+++ b/supabase/migrations/20260509174540_fix_bedtime_kid_reorderable.sql
@@ -1,0 +1,24 @@
+-- Bedtime is a routine — kids shouldn't be able to drag the steps out of
+-- order (issue #187). Bedtime was the only sequence in the seed library
+-- with `kid_reorderable = true`, which contradicts the point of teaching
+-- the routine.
+--
+-- Fix two surfaces:
+--   1. `template_boards` row that `handle_new_user()` clones for fresh
+--      signups — without this, every new user keeps inheriting the wrong
+--      default.
+--   2. `boards` rows already cloned into existing accounts. Scoped to
+--      `slug = 'bedtime'` so users who deliberately turned reorder back on
+--      for their copy aren't caught (the slug filter only matches the
+--      seeded original; user-customised boards keep slug from the clone
+--      but if a user flipped the toggle off and back on we'd still revert
+--      — accepted, since the toggle is being hidden for choice boards but
+--      remains correct for sequences post-PR).
+--
+-- Idempotent: the `= true` guard makes re-runs a no-op.
+
+update template_boards set kid_reorderable = false
+  where slug = 'bedtime' and kid_reorderable = true;
+
+update boards set kid_reorderable = false
+  where slug = 'bedtime' and kid_reorderable = true;


### PR DESCRIPTION
## Summary

Three bugs on the kids axis, one PR — same shape as the pictogram-editing slice that just shipped (#192).

- **#182** — Kids list rows were static text. Each row now opens a `KidSheet` modal with rename, "set as active", and delete (two-tap confirm + "also deletes N boards" hint). Outbox entries `renameKid` and `deleteKid` mirror the picto rename/delete handlers; server-side `boards.kid_id ON DELETE CASCADE` handles board cleanup, so the handler is just a single \`delete from kids\`.
- **#175** — Parent home heading hardcoded \`useKids().data?.[0]\` and \`useBoards()\` had no \`kid_id\` filter, so every kid's boards rendered under \`<firstKid>'s boards\`. Replaced with a localStorage-backed active-kid (per-device, no schema change) and a \`KidSwitcher\` pill row visible only when \`kids.length > 1\`. Boards filter is client-side; \`Board.kidId\` is already in the row.
- **#187** — Bedtime seed had \`kid_reorderable=true\` (only sequence with this on). New forward-only migration flips both \`template_boards.bedtime\` (future signups) and existing \`boards\` rows where \`slug='bedtime' and kid_reorderable=true\`. The "Kid can reorder" toggle in \`SettingsRow\` is now hidden for choice boards.

## Notable choices

- **localStorage, not a DB column** for active kid — per-device, mirrors \`talrum:last-board\`. Self-healing: if the stored id no longer matches a kid (deleted, account swap), \`useActiveKid\` falls back to the first kid via \`useSyncExternalStore\`.
- **Single-kid families see no UI change** — switcher hidden, "set as active" section hidden in the sheet, delete button disabled with "you need at least one kid" copy.
- **No new picto-style abstraction.** \`KidSheet\` reuses \`Modal\` + the same dialog chrome as \`PictogramSheet\` — copying the CSS is cheaper than designing a generic edit sheet for two callers.
- **\`KidSwitcher\` lives in \`src/ui/\`**, not \`src/features/kids/\`, because the no-cross-feature-imports lint rule blocks parent-home from reaching into kids/. KidSwitcher is presentational with no kids-feature logic, so ui/ is the right home.

## Test plan

- [x] \`npm test\` — 323/323 passing (323 incl. 9 new tests across KidSheet, Kids, SettingsRow, handlers).
- [x] \`npm run typecheck\` clean.
- [x] \`npm run lint\` clean.
- [x] \`supabase migration up --local\` — applies cleanly; verified \`select slug, kid_reorderable from template_boards where slug='bedtime'\` returns \`f\`.
- [ ] Manual smoke (post-merge or on review):
  - Add a second kid → switcher appears in header → tapping flips active kid + filters boards + updates heading
  - Kids tab → tap kid → rename, persists across reload
  - Kids tab → delete kid → cascades boards on parent home
  - Single-kid view → no switcher, no "set active", delete disabled
  - Choice board → "Kid can reorder" toggle hidden
  - Bedtime → toggle defaults to off

Closes #182
Closes #175
Closes #187