### PR TITLE
feat(observability): Sentry + telemetry seam for caught errors and silent fallbacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
 VITE_SUPABASE_URL=http://127.0.0.1:54321
 VITE_SUPABASE_ANON_KEY=<paste anon / publishable key from `supabase status`>
+# Sentry DSN — production builds only. Leave unset locally; the SDK no-ops
+# without it. Source-map upload also needs SENTRY_AUTH_TOKEN, SENTRY_ORG,
+# SENTRY_PROJECT at build time (set in deploy-pages.yml from GitHub secrets,
+# never in this file).
+VITE_SENTRY_DSN=

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -23,6 +23,10 @@ jobs:
         env:
           VITE_SUPABASE_URL: https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co
           VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
       - uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ self-hosted Supabase on a VPS is in [docs/self-hosting.md](./docs/self-hosting.m
    - `SUPABASE_ACCESS_TOKEN` (the PAT)
    - `SUPABASE_PROJECT_REF` (the ref)
    - `SUPABASE_DB_PASSWORD` (Postgres password from the dashboard)
+   - `VITE_SENTRY_DSN` (Sentry project DSN; build embeds it in the prod bundle)
+   - `SENTRY_AUTH_TOKEN` (Sentry org auth token with `project:releases` scope)
+   - `SENTRY_ORG` / `SENTRY_PROJECT` (org slug + project slug for source-map upload)
 4. In Cloudflare Pages, connect the repo with build command `npm run build`,
    output directory `dist`, production branch `main`. Add build env vars
    `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` (see
@@ -161,6 +164,19 @@ merge to `main`.
 - Schema: revert the migration commit; CI applies the revert. Destructive
   migrations need a forward-only undo migration — Postgres has no built-in
   rollback for already-applied DDL.
+
+**Observability**
+
+Production builds report errors to Sentry via `src/lib/telemetry.ts`. Dev
+builds and any build missing `VITE_SENTRY_DSN` no-op silently. Posture:
+
+- `sendDefaultPii: false`, no session replay, no traces — errors only.
+- `beforeSend` drops `event.user.email` and strips breadcrumb messages
+  longer than 120 chars (board names + pictogram labels are short; the cap
+  catches long user-content leaks without scrubbing legit stack frames).
+- Source maps are uploaded to Sentry during the CF Pages build and deleted
+  from `dist/` before deploy, so unminified traces appear in the Sentry
+  dashboard but `.map` files are never served from Pages.
 
 ## Conventions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@fontsource-variable/nunito": "^5.1.1",
+        "@sentry/react": "^10.53.1",
         "@supabase/supabase-js": "^2.104.1",
         "@tanstack/query-async-storage-persister": "^5.100.1",
         "@tanstack/react-query": "^5.100.1",
@@ -24,6 +25,7 @@
         "ulid": "^3.0.2"
       },
       "devDependencies": {
+        "@sentry/vite-plugin": "^5.3.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",
@@ -3947,6 +3949,354 @@
         "win32"
       ]
     },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.53.1.tgz",
+      "integrity": "sha512-X4d6y8sBMjmNhcDW4eMBU3ASsNIMz8dqaFkhyIMN/dkYr/yZKnbRZPaVuVUGvHKjnlficPpIH0/HK9KBjrYxPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.53.1.tgz",
+      "integrity": "sha512-vVpTI/aEYN5d9IgZeYJWMqVaN0+iFgidSrYNAsZTh1US5sJUzF/wrl+68KdpmCtFROrN3jiAn1oPSwL5CKvEJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.53.1.tgz",
+      "integrity": "sha512-wZNzTBYkgGUPWMuUQv7L64+OJmoCnz7GQNiTrTFK6EVAjJXFBCSsPp/nhif0bLhbk8+0g4xz633uOhpXuQbFdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.53.1",
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.53.1.tgz",
+      "integrity": "sha512-aueLaf/2prExwA76BGU5/bOXCKWqtt6jQXWA6WJQNrmKpPEtZJB4ypnpsou0McXQCF8tur2Y8U0TEkwQP13yJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.53.1",
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/babel-plugin-component-annotate": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-5.3.0.tgz",
+      "integrity": "sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.53.1.tgz",
+      "integrity": "sha512-zXF373hzUOGzUOrqd8xb1U3LQi5uYC3mwv+z5OMKUUinQlu30tTWBs7ypy6YTchtix9QlYaHWlayUF8vBZ5UjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.53.1",
+        "@sentry-internal/feedback": "10.53.1",
+        "@sentry-internal/replay": "10.53.1",
+        "@sentry-internal/replay-canvas": "10.53.1",
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-5.3.0.tgz",
+      "integrity": "sha512-L5T60sWdAI3qWwdg3Ptwek/0TY59PERrxyqp4XMUkroayQvGd9r5dIW9Q1kSeXX9iJ442nXbFZKAOyCKV4Z13Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.18.5",
+        "@sentry/babel-plugin-component-annotate": "5.3.0",
+        "@sentry/cli": "^2.58.5",
+        "dotenv": "^16.3.1",
+        "find-up": "^5.0.0",
+        "glob": "^13.0.6",
+        "magic-string": "~0.30.8"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.5.tgz",
+      "integrity": "sha512-tavJ7yGUZV+z3Ct2/ZB6mg339i08sAk6HDkgqmSRuQEu2iLS5sl9HIvuXfM6xjv8fwlgFOSy++WNABNAcGHUbg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "FSL-1.1-MIT",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.58.5",
+        "@sentry/cli-linux-arm": "2.58.5",
+        "@sentry/cli-linux-arm64": "2.58.5",
+        "@sentry/cli-linux-i686": "2.58.5",
+        "@sentry/cli-linux-x64": "2.58.5",
+        "@sentry/cli-win32-arm64": "2.58.5",
+        "@sentry/cli-win32-i686": "2.58.5",
+        "@sentry/cli-win32-x64": "2.58.5"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.5.tgz",
+      "integrity": "sha512-lYrNzenZFJftfwSya7gwrHGxtE+Kob/e1sr9lmHMFOd4utDlmq0XFDllmdZAMf21fxcPRI1GL28ejZ3bId01fQ==",
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.5.tgz",
+      "integrity": "sha512-KtHweSIomYL4WVDrBrYSYJricKAAzxUgX86kc6OnlikbyOhoK6Fy8Vs6vwd52P6dvWPjgrMpUYjW2M5pYXQDUw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.5.tgz",
+      "integrity": "sha512-/4gywFeBqRB6tR/iGMRAJ3HRqY6Z7Yp4l8ZCbl0TDLAfHNxu7schEw4tSnm2/Hh9eNMiOVy4z58uzAWlZXAYBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.5.tgz",
+      "integrity": "sha512-G7261dkmyxqlMdyvyP06b+RTIVzp1gZNgglj5UksxSouSUqRd/46W/2pQeOMPhloDYo9yLtCN2YFb3Mw4aUsWw==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.5.tgz",
+      "integrity": "sha512-rP04494RSmt86xChkQ+ecBNRYSPbyXc4u0IA7R7N1pSLCyO74e5w5Al+LnAq35cMfVbZgz5Sm0iGLjyiUu4I1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.5.tgz",
+      "integrity": "sha512-AOJ2nCXlQL1KBaCzv38m3i2VmSHNurUpm7xVKd6yAHX+ZoVBI8VT0EgvwmtJR2TY2N2hNCC7UrgRmdUsQ152bA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.5.tgz",
+      "integrity": "sha512-EsuboLSOnlrN7MMPJ1eFvfMDm+BnzOaSWl8eYhNo8W/BIrmNgpRUdBwnWn9Q2UOjJj5ZopukmsiMYtU/D7ml9g==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.5.tgz",
+      "integrity": "sha512-IZf+XIMiQwj+5NzqbOQfywlOitmCV424Vtf9c+ep61AaVScUFD1TSrQbOcJJv5xGxhlxNOMNgMeZhdexdzrKZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.53.1.tgz",
+      "integrity": "sha512-XG4ezlkyuAPjBC5+9kXC94rXXuqYTw9NRhfaDHssbTFaGnqBR8vQX2UUgZfY7ucbeelRDGfBu1sywoU+mB04uA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.53.1.tgz",
+      "integrity": "sha512-lrwNq5T/zW84l60894TpKHPcvFuc1I/Hnohecc0TfYVpIcYYuw2orCHoU4v4wgkFaJUpegVetbgdOphViyLVjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.53.1",
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/rollup-plugin": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/rollup-plugin/-/rollup-plugin-5.3.0.tgz",
+      "integrity": "sha512-hgPGPYdQJ/G1cGYOxAb7d4z3V+/k/E5/P/5TFPEEBLuIbFFk+JG0CISUDJdzXJjO382Lb99PBJuXGbueBmO79w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/bundler-plugin-core": "5.3.0",
+        "magic-string": "~0.30.8"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "rollup": ">=3.2.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/vite-plugin": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-5.3.0.tgz",
+      "integrity": "sha512-qcoSzo4n2MulVQ70UUPLq6dTleb2a2HwL2wuwvAgWhPChrYTuk6A6mDg6aQb9fairPAwFPiU9PzOANpoDJcz1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/bundler-plugin-core": "5.3.0",
+        "@sentry/rollup-plugin": "5.3.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
@@ -4827,6 +5177,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -5809,6 +6172,19 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -7180,6 +7556,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/husky": {
@@ -9080,6 +9470,52 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.38",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
@@ -9549,6 +9985,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -9558,6 +10004,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/nunito": "^5.1.1",
+    "@sentry/react": "^10.53.1",
     "@supabase/supabase-js": "^2.104.1",
     "@tanstack/query-async-storage-persister": "^5.100.1",
     "@tanstack/react-query": "^5.100.1",
@@ -49,6 +50,7 @@
     "ulid": "^3.0.2"
   },
   "devDependencies": {
+    "@sentry/vite-plugin": "^5.3.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",

--- a/src/app/AuthGate.test.tsx
+++ b/src/app/AuthGate.test.tsx
@@ -40,10 +40,8 @@ vi.mock('@/lib/supabase', () => ({
   },
 }));
 
-// Real clearPersistedCache fans out into PIN + last-board localStorage clears
-// that several tests below assert on. Default the mock to the real impl, then
-// let individual tests override it (e.g. to make it reject so we can prove the
-// telemetry path fires).
+// Default the mock to the real impl so the PIN/last-board localStorage tests
+// below keep working; individual tests override with mockRejectedValueOnce.
 vi.mock('@/lib/queryClient', async (importOriginal) => {
   const actual = (await importOriginal()) as { clearPersistedCache: () => Promise<void> } & Record<
     string,

--- a/src/app/AuthGate.test.tsx
+++ b/src/app/AuthGate.test.tsx
@@ -12,6 +12,9 @@ const onAuthStateChangeMock = vi.fn((listener: AuthChangeListener) => {
   return { data: { subscription: { unsubscribe: vi.fn() } } };
 });
 
+const clearPersistedCacheMock = vi.fn<() => Promise<void>>();
+const captureExceptionMock = vi.fn();
+
 const makeSession = (id: string, email: string): Session =>
   ({
     access_token: `token-${id}`,
@@ -37,6 +40,26 @@ vi.mock('@/lib/supabase', () => ({
   },
 }));
 
+// Real clearPersistedCache fans out into PIN + last-board localStorage clears
+// that several tests below assert on. Default the mock to the real impl, then
+// let individual tests override it (e.g. to make it reject so we can prove the
+// telemetry path fires).
+vi.mock('@/lib/queryClient', async (importOriginal) => {
+  const actual = (await importOriginal()) as { clearPersistedCache: () => Promise<void> } & Record<
+    string,
+    unknown
+  >;
+  clearPersistedCacheMock.mockImplementation(actual.clearPersistedCache);
+  return {
+    ...actual,
+    clearPersistedCache: () => clearPersistedCacheMock(),
+  };
+});
+
+vi.mock('@/lib/telemetry', () => ({
+  captureException: (...args: unknown[]) => captureExceptionMock(...args),
+}));
+
 vi.mock('@/features/login/Login', () => ({
   Login: (): JSX.Element => <div>login screen</div>,
 }));
@@ -49,6 +72,8 @@ const UserIdProbe = (): JSX.Element => <div data-testid="probe-user-id">{useSess
 afterEach(() => {
   getSessionMock.mockReset();
   onAuthStateChangeMock.mockClear();
+  clearPersistedCacheMock.mockClear();
+  captureExceptionMock.mockReset();
   window.localStorage.clear();
 });
 
@@ -328,6 +353,38 @@ describe('AuthGate', () => {
     // without ever actually waiting).
     expect(localStorage.getItem('talrum:pin-hash')).toBe('should-survive-refresh');
     expect(localStorage.getItem('talrum:last-board')).toBe('{"id":"keep","kind":"sequence"}');
+  });
+
+  // #142: clearPersistedCache is fired-and-forgotten on auth boundaries — the
+  // UX is best-effort and we never block sign-out on it. Used to swallow the
+  // rejection silently; now reports a warning to telemetry so persistent IDB
+  // failures don't stay invisible.
+  it('captures a warning when clearPersistedCache rejects on SIGNED_OUT (#142)', async () => {
+    const cacheError = new Error('idb wedged');
+    clearPersistedCacheMock.mockRejectedValueOnce(cacheError);
+    const sessionA = makeSession('user-a-id', 'a@example.com');
+    getSessionMock.mockResolvedValueOnce({ data: { session: sessionA } });
+    render(
+      <AuthGate>
+        <div data-testid="app-body">app</div>
+      </AuthGate>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('app-body')).toBeInTheDocument();
+    });
+    act(() => {
+      lastAuthListener?.('SIGNED_OUT', null);
+    });
+    await waitFor(() => {
+      expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    });
+    const [err, ctx] = captureExceptionMock.mock.calls[0] as [
+      unknown,
+      { level?: string; tags?: Record<string, string> },
+    ];
+    expect(err).toBe(cacheError);
+    expect(ctx.level).toBe('warning');
+    expect(ctx.tags).toMatchObject({ component: 'AuthGate', op: 'clearPersistedCache' });
   });
 
   // #184: switching VITE_SUPABASE_URL leaves the previous project's

--- a/src/app/AuthGate.tsx
+++ b/src/app/AuthGate.tsx
@@ -5,6 +5,7 @@ import { Login } from '@/features/login/Login';
 import { sweepStaleAuthTokens } from '@/lib/auth/sweepStaleAuthTokens';
 import { clearPersistedCache } from '@/lib/queryClient';
 import { supabase } from '@/lib/supabase';
+import { captureException } from '@/lib/telemetry';
 import { useOnline } from '@/lib/useOnline';
 import { Spinner } from '@/ui/Spinner/Spinner';
 
@@ -62,7 +63,12 @@ export const AuthGate = ({ children }: { children: ReactNode }): JSX.Element => 
       const isUserSwitch =
         newUserId !== null && lastUserIdRef.current !== null && newUserId !== lastUserIdRef.current;
       if (event === 'SIGNED_OUT' || isUserSwitch) {
-        void clearPersistedCache();
+        clearPersistedCache().catch((err: unknown) =>
+          captureException(err, {
+            level: 'warning',
+            tags: { component: 'AuthGate', op: 'clearPersistedCache' },
+          }),
+        );
       }
       lastUserIdRef.current = newUserId;
       setState(session ? { status: 'in', session } : { status: 'out' });

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -6,9 +6,11 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { startOutbox } from '@/lib/outbox';
+import { initTelemetry } from '@/lib/telemetry';
 
 import { App } from './App';
 
+initTelemetry();
 startOutbox();
 
 const root = document.getElementById('root');

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -15,8 +15,14 @@ const fromMock = vi.fn((_bucket: string) => ({
   createSignedUrl: createSignedUrlMock,
 }));
 
+const captureExceptionMock = vi.fn();
+
 vi.mock('@/lib/supabase', () => ({
   supabase: { storage: { from: (bucket: string) => fromMock(bucket) } },
+}));
+
+vi.mock('@/lib/telemetry', () => ({
+  captureException: (...args: unknown[]) => captureExceptionMock(...args),
 }));
 
 const { signedUrlFor } = await import('./storage');
@@ -25,6 +31,7 @@ const { signedUrlFor } = await import('./storage');
 // vitest.setup.ts (#144) — only the per-test mock counter needs resetting here.
 beforeEach(() => {
   createSignedUrlMock.mockReset();
+  captureExceptionMock.mockReset();
 });
 
 describe('signedUrlFor', () => {
@@ -67,5 +74,28 @@ describe('signedUrlFor', () => {
     const { signedUrlFor: signedUrlForFresh } = await import('./storage');
     const recovered = await signedUrlForFresh('pictogram-images', 'a/test.jpg');
     expect(recovered).toBe('https://example.test/old?token=old');
+  });
+
+  // #142: persistent mint failures used to be invisible — the catch returned
+  // the stale URL and dropped the error. Now they're captured as warnings so
+  // Sentry can show an aggregate signal while the UX stays offline-tolerant.
+  it('captures a warning when minting fails, even if a fallback is returned (#142)', async () => {
+    await set('signed-url:pictogram-images/a/test.jpg', {
+      url: 'https://example.test/old?token=old',
+      expiresAt: Date.now() - 1000,
+    });
+    vi.resetModules();
+    const mintError = new Error('offline');
+    createSignedUrlMock.mockRejectedValueOnce(mintError);
+    const { signedUrlFor: signedUrlForFresh } = await import('./storage');
+    await signedUrlForFresh('pictogram-images', 'a/test.jpg');
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    const [err, ctx] = captureExceptionMock.mock.calls[0] as [
+      unknown,
+      { level?: string; tags?: Record<string, string> },
+    ];
+    expect(err).toBe(mintError);
+    expect(ctx.level).toBe('warning');
+    expect(ctx.tags).toMatchObject({ component: 'storage', op: 'signedUrlFor' });
   });
 });

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -2,6 +2,7 @@ import { del, get, set } from 'idb-keyval';
 
 import { type SignedUrlEntry, signedUrlMemCache as memCache } from './storage-cache';
 import { supabase } from './supabase';
+import { captureException } from './telemetry';
 
 export const AUDIO_BUCKET = 'pictogram-audio';
 export const IMAGES_BUCKET = 'pictogram-images';
@@ -87,6 +88,10 @@ export const signedUrlFor = async (bucket: string, path: string): Promise<string
     void writePersisted(cacheKey, entry);
     return data.signedUrl;
   } catch (err) {
+    captureException(err, {
+      level: 'warning',
+      tags: { component: 'storage', op: 'signedUrlFor' },
+    });
     const fallback = memCache.get(cacheKey) ?? (await readPersisted(cacheKey));
     if (fallback) return fallback.url;
     throw err;

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,0 +1,53 @@
+import * as Sentry from '@sentry/react';
+
+type CaptureContext = Parameters<typeof Sentry.captureException>[1];
+
+let initialized = false;
+
+/**
+ * Initialize Sentry once, before React mounts, when running a production build
+ * with a DSN configured. Dev builds and unwired environments leave Sentry
+ * inert; the `captureException` / `captureMessage` exports below no-op so
+ * callers don't need their own gate.
+ *
+ * PII posture (intentional):
+ *   - sendDefaultPii: false (no IP, no cookies, no headers).
+ *   - tracesSampleRate: 0 (errors only — no performance/transaction data).
+ *   - No session-replay integration.
+ *   - beforeSend strips event.user.email and any breadcrumb message longer
+ *     than 120 chars. Board names and pictogram labels are short; the cap
+ *     catches accidental long user-content leaks (e.g. error.message echoing
+ *     a stack frame that captured a closure value) without scrubbing real
+ *     stack content.
+ */
+export const initTelemetry = (): void => {
+  if (initialized) return;
+  const dsn = import.meta.env.VITE_SENTRY_DSN;
+  if (!import.meta.env.PROD || !dsn) return;
+  Sentry.init({
+    dsn,
+    release: __APP_VERSION__,
+    sendDefaultPii: false,
+    tracesSampleRate: 0,
+    beforeSend(event) {
+      if (event.user?.email) delete event.user.email;
+      if (event.breadcrumbs) {
+        event.breadcrumbs = event.breadcrumbs.map((b) =>
+          b.message && b.message.length > 120 ? { ...b, message: '[stripped]' } : b,
+        );
+      }
+      return event;
+    },
+  });
+  initialized = true;
+};
+
+export const captureException = (err: unknown, ctx?: CaptureContext): void => {
+  if (!initialized) return;
+  Sentry.captureException(err, ctx);
+};
+
+export const captureMessage = (msg: string, ctx?: CaptureContext): void => {
+  if (!initialized) return;
+  Sentry.captureMessage(msg, ctx);
+};

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -2,14 +2,7 @@ import * as Sentry from '@sentry/react';
 
 type CaptureContext = Parameters<typeof Sentry.captureException>[1];
 
-let initialized = false;
-
 /**
- * Initialize Sentry once, before React mounts, when running a production build
- * with a DSN configured. Dev builds and unwired environments leave Sentry
- * inert; the `captureException` / `captureMessage` exports below no-op so
- * callers don't need their own gate.
- *
  * PII posture (intentional):
  *   - sendDefaultPii: false (no IP, no cookies, no headers).
  *   - tracesSampleRate: 0 (errors only — no performance/transaction data).
@@ -21,7 +14,7 @@ let initialized = false;
  *     stack content.
  */
 export const initTelemetry = (): void => {
-  if (initialized) return;
+  if (Sentry.getClient()) return;
   const dsn = import.meta.env.VITE_SENTRY_DSN;
   if (!import.meta.env.PROD || !dsn) return;
   Sentry.init({
@@ -39,15 +32,9 @@ export const initTelemetry = (): void => {
       return event;
     },
   });
-  initialized = true;
 };
 
 export const captureException = (err: unknown, ctx?: CaptureContext): void => {
-  if (!initialized) return;
+  if (!Sentry.getClient()) return;
   Sentry.captureException(err, ctx);
-};
-
-export const captureMessage = (msg: string, ctx?: CaptureContext): void => {
-  if (!initialized) return;
-  Sentry.captureMessage(msg, ctx);
 };

--- a/src/ui/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/ui/ErrorBoundary/ErrorBoundary.test.tsx
@@ -2,7 +2,12 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { type JSX, useState } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ErrorBoundary } from './ErrorBoundary';
+const captureExceptionMock = vi.fn();
+vi.mock('@/lib/telemetry', () => ({
+  captureException: (...args: unknown[]) => captureExceptionMock(...args),
+}));
+
+const { ErrorBoundary } = await import('./ErrorBoundary');
 
 const Boom = ({ msg = 'boom' }: { msg?: string }): JSX.Element => {
   throw new Error(msg);
@@ -14,6 +19,7 @@ describe('ErrorBoundary', () => {
   let errSpy: ReturnType<typeof vi.spyOn>;
   beforeEach(() => {
     errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    captureExceptionMock.mockReset();
   });
   afterEach(() => {
     errSpy.mockRestore();
@@ -36,6 +42,21 @@ describe('ErrorBoundary', () => {
       </ErrorBoundary>,
     );
     expect(screen.getByText('fallback')).toBeInTheDocument();
+  });
+
+  it('forwards the caught error and component stack to telemetry (#45)', () => {
+    render(
+      <ErrorBoundary fallback={() => <span>fallback</span>}>
+        <Boom msg="telemetry-target" />
+      </ErrorBoundary>,
+    );
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    const [err, ctx] = captureExceptionMock.mock.calls[0] as [Error, { contexts?: unknown }];
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe('telemetry-target');
+    expect(ctx).toMatchObject({
+      contexts: { react: { componentStack: expect.any(String) } },
+    });
   });
 
   it('clears error state when reset() is called from the fallback', () => {

--- a/src/ui/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/ui/ErrorBoundary/ErrorBoundary.tsx
@@ -1,4 +1,6 @@
-import { Component, type ReactNode } from 'react';
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+import { captureException } from '@/lib/telemetry';
 
 interface Props {
   children: ReactNode;
@@ -13,15 +15,20 @@ interface State {
  * The only class component in the repo — React's error-boundary API is
  * class-only. Catches render-time exceptions in the descendant subtree and
  * hands the consumer a `reset()` so the fallback can clear the error and
- * retry. When #45 (production error tracking) lands, add
- * `componentDidCatch(error, info)` here to forward to Sentry; until then
- * React's own dev-mode console.error is the only signal we get.
+ * retry. Forwards the caught error to Sentry via `captureException` with
+ * the React component stack as context (#45, #142).
  */
 export class ErrorBoundary extends Component<Props, State> {
   override state: State = { error: null };
 
   static getDerivedStateFromError(error: Error): State {
     return { error };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    captureException(error, {
+      contexts: { react: { componentStack: info.componentStack ?? '' } },
+    });
   }
 
   reset = (): void => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,31 @@
 import { fileURLToPath, URL } from 'node:url';
 
+import { sentryVitePlugin } from '@sentry/vite-plugin';
 import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
 import { defineConfig } from 'vitest/config';
 
 import pkg from './package.json' with { type: 'json' };
+
+// Source-map upload to Sentry. Disabled (plugin omitted) unless SENTRY_AUTH_TOKEN
+// is set — keeps local dev and CI's verify-job build identical to today. Maps
+// are emitted into dist/, uploaded to Sentry for unminified stack traces, then
+// deleted by the plugin so CF Pages never serves them publicly. The
+// `build.sourcemap` flag below is gated on the same condition so a deploy
+// without the token doesn't emit maps at all — otherwise CF Pages would
+// publish them with no upload-and-delete step to clean up.
+const sentryEnabled = Boolean(process.env.SENTRY_AUTH_TOKEN);
+const sentryPlugins = sentryEnabled
+  ? [
+      sentryVitePlugin({
+        org: process.env.SENTRY_ORG,
+        project: process.env.SENTRY_PROJECT,
+        authToken: process.env.SENTRY_AUTH_TOKEN,
+        release: { name: pkg.version },
+        sourcemaps: { filesToDeleteAfterUpload: ['./dist/**/*.map'] },
+      }),
+    ]
+  : [];
 
 export default defineConfig({
   plugins: [
@@ -70,7 +91,14 @@ export default defineConfig({
         enabled: false,
       },
     }),
+    ...sentryPlugins,
   ],
+  build: {
+    // Only emit maps when the Sentry plugin is active to upload-and-delete
+    // them. Otherwise a deploy without the token would leak unminified source
+    // via the `.map` files served by CF Pages.
+    sourcemap: sentryEnabled,
+  },
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,13 +7,9 @@ import { defineConfig } from 'vitest/config';
 
 import pkg from './package.json' with { type: 'json' };
 
-// Source-map upload to Sentry. Disabled (plugin omitted) unless SENTRY_AUTH_TOKEN
-// is set — keeps local dev and CI's verify-job build identical to today. Maps
-// are emitted into dist/, uploaded to Sentry for unminified stack traces, then
-// deleted by the plugin so CF Pages never serves them publicly. The
-// `build.sourcemap` flag below is gated on the same condition so a deploy
-// without the token doesn't emit maps at all — otherwise CF Pages would
-// publish them with no upload-and-delete step to clean up.
+// Emit + upload + delete source maps in one flag, gated on the Sentry auth
+// token. Any path that emits maps must upload-and-delete them — otherwise
+// CF Pages publishes the unminified bundles as `.map` siblings.
 const sentryEnabled = Boolean(process.env.SENTRY_AUTH_TOKEN);
 const sentryPlugins = sentryEnabled
   ? [
@@ -57,6 +53,11 @@ export default defineConfig({
         globPatterns: ['**/*.{js,css,html,woff2,png,svg,ico,jpg}'],
         navigateFallback: '/index.html',
         cleanupOutdatedCaches: true,
+        // Workbox emits sw.js.map + workbox-*.js.map in its closeBundle hook,
+        // which runs AFTER Sentry's filesToDeleteAfterUpload glob. Without
+        // this flag those maps would survive to CF Pages even with Sentry
+        // enabled, leaking unminified SW glue.
+        sourcemap: false,
         // Every new deploy: install → skip "waiting" → claim open tabs → next
         // navigation serves the fresh bundle. Without these, users sit on a
         // stale precache until they manually click "Reload" or close every tab.
@@ -94,9 +95,6 @@ export default defineConfig({
     ...sentryPlugins,
   ],
   build: {
-    // Only emit maps when the Sentry plugin is active to upload-and-delete
-    // them. Otherwise a deploy without the token would leak unminified source
-    // via the `.map` files served by CF Pages.
     sourcemap: sentryEnabled,
   },
   define: {


### PR DESCRIPTION
## Summary

- Adds `src/lib/telemetry.ts` — thin wrapper around `@sentry/react` (`initTelemetry`, `captureException`, `captureMessage`). Init gated on `import.meta.env.PROD && VITE_SENTRY_DSN`; the capture exports no-op when not initialized, so dev builds and unwired environments stay inert with no caller-side gating.
- Wires three real signals: `ErrorBoundary.componentDidCatch` forwards the error + React component stack; `AuthGate` replaces `void clearPersistedCache()` with a `.catch` that reports as a warning; `storage.signedUrlFor` captures mint failures as warnings before returning the stale fallback URL.
- Source-map upload via `@sentry/vite-plugin` — gated on `SENTRY_AUTH_TOKEN`. `build.sourcemap` is gated on the same flag so a deploy without the token emits no maps at all (with the token, maps are uploaded then deleted by `filesToDeleteAfterUpload`, so CF Pages never serves `.map` files).
- `deploy-pages.yml` passes `VITE_SENTRY_DSN`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` into the build step. README documents the four secrets and the PII posture.

## PII / privacy posture

`sendDefaultPii: false`, no session replay, `tracesSampleRate: 0`, no autoSessionTracking. `beforeSend` strips `event.user.email` and any breadcrumb message longer than 120 chars (board names + pictogram labels are short; the cap catches long user-content leaks without scrubbing legit stack frames). Documented in README's new Observability subsection.

## Note on #142

`SwUpdatePrompt.tsx` bullet of #142 is obsolete — that file no longer exists (SW registration moved under vite-plugin-pwa `autoUpdate`). The other two sites (`AuthGate.clearPersistedCache` and `storage.signedUrlFor`) are wired.

## User-supplied next step (out of this PR)

Create the four secrets in GitHub repo settings and provision the Sentry project + auth token. Until those secrets are set, CF Pages deploys produce identical artifacts to today (Sentry no-ops, no maps emitted).

Closes #45.
Closes #142.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (zero warnings)
- [x] `npm run lint:css` clean
- [x] `npm run test` — 391 passed, including three new specs (ErrorBoundary forward, AuthGate warning on rejection, storage warning on mint failure)
- [x] `npm run build` succeeds without Sentry envs; no `.map` files emitted into `dist/`
- [ ] Deploy preview verifies map upload + deletion once secrets are set