### PR TITLE
ci(ai-review): use Claude Opus instead of Sonnet

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model claude-sonnet-4-6
+            --model claude-opus-4-8
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Read,Grep"
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
Bumps the AI reviewer model from `claude-sonnet-4-6` to `claude-opus-4-8` for stronger architecture/security reasoning on PRs.

One-line change in `.github/workflows/ai-review.yml`.

**Tradeoff:** Opus costs materially more per token than Sonnet. The reviewer runs on every non-draft, non-docs PR (`paths-ignore` covers `**/*.md`, `docs/**`, `.github/**`), so this is a recurring per-PR cost. Acceptable for this repo's PR volume.

Note: this PR only touches `.github/`, which `ai-review.yml` ignores — so the reviewer won't run on itself. The new model takes effect on the next code PR.