### PR TITLE
ci(ai-review): expand reviewer scope to SRP + gated DRY, grant Read/Grep

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -26,7 +26,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --model claude-sonnet-4-6
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Read,Grep"
           prompt: |
             REPO: ${{ github.repository }}
             PR: ${{ github.event.pull_request.number }}
@@ -40,12 +40,16 @@ jobs:
             - Supabase migration syntax / function compile errors
             - Formatting, unused imports, naming-only nits
 
+            ALSO DO NOT FLAG:
+            - SOLID principles beyond SRP. OCP/LSP/ISP/DIP push toward overengineering in a solo Vite+Supabase codebase. Only SRP is in scope (see Architecture below).
+
             YOUR JOB IS THE STUFF CI CANNOT SEE. Focus on:
 
             1. Architecture
-               - A file or function doing too much; leaky abstractions; broken module boundaries.
+               - SRP violations: a function mixing IO, business logic, and presentation; a module owning unrelated concerns; leaky abstractions across boundaries.
                - Drive-by refactors unrelated to the PR's stated purpose — flag and ask to revert per the project's "surgical changes" rule.
                - New abstractions / configurability / hooks added "for future extensibility" with no current consumer.
+               - Duplication (DRY) — flag ONLY when ALL of these hold: (a) the duplicated block is ≥10 lines OR contains real business logic (not boilerplate, types, or config); (b) both copies are visible in the diff OR you have grep-confirmed the second copy in the repo; (c) a clear extraction point exists. Do NOT recommend extracting a helper for code that appears 2–3 times — per project rules, three similar lines beats premature abstraction. Never speculate about duplication you cannot see.
 
             2. Security (highest weight)
                - RLS policy regressions: missing or weakened policies on new tables; policies that reference public-schema helpers; helpers that should be SECURITY DEFINER but are not (or vice versa).


### PR DESCRIPTION
## Summary
- Adds `Read` and `Grep` to the AI reviewer's `allowedTools` so cross-file claims can be verified instead of guessed at.
- Replaces the vague "doing too much" architecture bullet with an explicit SRP rule (IO + business + presentation mixed; modules owning unrelated concerns).
- Adds a **gated** DRY rule with three hard preconditions (≥10 lines or real business logic; both copies visible or grep-confirmed; clear extraction point) plus an explicit anti-rule against extracting helpers for 2–3 repetitions.
- Adds a "do not flag OCP/LSP/ISP/DIP" guardrail so the reviewer doesn't reach for the rest of SOLID from training defaults.

## Why
The reviewer had no filesystem access beyond `gh pr diff`, so any claim like "this duplicates X" or "this RLS helper is also called from Y" would have been speculative. The DRY addition is intentionally narrow — the project's own AGENTS.md says "three similar lines is better than a premature abstraction," and untuned DRY is the most over-applied principle in LLM reviewers.

## Test plan
- [ ] Merge to `main` so the updated workflow takes effect.
- [ ] Open a follow-up test PR with one deliberate 15-line cross-file dupe → reviewer should flag.
- [ ] Same PR (or sibling) with three near-identical 3-line blocks → reviewer should NOT flag (rule of three).
- [ ] Trivial SRP violation (one function mixing fetch + transform + render) → reviewer should flag.
- [ ] A clean PR with an unused import → reviewer should NOT flag (CI's job).