### PR TITLE
ci(ai-review): revert reviewer to Sonnet 4.6

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model claude-opus-4-8
+            --model claude-sonnet-4-6
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Read,Grep"
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
Reverts the model change from #268.

Opus 4.8 crashes `claude-code-action` on multi-turn reviews: the action's agent SDK modifies `thinking` blocks across tool-use turns, so the API rejects the replayed block (`400 ... thinking blocks cannot be modified`). Hit on #270's 17-turn run; #269 survived only because it was a shorter run.

We're already on the latest action (`@v1` → v1.0.133, commit `787c5a0`, 2026-05-23), so no upgrade fixes it. Sonnet doesn't trip the bug.

`.github`-only change → `paths-ignore` skips the reviewer on this PR; `verify` (required) covers CI.