### PR TITLE
test: replace await Promise.resolve() microtask flushes with waitFor (#194)

### DIFF
--- a/src/app/AuthGate.test.tsx
+++ b/src/app/AuthGate.test.tsx
@@ -322,9 +322,10 @@ describe('AuthGate', () => {
     await act(async () => {
       lastAuthListener?.('TOKEN_REFRESHED', sessionA);
     });
-    // `act(async)` settles any React-induced async caused by the event, so an
-    // unwanted scrub would have landed by now. waitFor doesn't fit a negative
-    // assertion (it would pass immediately without ever actually waiting).
+    // `act(async)` flushes React updates from the dispatched event; the
+    // same-id branch is synchronous so nothing further needs to settle.
+    // waitFor doesn't fit a negative assertion (it would pass immediately
+    // without ever actually waiting).
     expect(localStorage.getItem('talrum:pin-hash')).toBe('should-survive-refresh');
     expect(localStorage.getItem('talrum:last-board')).toBe('{"id":"keep","kind":"sequence"}');
   });

--- a/src/app/AuthGate.test.tsx
+++ b/src/app/AuthGate.test.tsx
@@ -319,13 +319,12 @@ describe('AuthGate', () => {
     localStorage.setItem('talrum:pin-hash', 'should-survive-refresh');
     localStorage.setItem('talrum:last-board', '{"id":"keep","kind":"sequence"}');
 
-    act(() => {
+    await act(async () => {
       lastAuthListener?.('TOKEN_REFRESHED', sessionA);
     });
-    // Two microtask flushes guarantee any unwanted async scrub would have
-    // landed; waitFor doesn't fit a negative assertion.
-    await Promise.resolve();
-    await Promise.resolve();
+    // `act(async)` settles any React-induced async caused by the event, so an
+    // unwanted scrub would have landed by now. waitFor doesn't fit a negative
+    // assertion (it would pass immediately without ever actually waiting).
     expect(localStorage.getItem('talrum:pin-hash')).toBe('should-survive-refresh');
     expect(localStorage.getItem('talrum:last-board')).toBe('{"id":"keep","kind":"sequence"}');
   });

--- a/src/ui/KidSheet/KidSheet.test.tsx
+++ b/src/ui/KidSheet/KidSheet.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Kid } from '@/types/domain';
@@ -46,10 +46,10 @@ describe('KidSheet', () => {
     render(<KidSheet kid={liam} boardCount={0} onClose={onClose} />);
     fireEvent.change(screen.getByDisplayValue('Liam'), { target: { value: 'Liam Jr.' } });
     fireEvent.click(screen.getByRole('button', { name: /save name/i }));
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(renameMock).toHaveBeenCalledWith({ kidId: 'k1', name: 'Liam Jr.' });
-    expect(onClose).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(renameMock).toHaveBeenCalledWith({ kidId: 'k1', name: 'Liam Jr.' });
+      expect(onClose).toHaveBeenCalled();
+    });
   });
 
   it('disables Save when the name is unchanged or empty', () => {
@@ -95,9 +95,9 @@ describe('KidSheet', () => {
     expect(deleteMock).not.toHaveBeenCalled();
     // Second click confirms.
     fireEvent.click(screen.getByRole('button', { name: /delete forever/i }));
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(deleteMock).toHaveBeenCalledWith({ kidId: 'k1' });
-    expect(onClose).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(deleteMock).toHaveBeenCalledWith({ kidId: 'k1' });
+      expect(onClose).toHaveBeenCalled();
+    });
   });
 });

--- a/src/ui/OfflineIndicator/OfflineIndicator.test.tsx
+++ b/src/ui/OfflineIndicator/OfflineIndicator.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const useOutboxStatusMock = vi.fn();
@@ -83,10 +83,7 @@ describe('OfflineIndicator', () => {
     discardEntryMock.mockResolvedValue(undefined);
     render(<OfflineIndicator />);
     fireEvent.click(screen.getByRole('button', { name: 'Discard' }));
-    // Let the discardAllFailed promise chain settle.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(discardEntryMock).toHaveBeenCalledWith('a');
+    await waitFor(() => expect(discardEntryMock).toHaveBeenCalledWith('a'));
     expect(discardEntryMock).not.toHaveBeenCalledWith('b');
     expect(kickMock).not.toHaveBeenCalled();
   });

--- a/src/ui/PictogramSheet/PictogramSheet.test.tsx
+++ b/src/ui/PictogramSheet/PictogramSheet.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Board, Pictogram } from '@/types/domain';
@@ -102,11 +102,10 @@ describe('PictogramSheet', () => {
     const input = screen.getByDisplayValue('Apple');
     fireEvent.change(input, { target: { value: 'Big apple' } });
     fireEvent.click(screen.getByRole('button', { name: /save label/i }));
-    // Drain the awaited mutateAsync.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(renameMock).toHaveBeenCalledWith({ pictogramId: 'p1', label: 'Big apple' });
-    expect(onClose).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(renameMock).toHaveBeenCalledWith({ pictogramId: 'p1', label: 'Big apple' });
+      expect(onClose).toHaveBeenCalled();
+    });
   });
 
   it('disables Save when the label is unchanged or empty', () => {
@@ -139,13 +138,13 @@ describe('PictogramSheet', () => {
     expect(deleteMock).not.toHaveBeenCalled();
     // Second click confirms.
     fireEvent.click(screen.getByRole('button', { name: /delete forever/i }));
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(deleteMock).toHaveBeenCalledWith({
-      pictogramId: 'p1',
-      scrubFromBoardIds: ['b1', 'b2'],
+    await waitFor(() => {
+      expect(deleteMock).toHaveBeenCalledWith({
+        pictogramId: 'p1',
+        scrubFromBoardIds: ['b1', 'b2'],
+      });
+      expect(onClose).toHaveBeenCalled();
     });
-    expect(onClose).toHaveBeenCalled();
   });
 
   it('shows a "used on N boards" hint when the picto is referenced', () => {


### PR DESCRIPTION
Closes #194.

## Summary

- Replaces 12 `await Promise.resolve()` microtask flushes (in 4 test files) with idiomatic Testing Library helpers.
- Issue body listed 10 occurrences in 3 files; #195 added 2 more in `AuthGate.test.tsx` after the issue was filed — all 12 are addressed here.
- 10 positive assertions become `await waitFor(() => expect(...))`. The mixed positive+negative case in `OfflineIndicator` anchors `waitFor` on the positive expectation and evaluates the two negatives synchronously after the wait settles.
- 2 negative assertions in `AuthGate.test.tsx` ("scrub did NOT happen on TOKEN_REFRESHED") use `await act(async () => ...)` instead of `waitFor` — `waitFor` would pass immediately on a negative assertion without ever actually waiting, silently weakening the test. The original comment is rewritten to reflect the new idiom.
- Verified no other microtask-flush anti-patterns in the codebase (`flushPromises`, `await new Promise(setTimeout)`, `await null`, `act()` no-ops, `process.nextTick`).

No production code touched.

## Test plan
- [x] `npx vitest run src/ui/KidSheet src/ui/PictogramSheet src/ui/OfflineIndicator src/app/AuthGate.test.tsx` — 30/30 pass
- [x] `npm test` — 339/339 pass across 65 files
- [x] `grep -rn "await Promise.resolve" src/` — no matches
- [x] Pre-commit hooks (eslint, prettier, tsc) green