### PR TITLE
fix(kid-mode): key per-slot state by position, not pictogram id (#273)

### DIFF
--- a/src/features/kid-choice/KidChoice.test.tsx
+++ b/src/features/kid-choice/KidChoice.test.tsx
@@ -95,6 +95,23 @@ describe('KidChoice', () => {
     expect(screen.getByText(/Let.+s go to/)).toBeInTheDocument();
   });
 
+  it('selects only the tapped slot when a board lists the same pictogram twice (#273)', async () => {
+    // A choice board may legitimately repeat a pictogram. Selection must be
+    // keyed by slot position, not pictogram id — otherwise tapping one tile
+    // marks every identical tile as picked (and the React key collides).
+    const qc = makeClient();
+    render(
+      <Wrap qc={qc}>
+        <KidChoice board={{ ...board, stepIds: [park.id, park.id] }} onExit={vi.fn()} />
+      </Wrap>,
+    );
+    const first = screen.getByRole('button', { name: /A.*Park/i });
+    const second = screen.getByRole('button', { name: /B.*Park/i });
+    await userEvent.click(first);
+    expect(first.className).toMatch(/choicePicked/);
+    expect(second.className).not.toMatch(/choicePicked/);
+  });
+
   it('tapping the confirm pill re-speaks the picked label (#231)', async () => {
     const qc = makeClient();
     render(

--- a/src/features/kid-choice/KidChoice.tsx
+++ b/src/features/kid-choice/KidChoice.tsx
@@ -22,15 +22,18 @@ export const KidChoice = ({ board, onExit }: KidChoiceProps): JSX.Element => {
   const options: Pictogram[] = board.stepIds
     .map((id) => pictogramsById.get(id))
     .filter((p): p is Pictogram => Boolean(p));
-  const [pickedId, setPickedId] = useState<string | null>(null);
-  const pickedPicto = options.find((o) => o.id === pickedId) ?? null;
+  // Selection is keyed by slot position, not pictogram id: a choice board may
+  // legitimately list the same pictogram twice, and an id-keyed selection
+  // would mark every identical tile as picked (#273).
+  const [pickedIndex, setPickedIndex] = useState<number | null>(null);
+  const pickedPicto = pickedIndex === null ? null : (options[pickedIndex] ?? null);
 
   const speakPicked = (p: Pictogram): void => {
     void speakPictogram(p, board.voiceMode);
   };
 
-  const pick = (p: Pictogram): void => {
-    setPickedId(p.id);
+  const pick = (p: Pictogram, index: number): void => {
+    setPickedIndex(index);
     speakPicked(p);
   };
 
@@ -51,8 +54,8 @@ export const KidChoice = ({ board, onExit }: KidChoiceProps): JSX.Element => {
           <div className={styles.choices}>
             {options.map((p, idx) => {
               const accent = accentForIndex(idx);
-              const isPicked = pickedId === p.id;
-              const isOther = pickedId !== null && !isPicked;
+              const isPicked = pickedIndex === idx;
+              const isOther = pickedIndex !== null && !isPicked;
               const markerStyle = {
                 background: cssVar(accent.bg),
                 color: cssVar(accent.ink),
@@ -63,9 +66,9 @@ export const KidChoice = ({ board, onExit }: KidChoiceProps): JSX.Element => {
               };
               return (
                 <button
-                  key={p.id}
+                  key={`${p.id}-${idx}`}
                   type="button"
-                  onClick={() => pick(p)}
+                  onClick={() => pick(p, idx)}
                   className={[
                     styles.choice,
                     isPicked && styles.choicePicked,

--- a/src/features/kid-sequence/KidSequence.test.tsx
+++ b/src/features/kid-sequence/KidSequence.test.tsx
@@ -79,6 +79,23 @@ describe('KidSequence', () => {
     );
   });
 
+  it('flashes only the tapped slot when a step repeats the same pictogram (#273)', async () => {
+    // "jump, jump, jump" is a valid sequence. The speaking flash must track
+    // the tapped slot, not the pictogram id — an id-keyed flash lights up
+    // every identical tile at once.
+    const qc = makeClient();
+    render(
+      <Wrap qc={qc}>
+        <KidSequence board={{ ...board, stepIds: [apple.id, apple.id] }} onExit={vi.fn()} />
+      </Wrap>,
+    );
+    const [first, second] = screen.getAllByRole('button', { name: /Apple/i });
+    if (!first || !second) throw new Error('expected two Apple tiles');
+    await userEvent.click(first);
+    expect(first.className).toMatch(/tileActive/);
+    expect(second.className).not.toMatch(/tileActive/);
+  });
+
   it('hides per-tile labels when board.labelsVisible is false, but keeps an accessible name', () => {
     const qc = makeClient();
     render(

--- a/src/features/kid-sequence/KidSequence.tsx
+++ b/src/features/kid-sequence/KidSequence.tsx
@@ -38,7 +38,10 @@ const buildSteps = (stepIds: readonly string[], byId: Map<string, Pictogram>): S
 export const KidSequence = ({ board, onExit }: KidSequenceProps): JSX.Element => {
   const pictogramsById = usePictogramsById();
   const steps = buildSteps(board.stepIds, pictogramsById);
-  const [speakingId, setSpeakingId] = useState<string | null>(null);
+  // Track the speaking flash by slot key, not pictogram id: a sequence may
+  // repeat the same pictogram ("jump, jump, jump"), and an id-keyed flash
+  // would light up every identical tile at once (#273).
+  const [speakingKey, setSpeakingKey] = useState<string | null>(null);
   const setStepIds = useSetStepIds();
 
   // Track the flash timer so unmount cancels it. Otherwise a stray setState
@@ -55,11 +58,11 @@ export const KidSequence = ({ board, onExit }: KidSequenceProps): JSX.Element =>
   );
 
   const announce = (step: Step): void => {
-    setSpeakingId(step.picto.id);
+    setSpeakingKey(step.key);
     if (flashTimer.current) clearTimeout(flashTimer.current);
     flashTimer.current = setTimeout(() => {
       flashTimer.current = null;
-      setSpeakingId((curr) => (curr === step.picto.id ? null : curr));
+      setSpeakingKey((curr) => (curr === step.key ? null : curr));
     }, SPEAK_FLASH_MS);
     void speakPictogram(step.picto, board.voiceMode);
   };
@@ -73,7 +76,7 @@ export const KidSequence = ({ board, onExit }: KidSequenceProps): JSX.Element =>
   };
 
   const renderTile = (step: Step, drag?: DragBindings): JSX.Element => {
-    const isSpeaking = speakingId === step.picto.id;
+    const isSpeaking = speakingKey === step.key;
     return (
       <button
         ref={drag?.setNodeRef}


### PR DESCRIPTION
Closes #273.

A board may legitimately list the same pictogram more than once (a Choice with two of the same option; a sequence like "jump, jump, jump"). Two kid-facing components keyed **per-slot interactive state by pictogram id**, so a duplicate broke them. Fixed both.

## KidChoice — selection collision (+ key collision)
Tracked the picked option by `pickedId === p.id` and used `key={p.id}`. With a duplicate, tapping one tile marked **every** identical tile as picked, and the React key collided. → Track the picked **slot index**; key each tile by `${p.id}-${idx}`.

## KidSequence — flash collision
Tracked the speaking flash by `step.picto.id`, so tapping one repeated step lit the speaker badge on **every** identical tile. (React keys were already positional.) → Track the tapped slot's composite `step.key`.

`BoardBuilder` already used positional composite keys and index/key-based mutations — no change needed.

## Not done (out of scope, by design)
`step_ids` is **not** deduped — repeated steps are valid. Preventing two *identical* options on a Choice board would be a separate UX decision, not a correctness fix.

## Verification
- Two new regression tests (Choice: tapping A selects only A; Sequence: tapping slot 0 flashes only slot 0).
- Full suite green (394 tests), typecheck + lint clean.