### PR TITLE
ci: auto-deploy to Cloudflare Pages on push to main

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,27 @@
+name: deploy-pages
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+concurrency:
+  group: deploy-pages
+  cancel-in-progress: false
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=talrum --branch=main --commit-hash=${{ github.sha }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/deploy-pages.yml` so every push to `main` builds and ships to Cloudflare Pages automatically. Previously deploys were `wrangler pages deploy dist` run by hand from a local machine — which is exactly how the #218 fix got merged and then sat unshipped for a while because nobody remembered to push the artifact.

The workflow runs `npm ci && npm run build`, which means the verify-build-css guard from #218 still has the final say: any push that doesn't emit a valid styled CSS bundle fails the workflow and never reaches Cloudflare.

## Required setup before merge

Add two repo secrets at https://github.com/nbhansen/Talrum/settings/secrets/actions:

| Secret | Where to get it |
| --- | --- |
| `CLOUDFLARE_API_TOKEN` | Cloudflare dashboard → My Profile → API Tokens → Create Token → "Edit Cloudflare Workers" template, then narrow the Account permission to **Cloudflare Pages → Edit** and Zone to **None** |
| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare dashboard → any zone → right sidebar; or `wrangler whoami` |

Project name is hard-coded as `talrum` in the workflow (matches the existing CF Pages project). If the actual project name differs, change `--project-name=talrum`.

## What this does NOT do

- Doesn't deploy on PR branches. CF Pages preview deployments would be nice eventually, but adding them needs a different permission model (and would build every push to every branch). Out of scope.
- Doesn't replace `ci.yml`. That still runs typecheck/lint/test/build on every PR; this new workflow only runs on `main` and only adds the deploy step.
- Doesn't use path filters. The build is ~30s and the verifier prevents bad ships; adding filters introduces "why didn't it deploy?" surprises.

## Test plan

- [ ] Add the two secrets in repo settings
- [ ] Merge this PR
- [ ] Observe the `deploy-pages` workflow run automatically on the merge commit
- [ ] Confirm new CSS bundle hash on https://talrum.pages.dev/ — it should differ from `index-Bpdjmy0o.css` and the auth screen should render styled
- [ ] Trigger a no-op test: re-run the workflow via `gh workflow run deploy-pages.yml` (the `workflow_dispatch` trigger) and confirm it still passes