### PR TITLE
test(ai-review): negative control — rule of three (3x 3-line normalizers)

### DIFF
--- a/src/lib/_aireview_normalizers.ts
+++ b/src/lib/_aireview_normalizers.ts
@@ -1,0 +1,14 @@
+export function normalizeName(name: string): string {
+  if (!name) throw new Error('name required');
+  return name.trim().toLowerCase();
+}
+
+export function normalizeEmail(email: string): string {
+  if (!email) throw new Error('email required');
+  return email.trim().toLowerCase();
+}
+
+export function normalizeUsername(username: string): string {
+  if (!username) throw new Error('username required');
+  return username.trim().toLowerCase();
+}


### PR DESCRIPTION
**DO NOT MERGE.** Sibling test PR to #261. Verifies the AI reviewer respects the "three similar lines beats premature abstraction" rule.

## What
One new file (`_aireview_normalizers.ts`) contains three near-identical 3-line normalizers: `normalizeName`, `normalizeEmail`, `normalizeUsername`. Each is `if (!x) throw; return x.trim().toLowerCase();`.

## Expected reviewer behaviour
- Should NOT flag this as a DRY violation. The gates explicitly require ≥10 lines OR real business logic — these are short and boilerplate-ish.
- Even though there's an obvious `normalize(label, value)` extraction, the project's anti-rule says don't recommend it for 2–3 repetitions.

If the reviewer suggests extracting a helper, the rule isn't biting and the prompt needs tightening. If it flags something unrelated (SOLID letters, unused exports, naming), the guardrails leaked.

## Cleanup
Close without merging once the reviewer has commented.