### PR TITLE
fix(delete-account): reject malformed Authorization before auth round-trip (#217)

### DIFF
--- a/supabase/functions/delete-account/handler.test.ts
+++ b/supabase/functions/delete-account/handler.test.ts
@@ -45,16 +45,21 @@ Deno.test('handler: valid POST + valid Bearer → 200 { ok: true }', async () =>
   assertEquals(body, { ok: true });
 });
 
-Deno.test('handler: no Authorization header → 401 unauthorized', async () => {
+Deno.test('handler: no Authorization header → 401 without calling admin.auth.getUser', async () => {
   const req = new Request('https://x.invalid/delete-account', { method: 'POST', body: '' });
+  let getUserCalls = 0;
   const admin = makeAdminStub({
-    getUser: async () => ({ data: { user: null }, error: { message: 'no jwt' } }),
+    getUser: async () => {
+      getUserCalls += 1;
+      return { data: { user: null }, error: { message: 'should not be reached' } };
+    },
   });
   const res = await handleRequest(req, admin, noopDelete);
   assertEquals(res.status, 401);
   const body = await res.json();
   assertEquals(body.ok, false);
   assertEquals(body.error, 'unauthorized');
+  assertEquals(getUserCalls, 0);
 });
 
 Deno.test('handler: invalid Bearer → 401 unauthorized', async () => {
@@ -129,30 +134,33 @@ Deno.test('handler: unanticipated error → 500 internal_error', async () => {
   assertEquals(body.error, 'internal_error');
 });
 
-Deno.test(
-  'handler: malformed Authorization (lowercase bearer / missing scheme) → 401 unauthorized',
-  async () => {
-    const cases = [
-      'bearer x.y.z', // wrong case on scheme
-      'x.y.z', // no scheme at all
-      'Basic abc:def', // wrong scheme
-    ];
-    for (const authHeader of cases) {
-      const req = new Request('https://x.invalid/delete-account', {
-        method: 'POST',
-        headers: { Authorization: authHeader },
-        body: '',
-      });
-      const admin = makeAdminStub({
-        getUser: async () => ({ data: { user: null }, error: { message: 'no jwt' } }),
-      });
-      const res = await handleRequest(req, admin, noopDelete);
-      assertEquals(res.status, 401, `auth header: ${authHeader}`);
-      const body = await res.json();
-      assertEquals(body.error, 'unauthorized');
-    }
-  },
-);
+Deno.test('handler: malformed Authorization → 401 without calling admin.auth.getUser', async () => {
+  const cases = [
+    'bearer x.y.z', // wrong case on scheme
+    'x.y.z', // no scheme at all
+    'Basic abc:def', // wrong scheme
+    'Bearer ', // scheme present but empty token
+  ];
+  for (const authHeader of cases) {
+    const req = new Request('https://x.invalid/delete-account', {
+      method: 'POST',
+      headers: { Authorization: authHeader },
+      body: '',
+    });
+    let getUserCalls = 0;
+    const admin = makeAdminStub({
+      getUser: async () => {
+        getUserCalls += 1;
+        return { data: { user: null }, error: { message: 'should not be reached' } };
+      },
+    });
+    const res = await handleRequest(req, admin, noopDelete);
+    assertEquals(res.status, 401, `auth header: ${authHeader}`);
+    const body = await res.json();
+    assertEquals(body.error, 'unauthorized');
+    assertEquals(getUserCalls, 0, `getUser should not be called for header: ${authHeader}`);
+  }
+});
 
 Deno.test('handler: empty {} body is accepted (matches supabase-js invoke shape)', async () => {
   const req = new Request('https://x.invalid/delete-account', {

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -86,8 +86,17 @@ export const handleRequest = async (
       return errorResponse('bad_request', 'request body must be empty or {}', 400);
     }
 
+    // Short-circuit on missing/malformed Authorization before calling
+    // admin.auth.getUser, so unauthenticated spam costs only a header read
+    // (no Supabase auth round-trip, no edge-function quota beyond this).
     const auth = req.headers.get('Authorization') ?? '';
-    const jwt = auth.startsWith('Bearer ') ? auth.slice('Bearer '.length) : undefined;
+    if (!auth.startsWith('Bearer ')) {
+      return errorResponse('unauthorized', 'missing or malformed Authorization header', 401);
+    }
+    const jwt = auth.slice('Bearer '.length);
+    if (jwt.length === 0) {
+      return errorResponse('unauthorized', 'missing or malformed Authorization header', 401);
+    }
     const { data } = await admin.auth.getUser(jwt);
     if (!data.user) {
       return errorResponse('unauthorized', 'missing or invalid JWT', 401);


### PR DESCRIPTION
## Summary
- Short-circuits on missing or malformed \`Authorization\` header (no \`Bearer \` scheme, empty token) **before** calling \`admin.auth.getUser\`, so anonymous spam against the \`delete-account\` edge function costs only a header read — no Supabase auth round-trip, no extra edge-function quota.
- Cheapest variant of #217. Per-user repeat-call limiting and the platform-level options stay as follow-ups.

## Why
Per #217: every request — including unauthenticated ones — currently reads the body and calls \`admin.auth.getUser(jwt)\` before rejecting with 401. A loop can burn Supabase auth quota and edge-function invocations against the free tier without ever holding a valid JWT.

## What changed
- \`supabase/functions/delete-account/index.ts\`: explicit scheme + non-empty token check, returning 401 immediately on failure.
- \`supabase/functions/delete-account/handler.test.ts\`: the no-Authorization and malformed-Authorization tests now assert \`admin.auth.getUser\` is **not** invoked (the whole point of the fix). Added a new malformed case: \`'Bearer '\` (scheme present but empty token).

## Test plan
- [x] \`npm run test:functions\` — 19/19 pass
- [x] \`npm run lint\` clean
- [x] \`npm run typecheck\` clean
- [ ] CI: full \`verify\` job (e2e against running edge function should still pass since valid Bearer flow is unchanged)

## Out of scope (tracked in #217)
- Per-user invocation throttle (\`user_id → last_invocation_at\`)
- Platform-level WAF / Pro-tier rate limiting