### PR TITLE
fix(outbox): make the failed-sync Retry button actually retry

### DIFF
--- a/src/lib/outbox/drain.ts
+++ b/src/lib/outbox/drain.ts
@@ -114,5 +114,3 @@ export const startOutbox = (): void => {
   }
   void drain();
 };
-
-export const kick = (): Promise<void> => drain();

--- a/src/lib/outbox/index.ts
+++ b/src/lib/outbox/index.ts
@@ -4,7 +4,6 @@ import { ulid } from 'ulid';
 import {
   drain,
   getStatus,
-  kick,
   type OutboxStatus,
   refreshStatus,
   startOutbox,
@@ -15,7 +14,7 @@ import { deleteEntry, listEntries, putEntry } from './store';
 import type { OutboxEntry } from './types';
 
 export type { BoardRowPatch, OutboxEntry, OutboxEntryStatus } from './types';
-export { kick, startOutbox, UnretryableOutboxError };
+export { startOutbox, UnretryableOutboxError };
 
 /**
  * Distribute the Omit over each member of the union so caller payloads keep
@@ -79,6 +78,19 @@ export const enqueueAndDrain = async (input: EntryInput): Promise<void> => {
   // so the indicator wouldn't update its pending count until the next
   // online/offline event. Push the new status now.
   await refreshStatus();
+};
+
+/**
+ * Reset every failed entry to pending (fresh retry budget, stale lastError
+ * dropped) and drain. The indicator's "Retry" — a plain `drain()` skips
+ * failed entries, so without the reset the button is a no-op (#277).
+ */
+export const retryFailed = async (): Promise<void> => {
+  const failed = (await listEntries()).filter((e) => e.status === 'failed');
+  for (const { lastError: _lastError, ...entry } of failed) {
+    await putEntry({ ...entry, status: 'pending', attemptCount: 0 });
+  }
+  await drain();
 };
 
 /** Drop a single failed entry from the queue (the indicator's "Discard"). */

--- a/src/lib/outbox/outbox.test.ts
+++ b/src/lib/outbox/outbox.test.ts
@@ -19,7 +19,7 @@ vi.mock('@/lib/supabase', () => ({
 
 const { deleteEntry, listEntries, putEntry } = await import('./store');
 const { drain, getStatus, startOutbox, subscribeStatus } = await import('./drain');
-const { enqueueAndDrain } = await import('./index');
+const { enqueueAndDrain, retryFailed } = await import('./index');
 
 const baseEntry = (over: Partial<UpdateBoardEntry> = {}): UpdateBoardEntry => ({
   id: '01HZZZZZZZZZZZZZZZZZZZZZZZ',
@@ -131,6 +131,39 @@ describe('outbox drain', () => {
     expect(eqMock).toHaveBeenCalledTimes(1);
     const remaining = await listEntries();
     expect(remaining.map((e) => e.id)).toEqual(['01HZZA', '01HZZB']);
+  });
+});
+
+describe('retryFailed', () => {
+  it('re-attempts failed entries and clears them on success (#277)', async () => {
+    await putEntry(
+      baseEntry({ id: '01HZZA', status: 'failed', attemptCount: 3, lastError: 'Failed to fetch' }),
+    );
+    await retryFailed();
+    expect(eqMock).toHaveBeenCalledTimes(1);
+    expect(await listEntries()).toEqual([]);
+  });
+
+  it('grants a failed entry a fresh retry budget', async () => {
+    eqMock.mockRejectedValue(new TypeError('Failed to fetch'));
+    await putEntry(
+      baseEntry({ id: '01HZZA', status: 'failed', attemptCount: 3, lastError: 'Failed to fetch' }),
+    );
+    await retryFailed();
+    const entries = await listEntries();
+    expect(entries).toHaveLength(1);
+    // Reset to pending with attemptCount restarted — one drain attempt has
+    // run since the reset, so the count is 1, not 4.
+    expect(entries[0]?.status).toBe('pending');
+    expect(entries[0]?.attemptCount).toBe(1);
+  });
+
+  it('leaves pending entries untouched when there is nothing failed', async () => {
+    setOnline(false); // drain is a no-op offline, so the entry must survive as-is
+    await putEntry(baseEntry({ id: '01HZZA', attemptCount: 2 }));
+    await retryFailed();
+    const entries = await listEntries();
+    expect(entries[0]?.attemptCount).toBe(2);
   });
 });
 

--- a/src/ui/OfflineIndicator/OfflineIndicator.test.tsx
+++ b/src/ui/OfflineIndicator/OfflineIndicator.test.tsx
@@ -2,13 +2,13 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const useOutboxStatusMock = vi.fn();
-const kickMock = vi.fn();
+const retryFailedMock = vi.fn();
 const peekEntriesMock = vi.fn();
 const discardEntryMock = vi.fn();
 
 vi.mock('@/lib/outbox', () => ({
   useOutboxStatus: () => useOutboxStatusMock(),
-  kick: (...args: unknown[]) => kickMock(...args),
+  retryFailed: (...args: unknown[]) => retryFailedMock(...args),
   peekEntries: (...args: unknown[]) => peekEntriesMock(...args),
   discardEntry: (...args: unknown[]) => discardEntryMock(...args),
 }));
@@ -17,7 +17,7 @@ const { OfflineIndicator } = await import('./OfflineIndicator');
 
 afterEach(() => {
   useOutboxStatusMock.mockReset();
-  kickMock.mockReset();
+  retryFailedMock.mockReset();
   peekEntriesMock.mockReset();
   discardEntryMock.mockReset();
 });
@@ -69,6 +69,20 @@ describe('OfflineIndicator', () => {
     expect(screen.getByRole('button', { name: 'Discard' })).toBeInTheDocument();
   });
 
+  it('Retry resets failed entries via retryFailed, not a plain drain kick (#277)', () => {
+    useOutboxStatusMock.mockReturnValue({
+      online: true,
+      pendingCount: 0,
+      failedCount: 2,
+      draining: false,
+    });
+    retryFailedMock.mockResolvedValue(undefined);
+    render(<OfflineIndicator />);
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    // A plain drain skips failed entries — kicking one here was the #277 bug.
+    expect(retryFailedMock).toHaveBeenCalledTimes(1);
+  });
+
   it('discards failed entries without kicking the drain (#31)', async () => {
     useOutboxStatusMock.mockReturnValue({
       online: true,
@@ -85,6 +99,6 @@ describe('OfflineIndicator', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Discard' }));
     await waitFor(() => expect(discardEntryMock).toHaveBeenCalledWith('a'));
     expect(discardEntryMock).not.toHaveBeenCalledWith('b');
-    expect(kickMock).not.toHaveBeenCalled();
+    expect(retryFailedMock).not.toHaveBeenCalled();
   });
 });

--- a/src/ui/OfflineIndicator/OfflineIndicator.tsx
+++ b/src/ui/OfflineIndicator/OfflineIndicator.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'react';
 
-import { discardEntry, kick, peekEntries, useOutboxStatus } from '@/lib/outbox';
+import { discardEntry, peekEntries, retryFailed, useOutboxStatus } from '@/lib/outbox';
 
 import styles from './OfflineIndicator.module.css';
 
@@ -26,7 +26,7 @@ export const OfflineIndicator = (): JSX.Element | null => {
         <span className={styles.label}>
           {failedCount} sync {failedCount === 1 ? 'change' : 'changes'} failed
         </span>
-        <button type="button" className={styles.action} onClick={() => void kick()}>
+        <button type="button" className={styles.action} onClick={() => void retryFailed()}>
           Retry
         </button>
         <button type="button" className={styles.action} onClick={() => void discardAllFailed()}>


### PR DESCRIPTION
Closes #277.

## Bug
The failed-state pill's Retry button called `kick()` → `drain()`, but `drain()` only processes `status === 'pending'` entries and nothing ever reset `failed` → `pending`. Retry was a no-op in the only state where it renders; the user's sole working option was Discard (losing the queued edit).

## Fix
- `retryFailed()` in `src/lib/outbox/index.ts`: re-marks failed entries as pending with a fresh attempt budget (`attemptCount: 0`, stale `lastError` dropped), then drains.
- OfflineIndicator's Retry now calls it.
- Removed `kick()` — its only production consumer was the broken button; it was a bare alias for `drain()`.

## Tests (TDD — watched them fail first)
- `retryFailed` re-attempts failed entries and clears them on success.
- Failed entries get a fresh retry budget (`attemptCount` restarts).
- Pending entries are untouched when nothing has failed.
- Indicator wiring: Retry invokes `retryFailed`; Discard does not.

398/398 tests, lint, typecheck all green.