### PR TITLE
fix(auth): magic-link login that works in prod (#219)

### DIFF
--- a/src/features/login/Login.test.tsx
+++ b/src/features/login/Login.test.tsx
@@ -3,11 +3,10 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const signInWithOtpMock = vi.fn();
-const verifyOtpMock = vi.fn();
 
 vi.mock('@/lib/supabase', () => ({
   supabase: {
-    auth: { signInWithOtp: signInWithOtpMock, verifyOtp: verifyOtpMock },
+    auth: { signInWithOtp: signInWithOtpMock },
   },
 }));
 
@@ -15,69 +14,44 @@ const { Login } = await import('./Login');
 
 afterEach(() => {
   signInWithOtpMock.mockReset();
-  verifyOtpMock.mockReset();
 });
 
 describe('Login', () => {
-  it('starts on the email step with a Send code button', () => {
+  it('starts on the email step with a Send link button', () => {
     render(<Login />);
     expect(screen.getByLabelText('Email')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Send code' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Send link' })).toBeInTheDocument();
   });
 
-  it('submitting an email calls signInWithOtp and advances to the OTP step', async () => {
+  it('submitting an email sends a magic link redirecting back to the app, then confirms', async () => {
     signInWithOtpMock.mockResolvedValueOnce({ error: null });
     render(<Login />);
     await userEvent.type(screen.getByLabelText('Email'), 'parent@example.com');
-    await userEvent.click(screen.getByRole('button', { name: 'Send code' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Send link' }));
     expect(signInWithOtpMock).toHaveBeenCalledWith({
       email: 'parent@example.com',
-      options: { shouldCreateUser: true },
+      options: { shouldCreateUser: true, emailRedirectTo: window.location.origin },
     });
-    expect(await screen.findByLabelText('Code')).toBeInTheDocument();
+    // Advances to the confirmation step naming the address it was sent to.
+    expect(await screen.findByText(/Check your email/)).toBeInTheDocument();
+    expect(screen.getByText('parent@example.com')).toBeInTheDocument();
   });
 
-  it('shows the API error when sending the code fails and stays on the email step', async () => {
+  it('shows the API error when sending fails and stays on the email step', async () => {
     signInWithOtpMock.mockResolvedValueOnce({ error: { message: 'rate limit hit' } });
     render(<Login />);
     await userEvent.type(screen.getByLabelText('Email'), 'parent@example.com');
-    await userEvent.click(screen.getByRole('button', { name: 'Send code' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Send link' }));
     expect(await screen.findByText('rate limit hit')).toBeInTheDocument();
-    expect(screen.queryByLabelText('Code')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Check your email/)).not.toBeInTheDocument();
   });
 
-  it('submitting a 6-digit code calls verifyOtp', async () => {
-    signInWithOtpMock.mockResolvedValueOnce({ error: null });
-    verifyOtpMock.mockResolvedValueOnce({ error: null });
-    render(<Login />);
-    await userEvent.type(screen.getByLabelText('Email'), 'parent@example.com');
-    await userEvent.click(screen.getByRole('button', { name: 'Send code' }));
-    await screen.findByLabelText('Code');
-    await userEvent.type(screen.getByLabelText('Code'), '123456');
-    await userEvent.click(screen.getByRole('button', { name: 'Sign in' }));
-    expect(verifyOtpMock).toHaveBeenCalledWith({
-      email: 'parent@example.com',
-      token: '123456',
-      type: 'email',
-    });
-  });
-
-  it('non-numeric input is stripped from the OTP field', async () => {
+  it('Use a different email returns to the email step', async () => {
     signInWithOtpMock.mockResolvedValueOnce({ error: null });
     render(<Login />);
     await userEvent.type(screen.getByLabelText('Email'), 'parent@example.com');
-    await userEvent.click(screen.getByRole('button', { name: 'Send code' }));
-    const otp = (await screen.findByLabelText('Code')) as HTMLInputElement;
-    await userEvent.type(otp, 'abc12def34');
-    expect(otp.value).toBe('1234');
-  });
-
-  it('Back from the OTP step returns to the email step and clears errors', async () => {
-    signInWithOtpMock.mockResolvedValueOnce({ error: null });
-    render(<Login />);
-    await userEvent.type(screen.getByLabelText('Email'), 'parent@example.com');
-    await userEvent.click(screen.getByRole('button', { name: 'Send code' }));
-    await userEvent.click(await screen.findByRole('button', { name: 'Back' }));
-    expect(screen.getByRole('button', { name: 'Send code' })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Send link' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Use a different email' }));
+    expect(screen.getByRole('button', { name: 'Send link' })).toBeInTheDocument();
   });
 });

--- a/src/features/login/Login.tsx
+++ b/src/features/login/Login.tsx
@@ -1,42 +1,34 @@
 import { type FormEvent, type JSX, useState } from 'react';
 
 import talrumLogo from '@/assets/talrum-logo.png';
-import { useEmailOtp } from '@/lib/auth/login';
+import { useMagicLink } from '@/lib/auth/login';
 import { useOnline } from '@/lib/useOnline';
 import { Button } from '@/ui/Button/Button';
 import { TextField } from '@/ui/TextField/TextField';
 
 import styles from './Login.module.css';
 
-type Stage = 'email' | 'otp';
+type Stage = 'email' | 'sent';
 
 /**
- * Two-step magic-link sign-in. Step 1 sends an OTP email; step 2 verifies the
- * 6-digit code. In local dev the email is captured by Inbucket at
- * http://localhost:54324 — open the latest message, copy the code, paste.
+ * Magic-link sign-in. Step 1 sends an email with a sign-in link; the parent
+ * opens it on the same device and supabase-js exchanges the URL for a session
+ * (AuthGate then flips to the app). In local dev the email is captured by
+ * Mailpit at http://localhost:54324 — open the latest message, click the link.
  * New emails trigger handle_new_user() which clones the starter library.
  */
 export const Login = (): JSX.Element => {
   const [stage, setStage] = useState<Stage>('email');
   const [email, setEmail] = useState('');
-  const [code, setCode] = useState('');
   const online = useOnline();
-  const { sendCode, verify, busy, error, resetError } = useEmailOtp();
+  const { sendLink, busy, error, resetError } = useMagicLink();
 
-  const onSendCode = async (e: FormEvent): Promise<void> => {
+  const onSendLink = async (e: FormEvent): Promise<void> => {
     e.preventDefault();
     const trimmed = email.trim().toLowerCase();
     if (!trimmed) return;
-    const ok = await sendCode(trimmed);
-    if (ok) setStage('otp');
-  };
-
-  const onVerify = async (e: FormEvent): Promise<void> => {
-    e.preventDefault();
-    const trimmedCode = code.trim();
-    if (!trimmedCode) return;
-    await verify(email.trim().toLowerCase(), trimmedCode);
-    // Success path: AuthGate sees the new session and flips to the app.
+    const ok = await sendLink(trimmed);
+    if (ok) setStage('sent');
   };
 
   return (
@@ -45,7 +37,7 @@ export const Login = (): JSX.Element => {
         <div className={styles.brand}>
           <img src={talrumLogo} alt="" width={72} height={72} className={styles.mark} />
           <h1 className={styles.title}>Talrum</h1>
-          <p className={styles.subtitle}>Sign in with a one-time code.</p>
+          <p className={styles.subtitle}>Sign in with a magic link.</p>
         </div>
         {!online && (
           <div role="status" className={styles.offline}>
@@ -53,7 +45,7 @@ export const Login = (): JSX.Element => {
           </div>
         )}
         {stage === 'email' ? (
-          <form className={styles.form} onSubmit={(e) => void onSendCode(e)}>
+          <form className={styles.form} onSubmit={(e) => void onSendLink(e)}>
             <TextField
               label="Email"
               type="email"
@@ -67,48 +59,27 @@ export const Login = (): JSX.Element => {
             />
             {error && <div className={styles.error}>{error}</div>}
             <Button type="submit" variant="primary" disabled={busy || !email.trim() || !online}>
-              {busy ? 'Sending…' : 'Send code'}
+              {busy ? 'Sending…' : 'Send link'}
             </Button>
           </form>
         ) : (
-          <form className={styles.form} onSubmit={(e) => void onVerify(e)}>
-            <div className={styles.hint}>
-              Code sent to <strong>{email}</strong>. Check your email (or Inbucket in dev).
+          <div className={styles.form}>
+            <div role="status" className={styles.hint}>
+              Check your email — we sent a sign-in link to <strong>{email}</strong>. Open it on this
+              device to sign in. (In dev, see Mailpit.)
             </div>
-            <TextField
-              label="Code"
-              type="text"
-              name="otp"
-              required
-              autoFocus
-              autoComplete="one-time-code"
-              inputMode="numeric"
-              pattern="[0-9]*"
-              maxLength={6}
-              value={code}
-              onChange={(e) => setCode(e.target.value.replace(/\D/g, ''))}
-              placeholder="••••••"
-              inputClassName={styles.otp}
-            />
-            {error && <div className={styles.error}>{error}</div>}
-            <div className={styles.row}>
-              <Button
-                type="button"
-                variant="ghost"
-                onClick={() => {
-                  setStage('email');
-                  setCode('');
-                  resetError();
-                }}
-                disabled={busy}
-              >
-                Back
-              </Button>
-              <Button type="submit" variant="primary" disabled={busy || code.length < 6 || !online}>
-                {busy ? 'Verifying…' : 'Sign in'}
-              </Button>
-            </div>
-          </form>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => {
+                setStage('email');
+                resetError();
+              }}
+              disabled={busy}
+            >
+              Use a different email
+            </Button>
+          </div>
         )}
       </div>
     </main>

--- a/src/lib/auth/login.test.tsx
+++ b/src/lib/auth/login.test.tsx
@@ -2,83 +2,53 @@ import { act, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const signInWithOtpMock = vi.fn();
-const verifyOtpMock = vi.fn();
 
 vi.mock('@/lib/supabase', () => ({
   supabase: {
-    auth: { signInWithOtp: signInWithOtpMock, verifyOtp: verifyOtpMock },
+    auth: { signInWithOtp: signInWithOtpMock },
   },
 }));
 
-const { useEmailOtp } = await import('./login');
+const { useMagicLink } = await import('./login');
 
 afterEach(() => {
   signInWithOtpMock.mockReset();
-  verifyOtpMock.mockReset();
 });
 
-describe('useEmailOtp.sendCode', () => {
-  it('passes the email through to signInWithOtp with shouldCreateUser', async () => {
+describe('useMagicLink.sendLink', () => {
+  it('sends a magic link with shouldCreateUser and a redirect back to the app', async () => {
     signInWithOtpMock.mockResolvedValueOnce({ error: null });
-    const { result } = renderHook(() => useEmailOtp());
+    const { result } = renderHook(() => useMagicLink());
     let ok = false;
     await act(async () => {
-      ok = await result.current.sendCode('parent@example.com');
+      ok = await result.current.sendLink('parent@example.com');
     });
     expect(ok).toBe(true);
     expect(signInWithOtpMock).toHaveBeenCalledWith({
       email: 'parent@example.com',
-      options: { shouldCreateUser: true },
+      options: { shouldCreateUser: true, emailRedirectTo: window.location.origin },
     });
     expect(result.current.error).toBeNull();
   });
 
   it('captures the error message and returns false on failure', async () => {
     signInWithOtpMock.mockResolvedValueOnce({ error: { message: 'rate limit hit' } });
-    const { result } = renderHook(() => useEmailOtp());
+    const { result } = renderHook(() => useMagicLink());
     let ok = true;
     await act(async () => {
-      ok = await result.current.sendCode('parent@example.com');
+      ok = await result.current.sendLink('parent@example.com');
     });
     expect(ok).toBe(false);
     expect(result.current.error).toBe('rate limit hit');
   });
 });
 
-describe('useEmailOtp.verify', () => {
-  it('passes email and code through to verifyOtp with type "email"', async () => {
-    verifyOtpMock.mockResolvedValueOnce({ error: null });
-    const { result } = renderHook(() => useEmailOtp());
-    let ok = false;
-    await act(async () => {
-      ok = await result.current.verify('parent@example.com', '123456');
-    });
-    expect(ok).toBe(true);
-    expect(verifyOtpMock).toHaveBeenCalledWith({
-      email: 'parent@example.com',
-      token: '123456',
-      type: 'email',
-    });
-  });
-
-  it('captures the error message and returns false on failure', async () => {
-    verifyOtpMock.mockResolvedValueOnce({ error: { message: 'invalid code' } });
-    const { result } = renderHook(() => useEmailOtp());
-    let ok = true;
-    await act(async () => {
-      ok = await result.current.verify('parent@example.com', '000000');
-    });
-    expect(ok).toBe(false);
-    expect(result.current.error).toBe('invalid code');
-  });
-});
-
-describe('useEmailOtp.resetError', () => {
+describe('useMagicLink.resetError', () => {
   it('clears a previously set error', async () => {
     signInWithOtpMock.mockResolvedValueOnce({ error: { message: 'boom' } });
-    const { result } = renderHook(() => useEmailOtp());
+    const { result } = renderHook(() => useMagicLink());
     await act(async () => {
-      await result.current.sendCode('parent@example.com');
+      await result.current.sendLink('parent@example.com');
     });
     expect(result.current.error).toBe('boom');
     act(() => result.current.resetError());

--- a/src/lib/auth/login.ts
+++ b/src/lib/auth/login.ts
@@ -2,31 +2,36 @@ import { useState } from 'react';
 
 import { supabase } from '@/lib/supabase';
 
-export interface UseEmailOtp {
-  sendCode: (email: string) => Promise<boolean>;
-  verify: (email: string, code: string) => Promise<boolean>;
+export interface UseMagicLink {
+  sendLink: (email: string) => Promise<boolean>;
   busy: boolean;
   error: string | null;
   resetError: () => void;
 }
 
 /**
- * Two-step email OTP sign-in. Step 1 (`sendCode`) requests a code email;
- * step 2 (`verify`) submits the 6-digit code. Both return `true` on success
- * so callers can advance UI state without inspecting `error`. Centralized
- * here so features never call `supabase.auth.{signInWithOtp,verifyOtp}`
- * directly — see issue #126.
+ * Magic-link email sign-in. `sendLink` requests an email; the user clicks the
+ * link, lands back on the app at `emailRedirectTo`, and supabase-js's
+ * `detectSessionInUrl` (on by default) exchanges the URL for a session, which
+ * AuthGate picks up. Returns `true` on success so callers can advance UI state
+ * without inspecting `error`. Centralized here so features never call
+ * `supabase.auth.signInWithOtp` directly — see issue #126.
+ *
+ * Why a link, not a typed code (#219): the 6-digit code only reaches the user
+ * if the email template renders `{{ .Token }}`, which is dashboard-managed and
+ * was dropped in prod. The link is present in every email regardless of
+ * template, so it's the only sign-in path the frontend can guarantee works.
  */
-export const useEmailOtp = (): UseEmailOtp => {
+export const useMagicLink = (): UseMagicLink => {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const sendCode = async (email: string): Promise<boolean> => {
+  const sendLink = async (email: string): Promise<boolean> => {
     setBusy(true);
     setError(null);
     const { error: otpError } = await supabase.auth.signInWithOtp({
       email,
-      options: { shouldCreateUser: true },
+      options: { shouldCreateUser: true, emailRedirectTo: window.location.origin },
     });
     setBusy(false);
     if (otpError) {
@@ -36,23 +41,7 @@ export const useEmailOtp = (): UseEmailOtp => {
     return true;
   };
 
-  const verify = async (email: string, code: string): Promise<boolean> => {
-    setBusy(true);
-    setError(null);
-    const { error: verifyError } = await supabase.auth.verifyOtp({
-      email,
-      token: code,
-      type: 'email',
-    });
-    setBusy(false);
-    if (verifyError) {
-      setError(verifyError.message);
-      return false;
-    }
-    return true;
-  };
-
   const resetError = (): void => setError(null);
 
-  return { sendCode, verify, busy, error, resetError };
+  return { sendLink, busy, error, resetError };
 };


### PR DESCRIPTION
Closes #219.

Login promised a typed 6-digit code, but prod's email only has a magic link (the `{{ .Token }}` line was dropped from the dashboard-managed template). The template isn't in repo scope — `config.toml` must never be pushed — so the link is the only sign-in path the frontend can guarantee.

Replaces the email→code form with a magic-link flow: send email with `emailRedirectTo` = app origin; user clicks the link; supabase-js `detectSessionInUrl` exchanges it for a session AuthGate picks up.

**Verified end-to-end** against the local stack: following the emailed verify link returns access + refresh tokens. Unit tests rewritten; full suite (390) + lint + typecheck green.

Trade-off: loses the in-tab code-entry UX — which never worked in prod anyway.