### PR TITLE
fix(ci): inject Supabase env into deploy-pages build step

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -20,6 +20,9 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
+        env:
+          VITE_SUPABASE_URL: https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
       - uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary

Prod was throwing `Missing VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY` because the deploy-pages workflow built without those env vars set.

- Inject `VITE_SUPABASE_URL` (composed from existing `SUPABASE_PROJECT_REF` secret)
- Inject `VITE_SUPABASE_ANON_KEY` (new repo secret, just added)

Vite inlines `VITE_*` at build time, not runtime — so missing env at build = broken bundle on every page load.

## Test plan

- [x] Confirmed prod bundle has zero `supabase.co` references (curl + grep)
- [ ] After merge: workflow runs, fresh bundle goes to CF Pages, `https://talrum.pages.dev/` loads without the env error