### PR TITLE
chore: bedtime seed label + meta tag + query-key constant

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
       content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
     />
     <meta name="theme-color" content="oklch(97.5% 0.008 85)" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Talrum" />

--- a/src/lib/queries/pictograms.read.ts
+++ b/src/lib/queries/pictograms.read.ts
@@ -40,10 +40,10 @@ const fetchPictograms = async (): Promise<Pictogram[]> => {
   return data.map(rowToPictogram);
 };
 
-export const usePictograms = (): UseQueryResult<Pictogram[]> =>
-  useQuery({ queryKey: ['pictograms'], queryFn: fetchPictograms });
-
 export const pictogramsQueryKey = ['pictograms'] as const;
+
+export const usePictograms = (): UseQueryResult<Pictogram[]> =>
+  useQuery({ queryKey: pictogramsQueryKey, queryFn: fetchPictograms });
 
 /**
  * Convenience: same underlying query as `usePictograms`, but returns a

--- a/supabase/migrations/20260510120000_fix_bedtime_label.sql
+++ b/supabase/migrations/20260510120000_fix_bedtime_label.sql
@@ -1,0 +1,16 @@
+-- Issue #176: 'Bedtime' template's final step rendered as 'Out of bed' —
+-- the opposite of what a bedtime routine should end with. The original
+-- seed (20260427162919) labelled the `bed`-glyph pictogram as 'Out of
+-- bed', a phrase that only fits a wakeup sequence. Relabel to 'Sleep' so
+-- fresh signups see Bath -> Story time -> Drink -> Sleep.
+--
+-- Slug stays 'bed' to match the existing glyph and avoid also rewriting
+-- Bedtime's step_slugs array. Existing user data (rows in `pictograms`
+-- already cloned by handle_new_user) is intentionally left alone — users
+-- may have repurposed 'Out of bed' in custom morning routines, and #192
+-- gives them a rename UI if they want to change it.
+--
+-- Idempotent: the label-equals-'Out of bed' guard makes re-runs a no-op.
+
+update template_pictograms set label = 'Sleep'
+  where slug = 'bed' and label = 'Out of bed';


### PR DESCRIPTION
## Summary

Three independent trivial cleanups bundled into one PR.

- **Closes #176** — Bedtime template's last step rendered as 'Out of bed', the opposite of a bedtime routine. New migration relabels seed pictogram `bed` to 'Sleep' so fresh signups see Bath -> Story time -> Drink -> Sleep. Existing user data left alone (rename UI in #192).
- **Closes #189** — Add standardized `<meta name="mobile-web-app-capable">` next to the deprecated apple- variant. Silences the Chrome console warning; apple- variant kept for older iOS Safari.
- **Closes #201** — `usePictograms` now uses the named `pictogramsQueryKey` constant instead of a literal `['pictograms']`. Matches `boards.read.ts` pattern. Pure refactor.

## Test plan

- [x] `npm test` — 339 tests across 65 files pass
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run lint:css` clean
- [x] `supabase db reset` applies all 20 migrations cleanly; `template_pictograms` row for slug `bed` reads label 'Sleep' after apply
- [x] `npm run migrations:check-drift` — no drift