### PR TITLE
fix(parent-shell): remove redundant settings avatar (#185)

### DIFF
--- a/src/app/AuthGate.test.tsx
+++ b/src/app/AuthGate.test.tsx
@@ -208,7 +208,7 @@ describe('AuthGate', () => {
 
   // Regression cover for cross-user re-auth: signing out and back in as a
   // different user must propagate the new user.id all the way through
-  // SessionProvider so dependent hooks (mutations, useUserInitial) read the
+  // SessionProvider so dependent hooks (mutations, useUserEmail) read the
   // new user. Verifies AuthGate wires onAuthStateChange → setState →
   // SessionProvider value without missing a session swap.
   it('propagates a new session.user when onAuthStateChange fires after re-auth', async () => {

--- a/src/app/SessionProvider.tsx
+++ b/src/app/SessionProvider.tsx
@@ -11,7 +11,7 @@ interface SessionProviderProps {
 /**
  * Single source of truth for the signed-in user. Mounted by AuthGate after
  * the session has resolved; descendants read via useSession / useSessionUser
- * / useSignOut / useUserInitial without subscribing to auth themselves.
+ * / useSignOut / useUserEmail without subscribing to auth themselves.
  */
 export const SessionProvider = ({ session, children }: SessionProviderProps): JSX.Element => {
   const value = useMemo<SessionContextValue>(

--- a/src/features/settings/AccountSection.tsx
+++ b/src/features/settings/AccountSection.tsx
@@ -4,12 +4,6 @@ import { useSignOut, useUserEmail } from '@/lib/auth/session';
 
 import styles from './AccountSection.module.css';
 
-/**
- * Identity + sign-out for the Settings page. Sign-out used to live on the
- * sidebar avatar in ParentShell, where it could be hit by accident; the
- * avatar is now a settings entry point and this is the single place that
- * actually signs the user out.
- */
 export const AccountSection = (): JSX.Element => {
   const email = useUserEmail();
   const signOut = useSignOut();

--- a/src/layouts/ParentShell.module.css
+++ b/src/layouts/ParentShell.module.css
@@ -54,26 +54,6 @@
   gap: var(--tal-space-3);
 }
 
-.avatar {
-  width: 40px;
-  height: 40px;
-  border-radius: var(--tal-r-pill);
-  background: var(--tal-peach);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 15px;
-  font-weight: 800;
-  color: var(--tal-peach-ink);
-  border: none;
-  cursor: pointer;
-  font-family: inherit;
-}
-
-.avatar:hover {
-  filter: brightness(0.95);
-}
-
 .kidBtn {
   width: 56px;
   height: 56px;

--- a/src/layouts/ParentShell.tsx
+++ b/src/layouts/ParentShell.tsx
@@ -1,6 +1,5 @@
 import type { JSX, ReactNode } from 'react';
 
-import { useUserInitial } from '@/lib/auth/session';
 import type { NavIconName } from '@/ui/icons';
 import { LockIcon, NavIcon } from '@/ui/icons';
 import { OfflineIndicator } from '@/ui/OfflineIndicator/OfflineIndicator';
@@ -29,8 +28,6 @@ interface ParentShellProps {
   /**
    * Page-specific kid-mode entry point. Each route picks the right board
    * (e.g. ParentHome → first sequence board; BoardBuilder → this board).
-   * The avatar shows the user's initial from session and navigates to
-   * /settings via onNav; it no longer signs out directly.
    */
   onKidMode?: () => void;
   title?: string;
@@ -48,7 +45,6 @@ export const ParentShell = ({
   right,
   children,
 }: ParentShellProps): JSX.Element => {
-  const userInitial = useUserInitial();
   return (
     <div className={styles.shell}>
       <aside className={styles.sidebar}>
@@ -75,15 +71,6 @@ export const ParentShell = ({
           <button type="button" className={styles.kidBtn} onClick={onKidMode}>
             <LockIcon size={22} />
             <span>KID</span>
-          </button>
-          <button
-            type="button"
-            className={styles.avatar}
-            onClick={() => onNav?.('settings')}
-            title="Open settings"
-            aria-label="Open settings"
-          >
-            {userInitial ?? ''}
           </button>
         </div>
       </aside>

--- a/src/lib/auth/session.test-utils.tsx
+++ b/src/lib/auth/session.test-utils.tsx
@@ -28,7 +28,7 @@ interface TestSessionProviderProps {
 /**
  * Wraps tests in a SessionProvider with a fake authenticated user. Use when
  * rendering anything that calls useSession / useSessionUser / useSignOut /
- * useUserInitial / useUserEmail — e.g. ParentShell-wrapping screens.
+ * useUserEmail — e.g. ParentShell-wrapping screens.
  */
 export const TestSessionProvider = ({
   children,

--- a/src/lib/auth/session.test.tsx
+++ b/src/lib/auth/session.test.tsx
@@ -7,7 +7,7 @@ vi.mock('@/lib/supabase', () => ({
   supabase: { auth: { signOut: signOutMock } },
 }));
 
-const { useSession, useSessionUser, useSignOut, useUserInitial } = await import('./session');
+const { useSession, useSessionUser, useSignOut } = await import('./session');
 const { TestSessionProvider } = await import('./session.test-utils');
 
 describe('session hooks', () => {
@@ -19,11 +19,6 @@ describe('session hooks', () => {
   it('useSessionUser exposes the user', () => {
     const { result } = renderHook(() => useSessionUser(), { wrapper: TestSessionProvider });
     expect(result.current.email).toBe('parent@example.com');
-  });
-
-  it('useUserInitial returns the uppercase first character of the email', () => {
-    const { result } = renderHook(() => useUserInitial(), { wrapper: TestSessionProvider });
-    expect(result.current).toBe('P');
   });
 
   it('useSignOut calls supabase.auth.signOut', async () => {

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -33,14 +33,5 @@ export const useSession = (): Session => useSessionContext().session;
 export const useSessionUser = (): User => useSessionContext().user;
 export const useSignOut = (): (() => Promise<void>) => useSessionContext().signOut;
 
-/**
- * Uppercase first character of the user's email, or undefined when the user
- * has no email on the session (rare — e.g. phone-only auth, not used here).
- */
-export const useUserInitial = (): string | undefined => {
-  const first = useSessionUser().email?.[0];
-  return first ? first.toUpperCase() : undefined;
-};
-
-/** Same undefined caveat as useUserInitial — phone-only auth has no email. */
+/** Returns undefined for phone-only auth sessions, which have no email. */
 export const useUserEmail = (): string | undefined => useSessionUser().email;


### PR DESCRIPTION
## Summary
- Remove the bottom-of-sidebar avatar button from `ParentShell`. It duplicated the side-rail Settings nav entry directly above it and was a no-op on `/settings` itself (just refocused).
- Drop `useUserInitial` from `src/lib/auth/session.ts` plus its test and stale doc references — `ParentShell` was the only caller.

Closes #185.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run lint:css` clean (the `.avatar` and `.avatar:hover` rules are removed)
- [x] `npm test` — 338/338 pass (no test referenced "Open settings")
- [ ] Visual check: `KID` button still sits at the bottom of the sidebar; Settings is reachable via the side-rail nav item only