### PR TITLE
refactor(theme): tighten Board.accent to AccentBg union (#250)

### DIFF
--- a/src/lib/queries/boards.read.ts
+++ b/src/lib/queries/boards.read.ts
@@ -2,7 +2,7 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 import { formatUpdated } from '@/lib/formatUpdated';
 import { supabase } from '@/lib/supabase';
-import { type ColorToken } from '@/theme/tokens';
+import { type AccentBg } from '@/theme/tokens';
 import type { Board, BoardKind, VoiceMode } from '@/types/domain';
 import type { Database } from '@/types/supabase';
 
@@ -24,7 +24,7 @@ export const rowToBoard = (row: BoardRow): Board => ({
   voiceMode: row.voice_mode as VoiceMode,
   stepIds: [...row.step_ids],
   kidReorderable: row.kid_reorderable,
-  accent: row.accent as ColorToken,
+  accent: row.accent as AccentBg,
   updatedLabel: formatUpdated(row.updated_at),
 });
 

--- a/src/theme/tokens.test.ts
+++ b/src/theme/tokens.test.ts
@@ -35,8 +35,4 @@ describe('inkForAccent', () => {
   ] as const)('maps %s → %s', (bg, ink) => {
     expect(inkForAccent(bg)).toBe(ink);
   });
-
-  it('falls back to the default ink token when the bg is not an accent', () => {
-    expect(inkForAccent('photo-stripe-a')).toBe('ink');
-  });
 });

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -52,8 +52,15 @@ export const shadowVar = (token: ShadowToken): string => `var(--tal-shadow-${tok
 
 export const spaceVar = (token: SpaceToken): string => `var(--tal-space-${token})`;
 
+/**
+ * The 5 accent backgrounds usable on a Board. Narrower than ColorToken so
+ * that callers can't pass non-accent tokens (e.g. `ink`, `photo-stripe-a`)
+ * into accent-typed slots, and so `inkForAccent` can be a total function.
+ */
+export type AccentBg = 'sage' | 'sky' | 'peach' | 'lavender' | 'sun';
+
 export interface Accent {
-  bg: ColorToken;
+  bg: AccentBg;
   ink: ColorToken;
 }
 
@@ -73,10 +80,11 @@ export const accentForIndex = (i: number): Accent => {
   return accent;
 };
 
-/**
- * Look up the ink that pairs with an accent bg. Falls back to the default
- * `ink` token if the bg isn't an accent — keeps UI readable for any
- * out-of-cycle value instead of crashing.
- */
-export const inkForAccent = (bg: ColorToken): ColorToken =>
-  ACCENT_CYCLE.find((a) => a.bg === bg)?.ink ?? 'ink';
+/** Total: every AccentBg is present in ACCENT_CYCLE by construction. */
+export const inkForAccent = (bg: AccentBg): ColorToken => {
+  const accent = ACCENT_CYCLE.find((a) => a.bg === bg);
+  if (!accent) {
+    throw new Error(`inkForAccent: AccentBg '${bg}' missing from ACCENT_CYCLE`);
+  }
+  return accent.ink;
+};

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -1,4 +1,4 @@
-import type { ColorToken } from '@/theme/tokens';
+import type { AccentBg } from '@/theme/tokens';
 
 /**
  * A CSS color expression used for pictogram tile backgrounds. Unlike the
@@ -77,7 +77,7 @@ export interface Board {
    * extra interaction surface.
    */
   kidReorderable: boolean;
-  accent: ColorToken;
+  accent: AccentBg;
   updatedLabel: string;
 }
 


### PR DESCRIPTION
## Summary
- Adds `AccentBg = 'sage' | 'sky' | 'peach' | 'lavender' | 'sun'` and narrows `Accent.bg`, `Board.accent`, and `inkForAccent`'s parameter to it.
- Drops the `?? 'ink'` fallback in `inkForAccent`; bad data now throws at the type boundary (cast in `rowToBoard`) instead of silently degrading the UI.
- Removes the now-unreachable fallback test in `tokens.test.ts`.

Closes #250.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 385 tests pass
- [x] No fixture changes needed; all existing fixtures use one of the 5 accent values