### PR TITLE
chore: ignore graphify-out/ knowledge graph artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ skills-lock.json
 
 # Git worktrees (isolated workspaces for parallel branches)
 .worktrees/
+
+# Graphify output (local knowledge graph artifacts)
+graphify-out/


### PR DESCRIPTION
## Summary
- Add `graphify-out/` to `.gitignore` so locally-generated knowledge graph artifacts don't get committed.

## Test plan
- [x] `.gitignore` change is the only diff