### PR TITLE
fix(kid-mode): show empty-state when board has no pictograms (#183)

### DIFF
--- a/src/features/kid-choice/KidChoice.test.tsx
+++ b/src/features/kid-choice/KidChoice.test.tsx
@@ -136,4 +136,17 @@ describe('KidChoice', () => {
     // sure we suppress it rather than stacking it under the empty-state.
     expect(screen.queryByText(/Tap one to choose/)).not.toBeInTheDocument();
   });
+
+  it('shows the empty-state when every stepId references a missing pictogram', () => {
+    // Realistic production case: parent deletes a pictogram from Library
+    // while it's still referenced by a choice board.
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    qc.setQueryData(pictogramsQueryKey, []); // both park + zoo missing
+    render(
+      <Wrap qc={qc}>
+        <KidChoice board={board} onExit={vi.fn()} />
+      </Wrap>,
+    );
+    expect(screen.getByRole('status')).toHaveTextContent(/grown-up/i);
+  });
 });

--- a/src/features/kid-choice/KidChoice.test.tsx
+++ b/src/features/kid-choice/KidChoice.test.tsx
@@ -123,4 +123,17 @@ describe('KidChoice', () => {
     await userEvent.click(screen.getByRole('button', { name: /Exit kid mode/i }));
     expect(onExit).toHaveBeenCalledTimes(1);
   });
+
+  it('shows a friendly empty-state when the board has zero options (#183)', () => {
+    const qc = makeClient();
+    render(
+      <Wrap qc={qc}>
+        <KidChoice board={{ ...board, stepIds: [] }} onExit={vi.fn()} />
+      </Wrap>,
+    );
+    expect(screen.getByRole('status')).toHaveTextContent(/grown-up/i);
+    // The "Tap one to choose" prompt is meaningless with no options — make
+    // sure we suppress it rather than stacking it under the empty-state.
+    expect(screen.queryByText(/Tap one to choose/)).not.toBeInTheDocument();
+  });
 });

--- a/src/features/kid-choice/KidChoice.tsx
+++ b/src/features/kid-choice/KidChoice.tsx
@@ -29,22 +29,6 @@ export const KidChoice = ({ board, onExit }: KidChoiceProps): JSX.Element => {
     void speakPictogram(p, board.voiceMode);
   };
 
-  if (options.length === 0) {
-    return (
-      <KidModeLayout
-        eyebrow={board.name.toUpperCase()}
-        title="Pick one place"
-        titleSize="large"
-        onExit={onExit}
-        logoTint="sky"
-        logoTintInk="sky-ink"
-        logoContent={<ChoiceConnectorIcon size={22} />}
-      >
-        <EmptyState title="This board is empty" body="Ask a grown-up to add some pictograms." />
-      </KidModeLayout>
-    );
-  }
-
   return (
     <KidModeLayout
       eyebrow={board.name.toUpperCase()}
@@ -55,64 +39,73 @@ export const KidChoice = ({ board, onExit }: KidChoiceProps): JSX.Element => {
       logoTintInk="sky-ink"
       logoContent={<ChoiceConnectorIcon size={22} />}
     >
-      <div className={styles.choices}>
-        {options.map((p, idx) => {
-          const accent = accentForIndex(idx);
-          const isPicked = pickedId === p.id;
-          const isOther = pickedId !== null && !isPicked;
-          const markerStyle = {
-            background: cssVar(accent.bg),
-            color: cssVar(accent.ink),
-          };
-          const choiceStyle = isPicked ? { borderColor: cssVar(accent.ink) } : {};
-          const mediaStyle = {
-            background: p.style === 'photo' ? 'var(--tal-surface-alt)' : cssVar(accent.bg),
-          };
-          return (
-            <button
-              key={p.id}
-              type="button"
-              onClick={() => pick(p)}
-              className={[
-                styles.choice,
-                isPicked && styles.choicePicked,
-                isOther && styles.choiceDim,
-              ]
-                .filter(Boolean)
-                .join(' ')}
-              style={choiceStyle}
-              aria-label={
-                board.labelsVisible ? undefined : `${String.fromCharCode(65 + idx)} ${p.label}`
-              }
-            >
-              <span className={styles.marker} style={markerStyle}>
-                {String.fromCharCode(65 + idx)}
-              </span>
-              <div className={styles.mediaWrap} style={mediaStyle}>
-                <PictogramMedia picto={p} size={260} radius="0" />
-                {isPicked && (
-                  <div className={styles.pickedBadge} style={{ background: cssVar(accent.ink) }}>
-                    <CheckIcon size={26} />
+      {options.length === 0 ? (
+        <EmptyState title="This board is empty" body="Ask a grown-up to add some pictograms." />
+      ) : (
+        <>
+          <div className={styles.choices}>
+            {options.map((p, idx) => {
+              const accent = accentForIndex(idx);
+              const isPicked = pickedId === p.id;
+              const isOther = pickedId !== null && !isPicked;
+              const markerStyle = {
+                background: cssVar(accent.bg),
+                color: cssVar(accent.ink),
+              };
+              const choiceStyle = isPicked ? { borderColor: cssVar(accent.ink) } : {};
+              const mediaStyle = {
+                background: p.style === 'photo' ? 'var(--tal-surface-alt)' : cssVar(accent.bg),
+              };
+              return (
+                <button
+                  key={p.id}
+                  type="button"
+                  onClick={() => pick(p)}
+                  className={[
+                    styles.choice,
+                    isPicked && styles.choicePicked,
+                    isOther && styles.choiceDim,
+                  ]
+                    .filter(Boolean)
+                    .join(' ')}
+                  style={choiceStyle}
+                  aria-label={
+                    board.labelsVisible ? undefined : `${String.fromCharCode(65 + idx)} ${p.label}`
+                  }
+                >
+                  <span className={styles.marker} style={markerStyle}>
+                    {String.fromCharCode(65 + idx)}
+                  </span>
+                  <div className={styles.mediaWrap} style={mediaStyle}>
+                    <PictogramMedia picto={p} size={260} radius="0" />
+                    {isPicked && (
+                      <div
+                        className={styles.pickedBadge}
+                        style={{ background: cssVar(accent.ink) }}
+                      >
+                        <CheckIcon size={26} />
+                      </div>
+                    )}
                   </div>
-                )}
-              </div>
-              {board.labelsVisible && <span className={styles.label}>{p.label}</span>}
-            </button>
-          );
-        })}
-      </div>
-      <div className={styles.bottom}>
-        {pickedLabel ? (
-          <button type="button" className={styles.confirmBtn}>
-            <span className={styles.confirmCheck}>
-              <CheckIcon size={18} />
-            </span>
-            Let&apos;s go to {pickedLabel}
-          </button>
-        ) : (
-          <span className={styles.placeholder}>Tap one to choose ✨</span>
-        )}
-      </div>
+                  {board.labelsVisible && <span className={styles.label}>{p.label}</span>}
+                </button>
+              );
+            })}
+          </div>
+          <div className={styles.bottom}>
+            {pickedLabel ? (
+              <button type="button" className={styles.confirmBtn}>
+                <span className={styles.confirmCheck}>
+                  <CheckIcon size={18} />
+                </span>
+                Let&apos;s go to {pickedLabel}
+              </button>
+            ) : (
+              <span className={styles.placeholder}>Tap one to choose ✨</span>
+            )}
+          </div>
+        </>
+      )}
     </KidModeLayout>
   );
 };

--- a/src/features/kid-choice/KidChoice.tsx
+++ b/src/features/kid-choice/KidChoice.tsx
@@ -5,6 +5,7 @@ import { usePictogramsById } from '@/lib/queries/pictograms';
 import { speakPictogram } from '@/lib/voiceOut';
 import { accentForIndex, cssVar } from '@/theme/tokens';
 import type { Board, Pictogram } from '@/types/domain';
+import { EmptyState } from '@/ui/EmptyState/EmptyState';
 import { CheckIcon, ChoiceConnectorIcon } from '@/ui/icons';
 import { PictogramMedia } from '@/ui/PictoTile/PictogramMedia';
 
@@ -27,6 +28,22 @@ export const KidChoice = ({ board, onExit }: KidChoiceProps): JSX.Element => {
     setPickedId(p.id);
     void speakPictogram(p, board.voiceMode);
   };
+
+  if (options.length === 0) {
+    return (
+      <KidModeLayout
+        eyebrow={board.name.toUpperCase()}
+        title="Pick one place"
+        titleSize="large"
+        onExit={onExit}
+        logoTint="sky"
+        logoTintInk="sky-ink"
+        logoContent={<ChoiceConnectorIcon size={22} />}
+      >
+        <EmptyState title="This board is empty" body="Ask a grown-up to add some pictograms." />
+      </KidModeLayout>
+    );
+  }
 
   return (
     <KidModeLayout

--- a/src/features/kid-sequence/KidSequence.test.tsx
+++ b/src/features/kid-sequence/KidSequence.test.tsx
@@ -135,4 +135,25 @@ describe('KidSequence', () => {
     expect(screen.getByText('Apple')).toBeInTheDocument();
     expect(screen.queryByText('Drink')).not.toBeInTheDocument();
   });
+
+  it('shows a friendly empty-state when the board has zero steps (#183)', () => {
+    const qc = makeClient();
+    render(
+      <Wrap qc={qc}>
+        <KidSequence board={{ ...board, stepIds: [] }} onExit={vi.fn()} />
+      </Wrap>,
+    );
+    expect(screen.getByRole('status')).toHaveTextContent(/grown-up/i);
+  });
+
+  it('shows the empty-state when every stepId references a missing pictogram', () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    qc.setQueryData(pictogramsQueryKey, []); // both apple + cup missing
+    render(
+      <Wrap qc={qc}>
+        <KidSequence board={board} onExit={vi.fn()} />
+      </Wrap>,
+    );
+    expect(screen.getByRole('status')).toHaveTextContent(/grown-up/i);
+  });
 });

--- a/src/features/kid-sequence/KidSequence.tsx
+++ b/src/features/kid-sequence/KidSequence.tsx
@@ -5,6 +5,7 @@ import { useSetStepIds } from '@/lib/queries/boards';
 import { usePictogramsById } from '@/lib/queries/pictograms';
 import { speakPictogram } from '@/lib/voiceOut';
 import type { Board, Pictogram } from '@/types/domain';
+import { EmptyState } from '@/ui/EmptyState/EmptyState';
 import { SpeakerIcon } from '@/ui/icons';
 import { PictogramMedia } from '@/ui/PictoTile/PictogramMedia';
 import { type DragBindings, Reorderable } from '@/ui/Reorderable/Reorderable';
@@ -100,17 +101,21 @@ export const KidSequence = ({ board, onExit }: KidSequenceProps): JSX.Element =>
 
   return (
     <KidModeLayout eyebrow={board.name.toUpperCase()} title="" onExit={onExit}>
-      <div className={styles.strip}>
-        {board.kidReorderable ? (
-          <Reorderable
-            items={steps}
-            onReorder={handleReorder}
-            renderItem={(step, _i, drag) => <div key={step.key}>{renderTile(step, drag)}</div>}
-          />
-        ) : (
-          steps.map((step) => <div key={step.key}>{renderTile(step)}</div>)
-        )}
-      </div>
+      {steps.length === 0 ? (
+        <EmptyState title="This board is empty" body="Ask a grown-up to add some pictograms." />
+      ) : (
+        <div className={styles.strip}>
+          {board.kidReorderable ? (
+            <Reorderable
+              items={steps}
+              onReorder={handleReorder}
+              renderItem={(step, _i, drag) => <div key={step.key}>{renderTile(step, drag)}</div>}
+            />
+          ) : (
+            steps.map((step) => <div key={step.key}>{renderTile(step)}</div>)
+          )}
+        </div>
+      )}
     </KidModeLayout>
   );
 };


### PR DESCRIPTION
## Summary
- KidSequence and KidChoice now render the existing `EmptyState` ("This board is empty / Ask a grown-up to add some pictograms.") when the board resolves to zero rendered tiles, instead of a blank screen.
- Same code path also covers the rare case where every `stepId` references a pictogram that's been deleted from the library.
- Reuses `src/ui/EmptyState/EmptyState.tsx` — no new component, no CSS.

## Why
Per #183: a child opens an empty board in kid mode and sees nothing — title bar + Exit button only. The parent has no idea what's wrong. This gives the kid (and the adult standing next to them) a clear signal.

## Out of scope
The issue's "Related" sub-thread — the bottom-left KID toggle silently launching the last-edited board into kid mode without confirmation — is a separate behavior change in `useKidModeNav` / BoardBuilder wiring. Filing separately if the reviewer wants it tracked.

## Test plan
- [x] `npx vitest run src/features/kid-{sequence,choice}/*.test.tsx` — 3 new regression tests pass (empty stepIds in both surfaces; KidSequence with all-missing pictograms)
- [x] Full suite: 335/335 pass
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [ ] Manual smoke: create a new sequence board with no pictograms, tap KID toggle, confirm the empty-state appears

Closes #183