### PR TITLE
fix(pwa): resize logo + add build to CI verify (#203)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       - run: npm run lint
       - run: npm run lint:css
       - run: npm run test
+      - run: npm run build
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x


### PR DESCRIPTION
## Summary
- `src/assets/talrum-logo.png`: 2048×2048 / 4.34 MB → 256×256 / ~50 KB. The only consumer (`Login.tsx`) renders it at 72×72, so 256 is 3.5× — comfortable for retina.
- `.github/workflows/ci.yml`: add `npm run build` after `npm run test` so a broken PWA build can never slip past the merge gate again.

The 4.34 MB asset was over workbox's 2 MiB precache limit, failing `npm run build` on `main`. Verified locally: build is now green, precache is 1.5 MiB across 62 entries.

Closes #203.

## Test plan
- [x] `npm run build` passes locally
- [x] Resized logo renders identically at 72×72 in Login (no visible difference)
- [x] No other consumers of the PNG (only `Login.tsx`; sidebar uses the SVG `TalrumMark`)
- [ ] CI `verify` job now runs `build` step