### PR TITLE
ci(verify): require real handler response from function probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,20 +42,27 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY=$(supabase status -o json | jq -r '.SERVICE_ROLE_KEY')
           EOF
           nohup supabase functions serve delete-account --env-file supabase/functions/.env.local &>/tmp/funcs.log &
-          # Wait for the function to start serving. Probe with POST (no auth)
-          # and treat any HTTP response as "up" — the handler returns 401
-          # without auth, but curl -fsS would treat that as failure. We just
-          # want to know the server is accepting connections.
+          # Wait for the function to start serving. POST with no auth: the
+          # handler returns 401 once it's actually serving. 5xx means the
+          # gateway is up but the function isn't — accepting it here lets the
+          # e2e step run against a stalled function and exit non-zero with no
+          # useful diagnostics. Require a 4xx (handler response) instead.
           API_URL="$(supabase status -o json | jq -r '.API_URL')"
+          ready=0
           for i in {1..30}; do
             STATUS=$(curl -sS --max-time 2 -o /dev/null -w '%{http_code}' \
               -X POST -H 'Content-Type: application/json' --data '{}' \
               "$API_URL/functions/v1/delete-account" || echo "000")
-            if [[ "$STATUS" =~ ^[1-5][0-9][0-9]$ ]]; then
-              echo "function ready (HTTP $STATUS)"; break
+            if [[ "$STATUS" =~ ^4[0-9][0-9]$ ]]; then
+              echo "function ready (HTTP $STATUS)"; ready=1; break
             fi
             sleep 1
           done
+          if [[ "$ready" -ne 1 ]]; then
+            echo "function did not become ready within 30s (last HTTP $STATUS)" >&2
+            cat /tmp/funcs.log >&2 || true
+            exit 1
+          fi
       - run: npm run test:e2e:delete-account
       - if: failure()
         name: Dump function logs on failure


### PR DESCRIPTION
## Summary

- Tighten the function-serve readiness probe in `verify` to accept only **4xx** (a real handler response) instead of any 1xx-5xx.
- Fail the step with `funcs.log` dumped if the function never becomes ready within 30s.

## Why

PR #252 hit a CI failure today where the probe logged `function ready (HTTP 502)` and the e2e step then exited non-zero in 0.3s. 502 means the Supabase Edge gateway was up but the function wasn't actually serving yet. The handler returns **401** without auth as soon as it's serving (see `supabase/functions/delete-account/handler.test.ts:" no Authorization header → 401"`), so any 4xx response is the real "function ready" signal — 5xx isn't.

The old loop also silently fell through if it never broke, so the e2e step ran against an unready function with no diagnostic. Now it exits 1 and dumps `funcs.log`.

## Test plan

- [ ] CI green on this PR.
- [ ] Re-run CI on PR #252 / #253 if they're not yet merged — both should remain green.