### PR TITLE
refactor(backend): centralize outbox error handling, dedup error codes

### DIFF
--- a/src/lib/outbox/handlers.test.ts
+++ b/src/lib/outbox/handlers.test.ts
@@ -59,6 +59,11 @@ vi.mock('@/lib/supabase', () => ({
   },
 }));
 
+const captureExceptionMock = vi.fn();
+vi.mock('@/lib/telemetry', () => ({
+  captureException: (err: unknown, ctx?: unknown) => captureExceptionMock(err, ctx),
+}));
+
 const { runHandler, UnretryableOutboxError } = await import('./handlers');
 
 const baseProps = {
@@ -78,6 +83,7 @@ beforeEach(() => {
   deleteMock.mockClear();
   uploadMock.mockReset();
   removeMock.mockReset();
+  captureExceptionMock.mockReset();
   fromMock.mockClear();
   storageFromMock.mockClear();
   // Defaults: every supabase call succeeds.
@@ -232,6 +238,24 @@ describe('runHandler · clearPictoAudio', () => {
     await runHandler(entry);
     expect(removeMock).toHaveBeenCalledWith(['o-1/p-1.webm']);
     expect(updateMock).toHaveBeenCalledWith({ audio_path: null });
+  });
+
+  it('reports a failed file removal to telemetry but still nulls audio_path', async () => {
+    removeMock.mockResolvedValue({ error: new Error('storage offline') });
+    const entry: ClearPictogramAudioEntry = {
+      ...baseProps,
+      kind: 'clearPictoAudio',
+      pictogramId: 'p-1',
+      path: 'o-1/p-1.webm',
+    };
+    await runHandler(entry);
+    // Cleanup failure is swallowed — the row is still updated.
+    expect(updateMock).toHaveBeenCalledWith({ audio_path: null });
+    // ...but the leak is reported, not silent (#255).
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ tags: { component: 'outbox', op: 'storage-cleanup' } }),
+    );
   });
 });
 

--- a/src/lib/outbox/handlers.ts
+++ b/src/lib/outbox/handlers.ts
@@ -7,6 +7,7 @@ import {
   uploadBlob,
 } from '@/lib/storage';
 import { supabase } from '@/lib/supabase';
+import { captureException } from '@/lib/telemetry';
 
 import type {
   ClearPictogramAudioEntry,
@@ -56,172 +57,151 @@ const classifyAndThrow = (err: unknown): never => {
   throw err;
 };
 
+/**
+ * Storage-cleanup removals (old recordings, orphaned upload blobs) are
+ * best-effort: a leaked object is better than failing the user's write, so we
+ * don't propagate the error. But we report it to telemetry so the leak is
+ * observable rather than silent — see #255's silent-fallback seam.
+ */
+const reportCleanupFailure = (err: unknown): void => {
+  captureException(err, {
+    level: 'warning',
+    tags: { component: 'outbox', op: 'storage-cleanup' },
+  });
+};
+
 const handleUpdateBoard = async (entry: UpdateBoardEntry): Promise<void> => {
-  try {
-    const { error } = await supabase.from('boards').update(entry.patch).eq('id', entry.boardId);
-    if (error) throw error;
-  } catch (err) {
-    classifyAndThrow(err);
-  }
+  const { error } = await supabase.from('boards').update(entry.patch).eq('id', entry.boardId);
+  if (error) throw error;
 };
 
 const handleCreatePhotoPictogram = async (entry: CreatePhotoPictogramEntry): Promise<void> => {
   const path = `${entry.ownerId}/${entry.pictogramId}.${entry.extension}`;
-  try {
-    await uploadBlob(IMAGES_BUCKET, path, entry.blob);
-    invalidateSignedUrl(IMAGES_BUCKET, path);
-    const { error } = await supabase.from('pictograms').insert({
-      id: entry.pictogramId,
-      owner_id: entry.ownerId,
-      label: entry.label,
-      style: 'photo',
-      image_path: path,
-    });
-    if (error) {
-      // Insert failed after upload — clean up the blob so we don't leak.
-      await removeFromBucket(IMAGES_BUCKET, [path]).catch(() => undefined);
-      throw error;
-    }
-  } catch (err) {
-    classifyAndThrow(err);
+  await uploadBlob(IMAGES_BUCKET, path, entry.blob);
+  invalidateSignedUrl(IMAGES_BUCKET, path);
+  const { error } = await supabase.from('pictograms').insert({
+    id: entry.pictogramId,
+    owner_id: entry.ownerId,
+    label: entry.label,
+    style: 'photo',
+    image_path: path,
+  });
+  if (error) {
+    // Insert failed after upload — clean up the blob so we don't leak.
+    await removeFromBucket(IMAGES_BUCKET, [path]).catch(reportCleanupFailure);
+    throw error;
   }
 };
 
 const handleSetPictogramAudio = async (entry: SetPictogramAudioEntry): Promise<void> => {
   const path = `${entry.ownerId}/${entry.pictogramId}.${entry.extension}`;
-  try {
-    await uploadBlob(AUDIO_BUCKET, path, entry.blob);
-    invalidateSignedUrl(AUDIO_BUCKET, path);
-    const { error } = await supabase
-      .from('pictograms')
-      .update({ audio_path: path })
-      .eq('id', entry.pictogramId);
-    if (error) throw error;
-    if (entry.previousPath && entry.previousPath !== path) {
-      await removeFromBucket(AUDIO_BUCKET, [entry.previousPath]).catch(() => undefined);
-      invalidateSignedUrl(AUDIO_BUCKET, entry.previousPath);
-    }
-  } catch (err) {
-    classifyAndThrow(err);
+  await uploadBlob(AUDIO_BUCKET, path, entry.blob);
+  invalidateSignedUrl(AUDIO_BUCKET, path);
+  const { error } = await supabase
+    .from('pictograms')
+    .update({ audio_path: path })
+    .eq('id', entry.pictogramId);
+  if (error) throw error;
+  if (entry.previousPath && entry.previousPath !== path) {
+    await removeFromBucket(AUDIO_BUCKET, [entry.previousPath]).catch(reportCleanupFailure);
+    invalidateSignedUrl(AUDIO_BUCKET, entry.previousPath);
   }
 };
 
 const handleClearPictogramAudio = async (entry: ClearPictogramAudioEntry): Promise<void> => {
-  try {
-    await removeFromBucket(AUDIO_BUCKET, [entry.path]).catch(() => undefined);
-    invalidateSignedUrl(AUDIO_BUCKET, entry.path);
-    const { error } = await supabase
-      .from('pictograms')
-      .update({ audio_path: null })
-      .eq('id', entry.pictogramId);
-    if (error) throw error;
-  } catch (err) {
-    classifyAndThrow(err);
-  }
+  await removeFromBucket(AUDIO_BUCKET, [entry.path]).catch(reportCleanupFailure);
+  invalidateSignedUrl(AUDIO_BUCKET, entry.path);
+  const { error } = await supabase
+    .from('pictograms')
+    .update({ audio_path: null })
+    .eq('id', entry.pictogramId);
+  if (error) throw error;
 };
 
 const handleRenamePictogram = async (entry: RenamePictogramEntry): Promise<void> => {
-  try {
-    const { error } = await supabase
-      .from('pictograms')
-      .update({ label: entry.label })
-      .eq('id', entry.pictogramId);
-    if (error) throw error;
-  } catch (err) {
-    classifyAndThrow(err);
-  }
+  const { error } = await supabase
+    .from('pictograms')
+    .update({ label: entry.label })
+    .eq('id', entry.pictogramId);
+  if (error) throw error;
 };
 
 const handleReplacePictogramImage = async (entry: ReplacePictogramImageEntry): Promise<void> => {
   const path = `${entry.ownerId}/${entry.pictogramId}.${entry.extension}`;
-  try {
-    await uploadBlob(IMAGES_BUCKET, path, entry.blob);
-    invalidateSignedUrl(IMAGES_BUCKET, path);
-    const { error } = await supabase
-      .from('pictograms')
-      .update({ image_path: path })
-      .eq('id', entry.pictogramId);
-    if (error) throw error;
-    if (isUploadedStoragePath(entry.previousPath) && entry.previousPath !== path) {
-      await removeFromBucket(IMAGES_BUCKET, [entry.previousPath]).catch(() => undefined);
-      invalidateSignedUrl(IMAGES_BUCKET, entry.previousPath);
-    }
-  } catch (err) {
-    classifyAndThrow(err);
+  await uploadBlob(IMAGES_BUCKET, path, entry.blob);
+  invalidateSignedUrl(IMAGES_BUCKET, path);
+  const { error } = await supabase
+    .from('pictograms')
+    .update({ image_path: path })
+    .eq('id', entry.pictogramId);
+  if (error) throw error;
+  if (isUploadedStoragePath(entry.previousPath) && entry.previousPath !== path) {
+    await removeFromBucket(IMAGES_BUCKET, [entry.previousPath]).catch(reportCleanupFailure);
+    invalidateSignedUrl(IMAGES_BUCKET, entry.previousPath);
   }
 };
 
 const handleDeletePictogram = async (entry: DeletePictogramEntry): Promise<void> => {
-  try {
-    // Order matters: scrub boards' step_ids → clean up storage → delete the
-    // pictograms row last. step_ids is a uuid[] with no FK, so we have to
-    // strip references manually before the row goes away (otherwise boards
-    // that referenced it keep dangling UUIDs). Storage cleanup runs *before*
-    // the row delete so a transient storage failure throws and the outbox
-    // retries the whole entry — once the row is gone, a retry can't re-derive
-    // which keys to remove. Each step is idempotent on retry: the SELECT
-    // re-reads current step_ids, the UPDATEs are no-ops where already
-    // scrubbed, the storage removes return success on missing keys, and the
-    // final DELETE returns no error if the row is already gone.
-    //
-    // The boards scrub takes one SELECT plus N sequential UPDATE calls (one
-    // per actually-referencing board); idempotent so retries are safe.
-    if (entry.scrubFromBoardIds.length > 0) {
-      const { data: rows, error: readErr } = await supabase
+  // Order matters: scrub boards' step_ids → clean up storage → delete the
+  // pictograms row last. step_ids is a uuid[] with no FK, so we have to
+  // strip references manually before the row goes away (otherwise boards
+  // that referenced it keep dangling UUIDs). Storage cleanup runs *before*
+  // the row delete so a transient storage failure throws and the outbox
+  // retries the whole entry — once the row is gone, a retry can't re-derive
+  // which keys to remove. Each step is idempotent on retry: the SELECT
+  // re-reads current step_ids, the UPDATEs are no-ops where already
+  // scrubbed, the storage removes return success on missing keys, and the
+  // final DELETE returns no error if the row is already gone.
+  //
+  // The boards scrub takes one SELECT plus N sequential UPDATE calls (one
+  // per actually-referencing board); idempotent so retries are safe.
+  if (entry.scrubFromBoardIds.length > 0) {
+    const { data: rows, error: readErr } = await supabase
+      .from('boards')
+      .select('id, step_ids')
+      .in('id', entry.scrubFromBoardIds);
+    if (readErr) throw readErr;
+    for (const row of rows ?? []) {
+      const next = row.step_ids.filter((id: string) => id !== entry.pictogramId);
+      if (next.length === row.step_ids.length) continue;
+      const { error: updErr } = await supabase
         .from('boards')
-        .select('id, step_ids')
-        .in('id', entry.scrubFromBoardIds);
-      if (readErr) throw readErr;
-      for (const row of rows ?? []) {
-        const next = row.step_ids.filter((id: string) => id !== entry.pictogramId);
-        if (next.length === row.step_ids.length) continue;
-        const { error: updErr } = await supabase
-          .from('boards')
-          .update({ step_ids: next })
-          .eq('id', row.id);
-        if (updErr) throw updErr;
-      }
+        .update({ step_ids: next })
+        .eq('id', row.id);
+      if (updErr) throw updErr;
     }
-    if (isUploadedStoragePath(entry.previousImagePath)) {
-      await removeFromBucket(IMAGES_BUCKET, [entry.previousImagePath]);
-      invalidateSignedUrl(IMAGES_BUCKET, entry.previousImagePath);
-    }
-    if (isUploadedStoragePath(entry.previousAudioPath)) {
-      await removeFromBucket(AUDIO_BUCKET, [entry.previousAudioPath]);
-      invalidateSignedUrl(AUDIO_BUCKET, entry.previousAudioPath);
-    }
-    const { error } = await supabase.from('pictograms').delete().eq('id', entry.pictogramId);
-    if (error) throw error;
-  } catch (err) {
-    classifyAndThrow(err);
   }
+  if (isUploadedStoragePath(entry.previousImagePath)) {
+    await removeFromBucket(IMAGES_BUCKET, [entry.previousImagePath]);
+    invalidateSignedUrl(IMAGES_BUCKET, entry.previousImagePath);
+  }
+  if (isUploadedStoragePath(entry.previousAudioPath)) {
+    await removeFromBucket(AUDIO_BUCKET, [entry.previousAudioPath]);
+    invalidateSignedUrl(AUDIO_BUCKET, entry.previousAudioPath);
+  }
+  const { error } = await supabase.from('pictograms').delete().eq('id', entry.pictogramId);
+  if (error) throw error;
 };
 
 const handleRenameKid = async (entry: RenameKidEntry): Promise<void> => {
-  try {
-    const { error } = await supabase
-      .from('kids')
-      .update({ name: entry.name })
-      .eq('id', entry.kidId);
-    if (error) throw error;
-  } catch (err) {
-    classifyAndThrow(err);
-  }
+  const { error } = await supabase.from('kids').update({ name: entry.name }).eq('id', entry.kidId);
+  if (error) throw error;
 };
 
 const handleDeleteKid = async (entry: DeleteKidEntry): Promise<void> => {
-  try {
-    // boards.kid_id ON DELETE CASCADE handles board cleanup server-side.
-    // Pictograms are owner-scoped (not kid-scoped), so they survive — correct
-    // since they're shared across the owner's kids' boards.
-    const { error } = await supabase.from('kids').delete().eq('id', entry.kidId);
-    if (error) throw error;
-  } catch (err) {
-    classifyAndThrow(err);
-  }
+  // boards.kid_id ON DELETE CASCADE handles board cleanup server-side.
+  // Pictograms are owner-scoped (not kid-scoped), so they survive — correct
+  // since they're shared across the owner's kids' boards.
+  const { error } = await supabase.from('kids').delete().eq('id', entry.kidId);
+  if (error) throw error;
 };
 
-export const runHandler = (entry: OutboxEntry): Promise<void> => {
+/**
+ * Routes an entry to its handler. Handlers carry only their happy path; all
+ * error classification is owned by `runHandler` so a new handler can't forget
+ * the wrapper and silently let raw errors through as retry-forever transients.
+ */
+const dispatch = (entry: OutboxEntry): Promise<void> => {
   switch (entry.kind) {
     case 'updateBoard':
       return handleUpdateBoard(entry);
@@ -241,5 +221,13 @@ export const runHandler = (entry: OutboxEntry): Promise<void> => {
       return handleRenameKid(entry);
     case 'deleteKid':
       return handleDeleteKid(entry);
+  }
+};
+
+export const runHandler = async (entry: OutboxEntry): Promise<void> => {
+  try {
+    await dispatch(entry);
+  } catch (err) {
+    classifyAndThrow(err);
   }
 };

--- a/src/lib/queries/account.ts
+++ b/src/lib/queries/account.ts
@@ -21,22 +21,18 @@ const DELETE_ACCOUNT_FUNCTION_NAME = 'delete-account';
 // literal strings. Mirrors `supabase/functions/delete-account/types.ts`
 // byte-for-byte. If the function adds a new code, add it here and update
 // DeleteAccountDialog's toast map.
-export type DeleteAccountErrorCode =
-  | 'unauthorized'
-  | 'method_not_allowed'
-  | 'bad_request'
-  | 'storage_purge_failed'
-  | 'auth_delete_failed'
-  | 'internal_error';
-
-const KNOWN_CODES: ReadonlySet<DeleteAccountErrorCode> = new Set([
+const DELETE_ACCOUNT_ERROR_CODES = [
   'unauthorized',
   'method_not_allowed',
   'bad_request',
   'storage_purge_failed',
   'auth_delete_failed',
   'internal_error',
-]);
+] as const;
+
+export type DeleteAccountErrorCode = (typeof DELETE_ACCOUNT_ERROR_CODES)[number];
+
+const KNOWN_CODES: ReadonlySet<DeleteAccountErrorCode> = new Set(DELETE_ACCOUNT_ERROR_CODES);
 
 export class DeleteAccountError extends Error {
   constructor(


### PR DESCRIPTION
Backend architecture review pass over the outbox write path and the delete-account client. No behavior changes for the user.

## Changes

**`src/lib/outbox/handlers.ts`**
- Lifted the identical `try/catch` out of all nine handlers into `runHandler`, which now wraps a bare `dispatch` switch. A new handler can no longer forget the wrapper and let raw errors escape as retry-forever transients.
- Storage-cleanup removals (orphaned blobs, old recordings) previously swallowed errors with `.catch(() => undefined)`. They now report to the telemetry seam added in #255, so a leaked object is observable instead of silent. Control flow is unchanged — a leak is still preferred over failing the user's write.

**`src/lib/queries/account.ts`**
- `DeleteAccountErrorCode` and `KNOWN_CODES` were the same six strings declared twice; both now derive from one `as const` array.

## Tests
- Added a `handlers.test.ts` case asserting a failed cleanup removal calls `captureException` with the right tags while the row update still succeeds.
- `npm run typecheck`, `npm run lint` clean; full suite 392/392 pass.