### PR TITLE
fix(outbox): disable online fast-path while pending entries are queued

### DIFF
--- a/src/lib/outbox/index.ts
+++ b/src/lib/outbox/index.ts
@@ -37,10 +37,17 @@ type EntryInput = DistributiveOmit<
  *
  * Offline: skip the immediate attempt — persist the entry and resolve. The
  * UI keeps the optimistic state; the drain loop replays when `online` fires.
+ *
+ * The fast path requires an empty pending queue: a write that bypasses older
+ * queued entries gets overwritten when they replay — stale data wins (#279).
+ * In that case the write joins the queue and a drain flushes everything in
+ * FIFO order. Failed entries don't count — drain() skips them, so they'd
+ * block the fast path forever for nothing.
  */
 export const enqueueAndDrain = async (input: EntryInput): Promise<void> => {
   const isOnline = typeof navigator === 'undefined' ? true : navigator.onLine;
-  if (isOnline) {
+  const hasPendingBacklog = isOnline && (await listEntries()).some((e) => e.status === 'pending');
+  if (isOnline && !hasPendingBacklog) {
     const entry: OutboxEntry = {
       ...input,
       id: ulid(),
@@ -74,6 +81,11 @@ export const enqueueAndDrain = async (input: EntryInput): Promise<void> => {
     attemptCount: 0,
     status: 'pending',
   });
+  if (isOnline) {
+    // Online with a backlog: flush the queue (oldest first, this entry last).
+    await drain();
+    return;
+  }
   // The offline path doesn't call drain() (which is what normally emits),
   // so the indicator wouldn't update its pending count until the next
   // online/offline event. Push the new status now.

--- a/src/lib/outbox/outbox.test.ts
+++ b/src/lib/outbox/outbox.test.ts
@@ -206,6 +206,31 @@ describe('enqueueAndDrain', () => {
     expect(entries[0]?.attemptCount).toBe(1);
   });
 
+  it('online + pending backlog: enqueues behind the queue instead of jumping it (#279)', async () => {
+    // An older write is still queued (e.g. offline backlog). A new online
+    // write must not bypass it — the queued entry would replay later and
+    // overwrite the newer state on the server.
+    await putEntry(baseEntry({ id: '01HZZA', boardId: 'board-old' }));
+    await enqueueAndDrain({ kind: 'updateBoard', boardId: 'board-new', patch: { name: 'x' } });
+    expect(eqMock.mock.calls).toEqual([
+      ['id', 'board-old'],
+      ['id', 'board-new'],
+    ]);
+    expect(await listEntries()).toEqual([]);
+  });
+
+  it('online + failed-only backlog: fast path stays available', async () => {
+    // drain() skips failed entries, so holding the fast path hostage to them
+    // would queue new writes behind a dam that never breaks.
+    await putEntry(
+      baseEntry({ id: '01HZZA', boardId: 'board-old', status: 'failed', attemptCount: 3 }),
+    );
+    await enqueueAndDrain({ kind: 'updateBoard', boardId: 'board-new', patch: { name: 'x' } });
+    expect(eqMock).toHaveBeenCalledTimes(1);
+    expect(eqMock).toHaveBeenCalledWith('id', 'board-new');
+    expect((await listEntries()).map((e) => e.id)).toEqual(['01HZZA']);
+  });
+
   it('offline: enqueues without trying the handler', async () => {
     setOnline(false);
     await enqueueAndDrain({ kind: 'updateBoard', boardId: 'b', patch: { name: 'x' } });


### PR DESCRIPTION
Closes #279.

## Problem

`enqueueAndDrain` ran the handler immediately whenever `navigator.onLine`, even with older entries still pending in the queue (offline backlog not yet drained, or a drain stalled behind a transient failure). The new write jumped the FIFO order the drain loop carefully preserves; when the older queued write replayed afterwards, stale data won on the server.

Sequence: rename board offline → queued. Back online; before the drain catches up, rename again → fast path writes the new name immediately → drain replays the **older** rename → old name wins.

## Fix

The fast path now requires an empty pending queue (option 1 from the issue — one `listEntries()` check; the queue is empty in the steady state, so the fast path stays fast where it matters). With a backlog, the write joins the queue and a drain flushes everything oldest-first.

Failed entries do **not** block the fast path: `drain()` skips them by design, so they would dam new writes forever for nothing.

## Tests (TDD, watched red first)

- online + pending backlog: handler call order is queued-entry-first, queue empty after (#279)
- online + failed-only backlog: fast path still taken, failed entry left in place