### PR TITLE
fix(auth): scrub per-user state at every auth boundary (#178, #179, #184)

### DIFF
--- a/src/app/AuthGate.test.tsx
+++ b/src/app/AuthGate.test.tsx
@@ -335,27 +335,30 @@ describe('AuthGate', () => {
   // mount; the current project's key (derived from VITE_SUPABASE_URL) is
   // preserved.
   it('sweeps stale sb-*-auth-token keys on mount, preserving the current project key (#184)', async () => {
-    // .env.local pins VITE_SUPABASE_URL at https://wcwkxjjhribuecvcdenm.supabase.co
-    // for tests. The first segment of the host is the project ref.
-    const currentHost = new URL(import.meta.env.VITE_SUPABASE_URL).host;
-    const currentRef = currentHost.split(':')[0]?.split('.')[0] ?? '';
-    const currentKey = `sb-${currentRef}-auth-token`;
+    // Stub the env var explicitly: CI doesn't load .env.local, so reading
+    // import.meta.env.VITE_SUPABASE_URL would be undefined.
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://testref.supabase.co');
+    const currentKey = 'sb-testref-auth-token';
 
-    localStorage.setItem(currentKey, '{"current":1}');
-    localStorage.setItem('sb-some-other-ref-auth-token', '{"stale":1}');
-    localStorage.setItem('sb-127-auth-token', '{"stale":2}');
+    try {
+      localStorage.setItem(currentKey, '{"current":1}');
+      localStorage.setItem('sb-some-other-ref-auth-token', '{"stale":1}');
+      localStorage.setItem('sb-127-auth-token', '{"stale":2}');
 
-    getSessionMock.mockResolvedValueOnce({ data: { session: null } });
-    render(
-      <AuthGate>
-        <div>app</div>
-      </AuthGate>,
-    );
+      getSessionMock.mockResolvedValueOnce({ data: { session: null } });
+      render(
+        <AuthGate>
+          <div>app</div>
+        </AuthGate>,
+      );
 
-    await waitFor(() => {
-      expect(localStorage.getItem('sb-some-other-ref-auth-token')).toBeNull();
-      expect(localStorage.getItem('sb-127-auth-token')).toBeNull();
-    });
-    expect(localStorage.getItem(currentKey)).toBe('{"current":1}');
+      await waitFor(() => {
+        expect(localStorage.getItem('sb-some-other-ref-auth-token')).toBeNull();
+        expect(localStorage.getItem('sb-127-auth-token')).toBeNull();
+      });
+      expect(localStorage.getItem(currentKey)).toBe('{"current":1}');
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 });

--- a/src/app/AuthGate.test.tsx
+++ b/src/app/AuthGate.test.tsx
@@ -49,6 +49,7 @@ const UserIdProbe = (): JSX.Element => <div data-testid="probe-user-id">{useSess
 afterEach(() => {
   getSessionMock.mockReset();
   onAuthStateChangeMock.mockClear();
+  window.localStorage.clear();
 });
 
 describe('AuthGate', () => {
@@ -236,5 +237,125 @@ describe('AuthGate', () => {
     await waitFor(() => {
       expect(screen.getByTestId('probe-user-id')).toHaveTextContent('user-b-id');
     });
+  });
+
+  // #178: PIN hash and last-board pointer live in localStorage and were
+  // surviving sign-out, locking the next user out of kid-mode and pointing
+  // their auto-launch at user A's board UUID. The scrub on SIGNED_OUT now
+  // wipes both via clearPersistedCache → clearPin/clearLastBoard.
+  it('clears talrum:pin-hash and talrum:last-board from localStorage on SIGNED_OUT (#178)', async () => {
+    const sessionA = makeSession('user-a-id', 'a@example.com');
+    getSessionMock.mockResolvedValueOnce({ data: { session: sessionA } });
+    localStorage.setItem('talrum:pin-hash', 'hash-of-1234');
+    localStorage.setItem('talrum:last-board', '{"id":"abc","kind":"sequence"}');
+
+    render(
+      <AuthGate>
+        <div data-testid="app-body">app</div>
+      </AuthGate>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('app-body')).toBeInTheDocument();
+    });
+
+    act(() => {
+      lastAuthListener?.('SIGNED_OUT', null);
+    });
+    await waitFor(() => {
+      expect(localStorage.getItem('talrum:pin-hash')).toBeNull();
+      expect(localStorage.getItem('talrum:last-board')).toBeNull();
+    });
+  });
+
+  // #179: SIGNED_IN can fire for a different user without an intervening
+  // SIGNED_OUT (close-tab-then-resume, or fast account-switch). Without a
+  // user-id-change scrub, user B briefly sees user A's persisted cache and
+  // localStorage residue.
+  it('scrubs PIN + last-board when SIGNED_IN fires for a new user without SIGNED_OUT (#179)', async () => {
+    const sessionA = makeSession('user-a-id', 'a@example.com');
+    const sessionB = makeSession('user-b-id', 'b@example.com');
+    getSessionMock.mockResolvedValueOnce({ data: { session: sessionA } });
+
+    render(
+      <AuthGate>
+        <UserIdProbe />
+      </AuthGate>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-user-id')).toHaveTextContent('user-a-id');
+    });
+
+    // User A's residue lands in localStorage during their session.
+    localStorage.setItem('talrum:pin-hash', 'user-a-pin-hash');
+    localStorage.setItem('talrum:last-board', '{"id":"a-board","kind":"choice"}');
+
+    // No SIGNED_OUT — user B simply signs in on the same device.
+    act(() => {
+      lastAuthListener?.('SIGNED_IN', sessionB);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-user-id')).toHaveTextContent('user-b-id');
+      expect(localStorage.getItem('talrum:pin-hash')).toBeNull();
+      expect(localStorage.getItem('talrum:last-board')).toBeNull();
+    });
+  });
+
+  // Token refreshes fire SIGNED_IN with the same user.id. Scrubbing on
+  // every SIGNED_IN would wipe the cache on a routine refresh and cause a
+  // visible reload flicker; the user-id check below avoids that.
+  it('does NOT scrub on SIGNED_IN with the same user.id (token refresh)', async () => {
+    const sessionA = makeSession('user-a-id', 'a@example.com');
+    getSessionMock.mockResolvedValueOnce({ data: { session: sessionA } });
+
+    render(
+      <AuthGate>
+        <UserIdProbe />
+      </AuthGate>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-user-id')).toHaveTextContent('user-a-id');
+    });
+
+    localStorage.setItem('talrum:pin-hash', 'should-survive-refresh');
+    localStorage.setItem('talrum:last-board', '{"id":"keep","kind":"sequence"}');
+
+    act(() => {
+      lastAuthListener?.('TOKEN_REFRESHED', sessionA);
+    });
+    // Give any unwanted async clearPersistedCache a chance to land before
+    // we assert the canaries are still present.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(localStorage.getItem('talrum:pin-hash')).toBe('should-survive-refresh');
+    expect(localStorage.getItem('talrum:last-board')).toBe('{"id":"keep","kind":"sequence"}');
+  });
+
+  // #184: switching VITE_SUPABASE_URL leaves the previous project's
+  // sb-<host>-auth-token in localStorage forever. AuthGate sweeps once on
+  // mount; the current project's key (derived from VITE_SUPABASE_URL) is
+  // preserved.
+  it('sweeps stale sb-*-auth-token keys on mount, preserving the current project key (#184)', async () => {
+    // .env.local pins VITE_SUPABASE_URL at https://wcwkxjjhribuecvcdenm.supabase.co
+    // for tests. The first segment of the host is the project ref.
+    const currentHost = new URL(import.meta.env.VITE_SUPABASE_URL).host;
+    const currentRef = currentHost.split(':')[0]?.split('.')[0] ?? '';
+    const currentKey = `sb-${currentRef}-auth-token`;
+
+    localStorage.setItem(currentKey, '{"current":1}');
+    localStorage.setItem('sb-some-other-ref-auth-token', '{"stale":1}');
+    localStorage.setItem('sb-127-auth-token', '{"stale":2}');
+
+    getSessionMock.mockResolvedValueOnce({ data: { session: null } });
+    render(
+      <AuthGate>
+        <div>app</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => {
+      expect(localStorage.getItem('sb-some-other-ref-auth-token')).toBeNull();
+      expect(localStorage.getItem('sb-127-auth-token')).toBeNull();
+    });
+    expect(localStorage.getItem(currentKey)).toBe('{"current":1}');
   });
 });

--- a/src/app/AuthGate.test.tsx
+++ b/src/app/AuthGate.test.tsx
@@ -322,8 +322,8 @@ describe('AuthGate', () => {
     act(() => {
       lastAuthListener?.('TOKEN_REFRESHED', sessionA);
     });
-    // Give any unwanted async clearPersistedCache a chance to land before
-    // we assert the canaries are still present.
+    // Two microtask flushes guarantee any unwanted async scrub would have
+    // landed; waitFor doesn't fit a negative assertion.
     await Promise.resolve();
     await Promise.resolve();
     expect(localStorage.getItem('talrum:pin-hash')).toBe('should-survive-refresh');

--- a/src/app/AuthGate.tsx
+++ b/src/app/AuthGate.tsx
@@ -1,7 +1,8 @@
 import type { Session } from '@supabase/supabase-js';
-import { type JSX, type ReactNode, useCallback, useEffect, useState } from 'react';
+import { type JSX, type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 
 import { Login } from '@/features/login/Login';
+import { sweepStaleAuthTokens } from '@/lib/auth/sweepStaleAuthTokens';
 import { clearPersistedCache } from '@/lib/queryClient';
 import { supabase } from '@/lib/supabase';
 import { useOnline } from '@/lib/useOnline';
@@ -31,14 +32,22 @@ const normalizePath = (p: string): string => p.replace(/\/$/, '') || '/';
 export const AuthGate = ({ children }: { children: ReactNode }): JSX.Element => {
   const [state, setState] = useState<AuthState>({ status: 'loading' });
   const [retryCount, setRetryCount] = useState(0);
+  // Track the previously-known user.id so we can detect a same-tab account
+  // switch (SIGNED_IN with a different user without an intervening
+  // SIGNED_OUT, #179) and scrub before mounting SessionProvider.
+  const lastUserIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     setState({ status: 'loading' });
+    // Sweep stale `sb-<other-host>-auth-token` keys left by previous
+    // VITE_SUPABASE_URL values (#184). One-shot per mount; idempotent.
+    sweepStaleAuthTokens(import.meta.env.VITE_SUPABASE_URL);
     supabase.auth
       .getSession()
       .then(({ data }) => {
         if (cancelled) return;
+        lastUserIdRef.current = data.session?.user.id ?? null;
         setState(data.session ? { status: 'in', session: data.session } : { status: 'out' });
       })
       .catch((err: unknown) => {
@@ -47,12 +56,18 @@ export const AuthGate = ({ children }: { children: ReactNode }): JSX.Element => 
         setState({ status: 'error', message });
       });
     const { data: sub } = supabase.auth.onAuthStateChange((event, session) => {
-      // Drop the persisted React Query cache when the user signs out so the
-      // next sign-in (potentially a different account on the same device)
-      // doesn't briefly render the previous user's boards from disk.
-      if (event === 'SIGNED_OUT') {
+      // Drop ALL per-user persisted state at any auth boundary so the next
+      // user starts clean: explicit SIGNED_OUT, or a SIGNED_IN whose user.id
+      // differs from the one we last saw (account switch in the same tab).
+      // Token refreshes (same id) and the very first sign-in (no prior id)
+      // intentionally skip the scrub.
+      const newUserId = session?.user.id ?? null;
+      const isUserSwitch =
+        newUserId !== null && lastUserIdRef.current !== null && newUserId !== lastUserIdRef.current;
+      if (event === 'SIGNED_OUT' || isUserSwitch) {
         void clearPersistedCache();
       }
+      lastUserIdRef.current = newUserId;
       setState(session ? { status: 'in', session } : { status: 'out' });
     });
     return () => {

--- a/src/app/AuthGate.tsx
+++ b/src/app/AuthGate.tsx
@@ -56,12 +56,9 @@ export const AuthGate = ({ children }: { children: ReactNode }): JSX.Element => 
         setState({ status: 'error', message });
       });
     const { data: sub } = supabase.auth.onAuthStateChange((event, session) => {
-      // Drop ALL per-user persisted state at any auth boundary so the next
-      // user starts clean: explicit SIGNED_OUT, or a SIGNED_IN whose user.id
-      // differs from the one we last saw (account switch in the same tab).
-      // Token refreshes (same id) and the very first sign-in (no prior id)
-      // intentionally skip the scrub.
       const newUserId = session?.user.id ?? null;
+      // Skip the scrub on token refresh (same id) and the very first sign-in
+      // (no prior id) — those are not auth boundaries.
       const isUserSwitch =
         newUserId !== null && lastUserIdRef.current !== null && newUserId !== lastUserIdRef.current;
       if (event === 'SIGNED_OUT' || isUserSwitch) {

--- a/src/lib/auth/sweepStaleAuthTokens.test.ts
+++ b/src/lib/auth/sweepStaleAuthTokens.test.ts
@@ -58,9 +58,6 @@ describe('sweepStaleAuthTokens', () => {
     localStorage.setItem('sb-stale-auth-token', '{"stale":1}');
 
     expect(() => sweepStaleAuthTokens('not a url')).not.toThrow();
-
-    // Without a parseable host we cannot identify the current key, so leave
-    // everything in place rather than risk wiping a valid session.
     expect(localStorage.getItem('sb-stale-auth-token')).toBe('{"stale":1}');
   });
 });

--- a/src/lib/auth/sweepStaleAuthTokens.test.ts
+++ b/src/lib/auth/sweepStaleAuthTokens.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { sweepStaleAuthTokens } from './sweepStaleAuthTokens';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe('sweepStaleAuthTokens', () => {
+  it('removes sb-*-auth-token keys for hosts other than the current Supabase URL', () => {
+    localStorage.setItem('sb-127-auth-token', '{"current":1}');
+    localStorage.setItem('sb-wcwkxjjhribuecvcdenm-auth-token', '{"stale":1}');
+    localStorage.setItem('sb-anotherproject-auth-token', '{"stale":2}');
+
+    sweepStaleAuthTokens('http://127.0.0.1:54321');
+
+    expect(localStorage.getItem('sb-127-auth-token')).toBe('{"current":1}');
+    expect(localStorage.getItem('sb-wcwkxjjhribuecvcdenm-auth-token')).toBeNull();
+    expect(localStorage.getItem('sb-anotherproject-auth-token')).toBeNull();
+  });
+
+  it('preserves the current cloud project key', () => {
+    localStorage.setItem('sb-projectref-auth-token', '{"current":1}');
+    localStorage.setItem('sb-127-auth-token', '{"stale":1}');
+
+    sweepStaleAuthTokens('https://projectref.supabase.co');
+
+    expect(localStorage.getItem('sb-projectref-auth-token')).toBe('{"current":1}');
+    expect(localStorage.getItem('sb-127-auth-token')).toBeNull();
+  });
+
+  it('leaves unrelated keys untouched', () => {
+    localStorage.setItem('talrum:pin-hash', 'abc');
+    localStorage.setItem('talrum:last-board', '{"id":"x","kind":"sequence"}');
+    localStorage.setItem('sb-stale-auth-token', '{"stale":1}');
+
+    sweepStaleAuthTokens('http://127.0.0.1:54321');
+
+    expect(localStorage.getItem('talrum:pin-hash')).toBe('abc');
+    expect(localStorage.getItem('talrum:last-board')).toBe('{"id":"x","kind":"sequence"}');
+    expect(localStorage.getItem('sb-stale-auth-token')).toBeNull();
+  });
+
+  it('is a no-op when there are no stale keys', () => {
+    localStorage.setItem('sb-127-auth-token', '{"current":1}');
+
+    sweepStaleAuthTokens('http://127.0.0.1:54321');
+
+    expect(localStorage.getItem('sb-127-auth-token')).toBe('{"current":1}');
+    expect(localStorage.length).toBe(1);
+  });
+
+  it('does nothing on a malformed Supabase URL rather than throwing', () => {
+    localStorage.setItem('sb-stale-auth-token', '{"stale":1}');
+
+    expect(() => sweepStaleAuthTokens('not a url')).not.toThrow();
+
+    // Without a parseable host we cannot identify the current key, so leave
+    // everything in place rather than risk wiping a valid session.
+    expect(localStorage.getItem('sb-stale-auth-token')).toBe('{"stale":1}');
+  });
+});

--- a/src/lib/auth/sweepStaleAuthTokens.ts
+++ b/src/lib/auth/sweepStaleAuthTokens.ts
@@ -1,0 +1,40 @@
+/**
+ * Supabase stores its session under `sb-<host-first-segment>-auth-token` in
+ * localStorage. When VITE_SUPABASE_URL points at a different project than a
+ * previous boot (cloud → staging → local rotation, or any env switch), the
+ * old key sticks around forever — see #184.
+ *
+ * Sweep removes any `sb-*-auth-token` whose host differs from the currently
+ * configured Supabase URL. Idempotent and safe: Supabase recreates its key
+ * on the next sign-in. On a malformed URL we leave everything alone rather
+ * than risk wiping a live session.
+ */
+const TOKEN_KEY_PATTERN = /^sb-.+-auth-token$/;
+
+const currentTokenKey = (supabaseUrl: string): string | null => {
+  let host: string;
+  try {
+    host = new URL(supabaseUrl).host;
+  } catch {
+    return null;
+  }
+  // "127.0.0.1:54321" → "127", "<ref>.supabase.co" → "<ref>".
+  const firstSegment = host.split(':')[0]?.split('.')[0];
+  if (!firstSegment) return null;
+  return `sb-${firstSegment}-auth-token`;
+};
+
+export const sweepStaleAuthTokens = (supabaseUrl: string): void => {
+  const keep = currentTokenKey(supabaseUrl);
+  if (!keep) return;
+  const stale: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && key !== keep && TOKEN_KEY_PATTERN.test(key)) {
+      stale.push(key);
+    }
+  }
+  for (const key of stale) {
+    localStorage.removeItem(key);
+  }
+};

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -3,6 +3,9 @@ import { QueryClient } from '@tanstack/react-query';
 import type { PersistQueryClientOptions } from '@tanstack/react-query-persist-client';
 import { del, get, keys, set } from 'idb-keyval';
 
+import { clearLastBoard } from './lastBoard';
+import { clearPin } from './pin';
+
 /**
  * AAC use is calm, not real-time. Skip focus-refetching so an iPad tap away
  * doesn't churn; keep data fresh for 30s so a mutation + immediate re-read
@@ -49,8 +52,9 @@ export const persistOptions: Omit<PersistQueryClientOptions, 'queryClient'> = {
 };
 
 /**
- * Drop ALL per-user persisted state on sign-out so the next user starts
- * clean. Called by AuthGate's onAuthStateChange handler. Wipes:
+ * Drop ALL per-user persisted state at an auth boundary (sign-out, or a
+ * same-tab switch to a different user.id) so the next user starts clean.
+ * Called by AuthGate's onAuthStateChange handler. Wipes:
  *   - The React Query cache (in-memory + persisted under the persister key).
  *   - Every queued outbox entry — without this, mutations queued offline by
  *     user A would replay against user B's session on next sign-in. RLS
@@ -59,12 +63,19 @@ export const persistOptions: Omit<PersistQueryClientOptions, 'queryClient'> = {
  *     about user A's prior intent.
  *   - Persisted signed-URL entries — same logic, those reference user A's
  *     storage paths.
+ *   - The parent PIN hash (#178) — otherwise user B is locked out of kid
+ *     mode by user A's PIN on a shared device.
+ *   - The last-board pointer (#178) — otherwise user B's auto-launch lands
+ *     on user A's board UUID, which 404s under RLS.
  *
- * Synchronous from the caller's POV; the IDB deletes race with the next
- * sign-in's hydration but every operation is idempotent.
+ * Synchronous from the caller's POV for the localStorage clears; the IDB
+ * deletes race with the next sign-in's hydration but every operation is
+ * idempotent.
  */
 export const clearPersistedCache = async (): Promise<void> => {
   queryClient.clear();
+  clearPin();
+  clearLastBoard();
   await persister.removeClient();
   const all = await keys();
   const stripeKeys = all.filter(

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -76,11 +76,16 @@ export const clearPersistedCache = async (): Promise<void> => {
   queryClient.clear();
   clearPin();
   clearLastBoard();
-  await persister.removeClient();
-  const all = await keys();
-  const stripeKeys = all.filter(
-    (k): k is string =>
-      typeof k === 'string' && (k.startsWith('outbox:') || k.startsWith('signed-url:')),
-  );
-  await Promise.all(stripeKeys.map((k) => del(k)));
+  // persister and the outbox/signed-url sweep touch disjoint IDB entries,
+  // so the round trips parallelize cleanly.
+  await Promise.all([
+    persister.removeClient(),
+    keys().then((all) => {
+      const stripeKeys = all.filter(
+        (k): k is string =>
+          typeof k === 'string' && (k.startsWith('outbox:') || k.startsWith('signed-url:')),
+      );
+      return Promise.all(stripeKeys.map((k) => del(k)));
+    }),
+  ]);
 };


### PR DESCRIPTION
## Summary

Three open bugs (#178, #179, #184) were instances of the same root cause: per-user client state was not consistently scrubbed across auth-state transitions. On a shared device (the AAC use case — caregiver hand-off, parent + therapist iPad), the leftover state caused real lockouts and cross-tenant data flicker.

- **#178** — `talrum:pin-hash` and `talrum:last-board` survived sign-out, so user B was locked into kid mode by user A's PIN and auto-launched into a board UUID that 404'd under RLS.
- **#179** — A same-tab account switch (SIGNED_IN with a different user.id, no SIGNED_OUT in between) didn't fire the existing scrub, so user B briefly saw user A's React Query cache + signed-URL entries.
- **#184** — `sb-<host>-auth-token` keys for previous `VITE_SUPABASE_URL` values were never cleaned up, growing localStorage unboundedly across env switches.

## What changed

- `src/lib/auth/sweepStaleAuthTokens.ts` (new) — derives the current project's `sb-<ref>-auth-token` key from `VITE_SUPABASE_URL` and removes any other `sb-*-auth-token` keys.
- `src/lib/queryClient.ts` — `clearPersistedCache` now also calls `clearPin()` and `clearLastBoard()`, keeping "what does a full per-user scrub do" in one place. The two IDB operations (persister + outbox/signed-url sweep) run in parallel.
- `src/app/AuthGate.tsx` — tracks the previous `session.user.id` in a `useRef`. Scrubs on `SIGNED_OUT` *or* on a `SIGNED_IN` whose id differs from the prior one. Token refreshes (same id) and the very first sign-in (no prior id) intentionally skip the scrub. The sweep runs once on mount.

## Forward-only fix

This PR forward-fixes the bug class for any future auth event. It does NOT backfill existing residue on first boot — a user who is currently signed in with stale `talrum:pin-hash` / `talrum:last-board` from a previous user on the same device will not have those scrubbed until the next `SIGNED_OUT` or user-switch fires. Backfilling on mount would clear a legitimate logged-in user's PIN, so the trade-off is intentional. The mount sweep DOES handle the `sb-*-auth-token` cleanup unconditionally (#184 backfills cleanly).

## Test plan

- [x] `npm test` — 332 tests pass (4 new regression tests in `AuthGate.test.tsx`, 5 unit tests for the sweep helper)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run lint:css` — clean
- [ ] Manual smoke (local Supabase + a second test account):
  - [ ] Sign in as A, set PIN, navigate to a board, sign out → `talrum:pin-hash` and `talrum:last-board` are gone in devtools.
  - [ ] Sign in as A, *don't sign out*, sign in as B in same tab → no flash of A's boards on first paint, no 401/406 on initial `boards` query.
  - [ ] Point `.env.local` at a different `VITE_SUPABASE_URL` host, reload → previous host's `sb-*-auth-token` is removed; current host's key is created cleanly on sign-in.

Closes #178, #179, #184.