### PR TITLE
fix(ui): guard Segmented onChange against active-tab clicks (#245)

### DIFF
--- a/src/features/board-builder/BoardBuilder.tsx
+++ b/src/features/board-builder/BoardBuilder.tsx
@@ -151,10 +151,7 @@ export const BoardBuilder = ({
 
       <SettingsRow
         kind={board.kind}
-        onKindChange={(kind) => {
-          if (kind === board.kind) return;
-          setPendingKind(kind);
-        }}
+        onKindChange={setPendingKind}
         labelsVisible={board.labelsVisible}
         onLabelsChange={(visible) => setLabels.mutate({ boardId: board.id, visible })}
         voiceMode={board.voiceMode}

--- a/src/ui/Segmented/Segmented.test.tsx
+++ b/src/ui/Segmented/Segmented.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Segmented } from './Segmented';
+
+const OPTIONS = [
+  { value: 'a' as const, label: 'A' },
+  { value: 'b' as const, label: 'B' },
+];
+
+describe('Segmented', () => {
+  it('fires onChange when an inactive tab is clicked', async () => {
+    const onChange = vi.fn();
+    render(<Segmented value="a" onChange={onChange} options={OPTIONS} />);
+    await userEvent.click(screen.getByRole('tab', { name: 'B' }));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+
+  it('does not fire onChange when the already-active tab is clicked (#245)', async () => {
+    const onChange = vi.fn();
+    render(<Segmented value="a" onChange={onChange} options={OPTIONS} />);
+    await userEvent.click(screen.getByRole('tab', { name: 'A' }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/Segmented/Segmented.tsx
+++ b/src/ui/Segmented/Segmented.tsx
@@ -29,7 +29,10 @@ export const Segmented = <V extends string>({
           role="tab"
           aria-selected={active}
           className={[styles.option, active && styles.active].filter(Boolean).join(' ')}
-          onClick={() => onChange(o.value)}
+          onClick={() => {
+            if (active) return;
+            onChange(o.value);
+          }}
         >
           <span>{o.label}</span>
           {active && o.sub && <span className={styles.sub}>{o.sub}</span>}


### PR DESCRIPTION
## Summary
- Push the "click active tab = no-op" semantics into `Segmented` itself so every consumer doesn't have to remember the guard. Aligns with native HTML radio behavior.
- Remove the now-redundant guard in `BoardBuilder.onKindChange` — the primitive owns the contract.
- Add `Segmented.test.tsx` pinning both branches: inactive tab fires `onChange`, active tab does not.

Audit confirmed `SettingsRow → BoardBuilder` is the only consumer of `Segmented` in the repo, and it already wanted the guard. No telemetry/re-confirm use cases lost.

closes #245

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/ui/Segmented/Segmented.test.tsx src/features/board-builder/BoardBuilder.test.tsx` — 9/9 pass
- [ ] CI verify green