### PR TITLE
chore(pictograms): delete unused pictogramToInsert helper (#199)

### DIFF
--- a/src/lib/queries/pictograms.mutations.test.ts
+++ b/src/lib/queries/pictograms.mutations.test.ts
@@ -2,12 +2,9 @@ import { QueryClient } from '@tanstack/react-query';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { Pictogram } from '@/types/domain';
-import type { Database } from '@/types/supabase';
 
-import { __test_revokePictogramBlobs, pictogramToInsert } from './pictograms.mutations';
-import { pictogramsQueryKey, rowToPictogram } from './pictograms.read';
-
-type Row = Database['public']['Tables']['pictograms']['Row'];
+import { __test_revokePictogramBlobs } from './pictograms.mutations';
+import { pictogramsQueryKey } from './pictograms.read';
 
 describe('revokePictogramBlobs (#28)', () => {
   // jsdom doesn't ship URL.revokeObjectURL; install a stub so vi.spyOn has
@@ -49,29 +46,5 @@ describe('revokePictogramBlobs (#28)', () => {
     const qc = new QueryClient();
     __test_revokePictogramBlobs(qc);
     expect(revokeSpy).not.toHaveBeenCalled();
-  });
-});
-
-describe('pictogramToInsert round-trip', () => {
-  it('illus → insert → row → domain preserves shape', () => {
-    const original: Pictogram = {
-      id: 'bed',
-      label: 'Out of bed',
-      style: 'illus',
-      glyph: 'bed',
-      tint: 'oklch(88% 0.05 300)',
-    };
-    const insert = pictogramToInsert(original, 'owner-uuid');
-    const row: Row = {
-      ...insert,
-      id: insert.id ?? 'bed',
-      slug: insert.slug ?? null,
-      audio_path: insert.audio_path ?? null,
-      image_path: insert.image_path ?? null,
-      glyph: insert.glyph ?? null,
-      tint: insert.tint ?? null,
-      created_at: '2026-04-24T00:00:00Z',
-    };
-    expect(rowToPictogram(row)).toEqual(original);
   });
 });

--- a/src/lib/queries/pictograms.mutations.ts
+++ b/src/lib/queries/pictograms.mutations.ts
@@ -10,32 +10,6 @@ import { enqueueAndDrain } from '@/lib/outbox';
 import { boardsQueryKey } from '@/lib/queries/boards.read';
 import { pictogramsQueryKey } from '@/lib/queries/pictograms.read';
 import type { Board, Pictogram } from '@/types/domain';
-import type { Database } from '@/types/supabase';
-
-export const pictogramToInsert = (
-  p: Pictogram,
-  ownerId: string,
-): Database['public']['Tables']['pictograms']['Insert'] =>
-  p.style === 'illus'
-    ? {
-        id: p.id,
-        owner_id: ownerId,
-        slug: p.slug ?? null,
-        label: p.label,
-        style: 'illus',
-        glyph: p.glyph,
-        tint: p.tint,
-        audio_path: p.audioPath ?? null,
-      }
-    : {
-        id: p.id,
-        owner_id: ownerId,
-        slug: p.slug ?? null,
-        label: p.label,
-        style: 'photo',
-        image_path: p.imagePath ?? null,
-        audio_path: p.audioPath ?? null,
-      };
 
 const patchPictogramInList = (
   list: Pictogram[] | undefined,


### PR DESCRIPTION
Closes #199 with option 2 (delete).

`pictogramToInsert` had no production callers:
- The only photo INSERT is `handleCreatePhotoPictogram` in `src/lib/outbox/handlers.ts`, which builds the row inline.
- `illus` pictograms are seeded server-side (bedtime seed migration) and never client-inserted — the entire `illus` branch of the helper was dead.
- The only consumer was the round-trip test in `pictograms.mutations.test.ts`, which asserted the correctness of a function that didn't power any write path.

Wiring it in (option 1) would add indirection for one inline insert and leave the illus branch dead anyway.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npx vitest run src/lib/queries/pictograms.mutations.test.ts` — remaining `revokePictogramBlobs` tests still pass