### PR TITLE
refactor(outbox): derive BoardRowPatch from generated Database types

### DIFF
--- a/src/lib/outbox/types.ts
+++ b/src/lib/outbox/types.ts
@@ -1,17 +1,26 @@
 import type { BoardKind, VoiceMode } from '@/types/domain';
+import type { Database } from '@/types/supabase';
+
+type BoardUpdate = Database['public']['Tables']['boards']['Update'];
 
 /**
- * Patch shape for a board UPDATE. Field names match the DB columns so the
- * handler can pass it straight to `supabase.from('boards').update(patch)`.
+ * Patch shape for a board UPDATE. Field names and shapes are derived from the
+ * generated `boards` Update type so a schema change can't leave this stale —
+ * the handler passes it straight to `supabase.from('boards').update(patch)`.
+ *
+ * `kind` and `voice_mode` are re-narrowed to their domain unions: the columns
+ * are plain `text` (generated as `string`), but DB CHECK constraints plus the
+ * camelCase→snake_case mappers in `boards.mutations.ts` guarantee only the
+ * union members ever flow through. Keeping the narrow types here stops a
+ * caller from queueing an arbitrary string.
  */
-export interface BoardRowPatch {
-  name?: string;
+export type BoardRowPatch = Pick<
+  BoardUpdate,
+  'name' | 'labels_visible' | 'step_ids' | 'kid_reorderable'
+> & {
   kind?: BoardKind;
-  labels_visible?: boolean;
   voice_mode?: VoiceMode;
-  step_ids?: string[];
-  kid_reorderable?: boolean;
-}
+};
 
 export type OutboxEntryStatus = 'pending' | 'failed';
 


### PR DESCRIPTION
Closes #265.

## What

`BoardRowPatch` was a hand-written interface duplicating the `boards` table's snake_case columns. This replaces it with a `Pick` over the generated `Database['public']['Tables']['boards']['Update']` type.

```ts
export type BoardRowPatch = Pick<
  BoardUpdate,
  'name' | 'labels_visible' | 'step_ids' | 'kid_reorderable'
> & {
  kind?: BoardKind;
  voice_mode?: VoiceMode;
};
```

## Why

The hand-maintained type could drift from the schema: a column rename/type change regenerates `src/types/supabase.ts` (CI fails on that drift) but left `BoardRowPatch` stale, surfacing as a runtime mutation failure rather than a typecheck error. Deriving it closes the gap.

`kind`/`voice_mode` keep their domain-union narrowing — the columns are plain `text` (generated as `string`), but the DB CHECK constraints (`migrations/20260424145159_init.sql:35,37`) plus the camelCase→snake_case mappers in `boards.mutations.ts` guarantee only union members flow through, and the narrow types stop a caller queueing an arbitrary string.

## Verification

- `npm run typecheck` — clean
- `npm run lint` / `lint:css` — clean
- `npm run test` — 392 passed (72 files), incl. outbox handler + board mutation suites