### PR TITLE
test(delete-account): cover post-deletion JWT replay (#217)

### DIFF
--- a/supabase/functions/delete-account/handler.test.ts
+++ b/supabase/functions/delete-account/handler.test.ts
@@ -75,6 +75,35 @@ Deno.test('handler: invalid Bearer → 401 unauthorized', async () => {
   assertEquals(res.status, 401);
 });
 
+Deno.test(
+  'handler: replayed JWT after the account is gone → 401 without re-running deletion (#217)',
+  async () => {
+    // Acceptance criterion #2: once an account is deleted, its JWT no longer
+    // resolves to a user, so admin.auth.getUser returns null and we 401 before
+    // ever entering the deletion path again. This bounds the authenticated abuse
+    // surface — a replayed token can't trigger a second deletion run.
+    const req = new Request('https://x.invalid/delete-account', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer once.valid.now.deleted' },
+      body: '',
+    });
+    const admin = makeAdminStub({
+      getUser: async () => ({ data: { user: null }, error: null }),
+    });
+    let deleteCalls = 0;
+    const deleteFn = async (uid: string): Promise<{ audioCount: number; imageCount: number }> => {
+      deleteCalls += 1;
+      return noopDelete(uid);
+    };
+    const res = await handleRequest(req, admin, deleteFn);
+    assertEquals(res.status, 401);
+    const body = await res.json();
+    assertEquals(body.ok, false);
+    assertEquals(body.error, 'unauthorized');
+    assertEquals(deleteCalls, 0);
+  },
+);
+
 Deno.test('handler: non-empty body → 400 bad_request', async () => {
   const req = new Request('https://x.invalid/delete-account', {
     method: 'POST',


### PR DESCRIPTION
Closes #217.

## What

Adds one regression test to the `delete-account` edge function suite pinning acceptance criterion #2 of #217: a replayed JWT after the account is gone returns 401 **without re-entering the deletion path**.

## Why this closes #217 (not a rate-limiter)

The issue's title says "add rate limiting," but its **Acceptance** section defines done as:

1. Anonymous POST without `Authorization` rejected *before* `admin.auth.getUser` — **already implemented + tested** (`index.ts:92-99`; `getUserCalls === 0` assertions).
2. Repeated authed POST after delete → 401/404 without re-running deletion — **this commit** pins it.
3. Tests cover both paths — now satisfied.

The `deleteCalls === 0` assertion is the load-bearing new coverage: the existing "invalid Bearer → 401" test only checks status, so it wouldn't catch a regression that re-ran deletion for a null user. The null-user stub (`{ data: { user: null }, error: null }`) faithfully models Supabase on a deleted account's JWT.

Per-IP / per-user fixed-window rate limiting is **out of scope**: it needs Pro-only platform limits or a stateful store, neither available on the free tier ([[project_supabase_free_tier]]). If wanted later, that's a separate scoped issue (Postgres-counter approach), not a blocker for #217.

## Verification

`deno test --allow-env` → 20 passed / 0 failed. Prettier + typecheck clean (pre-commit hooks).

Reviewed via code-reviewer subagent: confirmed genuine regression guard, faithful stub, sound scope decision.