### PR TITLE
refactor(kid-mode): centralise kid-visible copy in src/lib/kidCopy (#241)

### DIFF
--- a/src/features/kid-choice/KidChoice.tsx
+++ b/src/features/kid-choice/KidChoice.tsx
@@ -1,6 +1,7 @@
 import { type JSX, useState } from 'react';
 
 import { KidModeLayout } from '@/layouts/KidModeLayout';
+import { kidCopy } from '@/lib/kidCopy';
 import { usePictogramsById } from '@/lib/queries/pictograms';
 import { speakPictogram } from '@/lib/voiceOut';
 import { accentForIndex, cssVar } from '@/theme/tokens';
@@ -36,7 +37,7 @@ export const KidChoice = ({ board, onExit }: KidChoiceProps): JSX.Element => {
   return (
     <KidModeLayout
       eyebrow={board.name.toUpperCase()}
-      title="Pick one"
+      title={kidCopy.choice.title}
       titleSize="large"
       onExit={onExit}
       logoTint="sky"
@@ -44,7 +45,7 @@ export const KidChoice = ({ board, onExit }: KidChoiceProps): JSX.Element => {
       logoContent={<ChoiceConnectorIcon size={22} />}
     >
       {options.length === 0 ? (
-        <EmptyState title="This board is empty" body="Ask a grown-up to add some pictograms." />
+        <EmptyState title={kidCopy.emptyBoard.title} body={kidCopy.emptyBoard.body} />
       ) : (
         <>
           <div className={styles.choices}>
@@ -102,15 +103,15 @@ export const KidChoice = ({ board, onExit }: KidChoiceProps): JSX.Element => {
                 type="button"
                 className={styles.confirmBtn}
                 onClick={() => speakPicked(pickedPicto)}
-                aria-label={`Hear ${pickedPicto.label} again`}
+                aria-label={kidCopy.choice.hearAgain(pickedPicto.label)}
               >
                 <span className={styles.confirmCheck}>
                   <CheckIcon size={18} />
                 </span>
-                Let&apos;s go to {pickedPicto.label}
+                {kidCopy.choice.letsGoTo(pickedPicto.label)}
               </button>
             ) : (
-              <span className={styles.placeholder}>Tap one to choose ✨</span>
+              <span className={styles.placeholder}>{kidCopy.choice.tapPlaceholder}</span>
             )}
           </div>
         </>

--- a/src/features/kid-sequence/KidSequence.tsx
+++ b/src/features/kid-sequence/KidSequence.tsx
@@ -1,6 +1,7 @@
 import { type JSX, useEffect, useRef, useState } from 'react';
 
 import { KidModeLayout } from '@/layouts/KidModeLayout';
+import { kidCopy } from '@/lib/kidCopy';
 import { useSetStepIds } from '@/lib/queries/boards';
 import { usePictogramsById } from '@/lib/queries/pictograms';
 import { speakPictogram } from '@/lib/voiceOut';
@@ -102,7 +103,7 @@ export const KidSequence = ({ board, onExit }: KidSequenceProps): JSX.Element =>
   return (
     <KidModeLayout eyebrow={board.name.toUpperCase()} title="" onExit={onExit}>
       {steps.length === 0 ? (
-        <EmptyState title="This board is empty" body="Ask a grown-up to add some pictograms." />
+        <EmptyState title={kidCopy.emptyBoard.title} body={kidCopy.emptyBoard.body} />
       ) : (
         <div className={styles.strip}>
           {board.kidReorderable ? (

--- a/src/layouts/KidModeLayout.tsx
+++ b/src/layouts/KidModeLayout.tsx
@@ -1,6 +1,7 @@
 import type { JSX, ReactNode } from 'react';
 
 import { TalrumLogo } from '@/layouts/TalrumLogo';
+import { kidCopy } from '@/lib/kidCopy';
 import type { ColorToken } from '@/theme/tokens';
 import { LockIcon } from '@/ui/icons';
 
@@ -49,7 +50,7 @@ export const KidModeLayout = ({
       </div>
       <button type="button" className={styles.exit} onClick={onExit}>
         <LockIcon size={14} />
-        Exit kid mode
+        {kidCopy.exitButton}
       </button>
     </div>
     <div className={styles.body}>{children}</div>

--- a/src/lib/kidCopy.test.ts
+++ b/src/lib/kidCopy.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { kidCopy } from './kidCopy';
+
+describe('kidCopy', () => {
+  it('interpolates the picked label into the confirm CTA', () => {
+    expect(kidCopy.choice.letsGoTo('Park')).toBe("Let's go to Park");
+  });
+
+  it('interpolates the picked label into the re-speak aria label', () => {
+    expect(kidCopy.choice.hearAgain('Park')).toBe('Hear Park again');
+  });
+});

--- a/src/lib/kidCopy.ts
+++ b/src/lib/kidCopy.ts
@@ -1,0 +1,29 @@
+/**
+ * Single audit point for kid-visible strings. Add new kid-mode copy here
+ * before referencing it from a component. Keep generic chrome (Cancel,
+ * Delete) out — only strings the kid actually sees, plus the PIN flow
+ * that gates kid-mode exit.
+ */
+export const kidCopy = {
+  exitButton: 'Exit kid mode',
+  emptyBoard: {
+    title: 'This board is empty',
+    body: 'Ask a grown-up to add some pictograms.',
+  },
+  choice: {
+    title: 'Pick one',
+    tapPlaceholder: 'Tap one to choose ✨',
+    letsGoTo: (label: string): string => `Let's go to ${label}`,
+    hearAgain: (label: string): string => `Hear ${label} again`,
+  },
+  pin: {
+    verifyTitle: 'Enter PIN to exit',
+    verifySubtitle: 'Enter your 4-digit parent PIN.',
+    setupNewTitle: 'Set a parent PIN',
+    setupNewSubtitle: 'Choose a 4-digit PIN for exiting kid mode.',
+    setupConfirmTitle: 'Confirm your PIN',
+    setupConfirmSubtitle: 'Enter the same 4 digits again.',
+    mismatchError: "PINs don't match",
+    wrongPin: 'Wrong PIN',
+  },
+} as const;

--- a/src/ui/KidModeGate/KidModeGate.tsx
+++ b/src/ui/KidModeGate/KidModeGate.tsx
@@ -1,5 +1,6 @@
 import { type JSX, type ReactNode, useState } from 'react';
 
+import { kidCopy } from '@/lib/kidCopy';
 import { hasPin, pinGateDisabled, setPin, verifyPin } from '@/lib/pin';
 import { Modal } from '@/ui/Modal/Modal';
 
@@ -58,27 +59,28 @@ export const KidModeGate = ({ onExitConfirmed, children }: KidModeGateProps): JS
         <Modal onClose={close}>
           {stage.kind === 'verify' && (
             <PinPad
-              title="Enter PIN to exit"
-              subtitle="Enter your 4-digit parent PIN."
+              title={kidCopy.pin.verifyTitle}
+              subtitle={kidCopy.pin.verifySubtitle}
               onSubmit={handleVerify}
               onCancel={close}
+              errorMessage={kidCopy.pin.wrongPin}
             />
           )}
           {stage.kind === 'setup-new' && (
             <PinPad
-              title="Set a parent PIN"
-              subtitle="Choose a 4-digit PIN for exiting kid mode."
+              title={kidCopy.pin.setupNewTitle}
+              subtitle={kidCopy.pin.setupNewSubtitle}
               onSubmit={handleSetupNew}
               onCancel={close}
             />
           )}
           {stage.kind === 'setup-confirm' && (
             <PinPad
-              title="Confirm your PIN"
-              subtitle="Enter the same 4 digits again."
+              title={kidCopy.pin.setupConfirmTitle}
+              subtitle={kidCopy.pin.setupConfirmSubtitle}
               onSubmit={handleSetupConfirm}
               onCancel={close}
-              errorMessage="PINs don't match"
+              errorMessage={kidCopy.pin.mismatchError}
             />
           )}
         </Modal>


### PR DESCRIPTION
## Summary
- Pull kid-mode literals into `src/lib/kidCopy.ts` — single audit point for "what does the kid actually see?" Mirrors the `boardKindVocab` shape from #236.
- Covers `KidChoice`, `KidSequence`, `KidModeLayout`, `KidModeGate`. Parametrised strings (`letsGoTo`, `hearAgain`) ship as functions.
- PIN flow strings move with the gate. `PinPad`'s internal `"Wrong PIN"` default stays in place (PinPad is generic), but `KidModeGate`'s verify branch now passes the centralised value explicitly so the audit point sees every kid-mode PIN string.
- Generic chrome (`Cancel`, `Delete`) stays inline — not kid-mode-specific.

closes #241

## Audit
Strings now in `kidCopy`:

| Surface | Keys |
|---|---|
| `exitButton` | `Exit kid mode` |
| `emptyBoard.{title,body}` | empty-state copy (shared by KidChoice + KidSequence) |
| `choice.{title,tapPlaceholder,letsGoTo,hearAgain}` | KidChoice |
| `pin.*` | 6 modal strings + mismatch + wrongPin |

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 380/380 pass (existing tests use regex matches + identical values, so no test edits required)
- [x] Added `src/lib/kidCopy.test.ts` pinning the two interpolating helpers
- [ ] CI verify green