### PR TITLE
perf(pictograms): memoize usePictogramsById / usePictogramsBySlug Maps (#197)

### DIFF
--- a/src/lib/queries/pictograms.memo.test.tsx
+++ b/src/lib/queries/pictograms.memo.test.tsx
@@ -1,0 +1,65 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import type { JSX, ReactNode } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import type { Pictogram } from '@/types/domain';
+
+import { pictogramsQueryKey, usePictogramsById, usePictogramsBySlug } from './pictograms';
+
+const apple: Pictogram = {
+  id: 'apple',
+  label: 'Apple',
+  style: 'illus',
+  glyph: 'apple',
+  tint: 'oklch(88% 0.05 20)',
+  slug: 'apple',
+};
+const cup: Pictogram = {
+  id: 'cup',
+  label: 'Cup',
+  style: 'illus',
+  glyph: 'cup',
+  tint: 'oklch(88% 0.05 240)',
+  slug: 'cup',
+};
+
+const wrap = (qc: QueryClient): ((props: { children: ReactNode }) => JSX.Element) => {
+  const Wrapped = ({ children }: { children: ReactNode }): JSX.Element => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+  return Wrapped;
+};
+
+describe('usePictogramsById memoization (#197)', () => {
+  it('returns the same Map identity across renders when data is unchanged', () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    qc.setQueryData(pictogramsQueryKey, [apple, cup]);
+    const { result, rerender } = renderHook(() => usePictogramsById(), { wrapper: wrap(qc) });
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+
+  it('returns a new Map when the underlying data changes', () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    qc.setQueryData(pictogramsQueryKey, [apple]);
+    const { result, rerender } = renderHook(() => usePictogramsById(), { wrapper: wrap(qc) });
+    const first = result.current;
+    qc.setQueryData(pictogramsQueryKey, [apple, cup]);
+    rerender();
+    expect(result.current).not.toBe(first);
+    expect(result.current.get('cup')).toEqual(cup);
+  });
+});
+
+describe('usePictogramsBySlug memoization (#197)', () => {
+  it('returns the same Map identity across renders when data is unchanged', () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    qc.setQueryData(pictogramsQueryKey, [apple, cup]);
+    const { result, rerender } = renderHook(() => usePictogramsBySlug(), { wrapper: wrap(qc) });
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});

--- a/src/lib/queries/pictograms.ts
+++ b/src/lib/queries/pictograms.ts
@@ -6,6 +6,7 @@ import {
   useQueryClient,
   type UseQueryResult,
 } from '@tanstack/react-query';
+import { useMemo } from 'react';
 
 import { useSessionUser } from '@/lib/auth/session';
 import { enqueueAndDrain } from '@/lib/outbox';
@@ -83,24 +84,30 @@ export const pictogramsQueryKey = ['pictograms'] as const;
  * Convenience: same underlying query as `usePictograms`, but returns a
  * `Map<id, Pictogram>` so callers resolving `board.stepIds → Pictogram`
  * don't keep rebuilding the lookup. Returns an empty map while loading.
+ *
+ * Memoized on the `data` reference: React Query holds the array identity-
+ * stable until it changes, so each consumer recomputes the Map at most
+ * once per cache update — not once per render.
  */
 export const usePictogramsById = (): Map<string, Pictogram> => {
   const { data } = usePictograms();
-  return new Map((data ?? []).map((p) => [p.id, p]));
+  return useMemo(() => new Map((data ?? []).map((p) => [p.id, p])), [data]);
 };
 
 /**
  * Lookup by seed slug ('apple', 'book') — useful for the few client-side
  * lists that reference specific seed pictograms by name. User-uploaded
- * pictograms have no slug and aren't in this map.
+ * pictograms have no slug and aren't in this map. Memoized on `data`.
  */
 export const usePictogramsBySlug = (): Map<string, Pictogram> => {
   const { data } = usePictograms();
-  const out = new Map<string, Pictogram>();
-  for (const p of data ?? []) {
-    if (p.slug) out.set(p.slug, p);
-  }
-  return out;
+  return useMemo(() => {
+    const out = new Map<string, Pictogram>();
+    for (const p of data ?? []) {
+      if (p.slug) out.set(p.slug, p);
+    }
+    return out;
+  }, [data]);
 };
 
 const patchPictogramInList = (


### PR DESCRIPTION
## Summary
- Wrap the Map construction in both \`usePictogramsById\` and \`usePictogramsBySlug\` in \`useMemo\` keyed on the underlying \`data\` reference.
- React Query keeps the pictograms array identity-stable until it actually changes (structural sharing), so each consumer recomputes the Map at most once per cache update — not once per render.
- Six consumers benefit: \`KidSequence\`, \`KidChoice\`, \`BoardBuilder\`, \`BoardCard\`, \`ParentHome\`, plus the seed-slug lookup in \`ParentHome\`.

## Why
Surfaced by the efficiency review on PR #196 (empty-board kid mode). Not on a hot path today, but the wasted recomputation scales with library size × consumer count, and identity-unstable Maps are quietly hostile to \`useEffect\` deps and child memoization downstream.

## Test plan
- [x] New \`pictograms.memo.test.tsx\` — 3 tests pinning identity stability across re-renders when data is unchanged, and a fresh Map when data changes
- [x] Full suite: 339/339 pass (was 335; +3 new + 1 existing-counted-twice)
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean

## Why useMemo over a module-level \`select\`
\`select\` would centralize the computation but would require either restructuring \`usePictograms\` or adding a parallel hook. \`useMemo\` is one-line, identity-stable per consumer, and the underlying \`data\` reference is shared across all consumers via React Query's cache — so all consumers' memos invalidate together on a real data change. Same effective behavior, smaller diff.

Closes #197