### PR TITLE
fix(pictograms): delete via atomic delete_pictogram RPC (#280)

### DIFF
--- a/src/lib/outbox/handlers.test.ts
+++ b/src/lib/outbox/handlers.test.ts
@@ -52,9 +52,15 @@ const storageFromMock = vi.fn((_bucket: string) => ({
   createSignedUrl: createSignedUrlMock,
 }));
 
+const rpcMock =
+  vi.fn<
+    (fn: string, args: Record<string, unknown>) => Promise<{ error: MockPostgrestError | null }>
+  >();
+
 vi.mock('@/lib/supabase', () => ({
   supabase: {
     from: (table: string) => fromMock(table),
+    rpc: (fn: string, args: Record<string, unknown>) => rpcMock(fn, args),
     storage: { from: (bucket: string) => storageFromMock(bucket) },
   },
 }));
@@ -91,6 +97,8 @@ beforeEach(() => {
   insertMock.mockResolvedValue({ error: null });
   inMock.mockResolvedValue({ data: [], error: null });
   deleteEqMock.mockResolvedValue({ error: null });
+  rpcMock.mockReset();
+  rpcMock.mockResolvedValue({ error: null });
   uploadMock.mockResolvedValue({ error: null });
   removeMock.mockResolvedValue({ error: null });
 });
@@ -328,33 +336,20 @@ describe('runHandler · replacePictoImage', () => {
 });
 
 describe('runHandler · deletePicto', () => {
-  it('scrubs the id from referenced boards, deletes the row, and cleans up uploads', async () => {
-    inMock.mockResolvedValue({
-      data: [
-        { id: 'b-1', step_ids: ['p-1', 'p-2'] },
-        { id: 'b-2', step_ids: ['p-2'] }, // already not referenced — no update
-      ],
-      error: null,
-    });
+  it('cleans up uploads then deletes via the delete_pictogram RPC', async () => {
     const entry: DeletePictogramEntry = {
       ...baseProps,
       kind: 'deletePicto',
       pictogramId: 'p-1',
       previousImagePath: 'o-1/p-1.jpg',
       previousAudioPath: 'o-1/p-1.webm',
-      scrubFromBoardIds: ['b-1', 'b-2'],
     };
     await runHandler(entry);
-    expect(selectMock).toHaveBeenCalledWith('id, step_ids');
-    expect(inMock).toHaveBeenCalledWith('id', ['b-1', 'b-2']);
-    // Only b-1 had a step_ids change.
-    expect(updateMock).toHaveBeenCalledTimes(1);
-    expect(updateMock).toHaveBeenCalledWith({ step_ids: ['p-2'] });
-    expect(eqMock).toHaveBeenCalledWith('id', 'b-1');
-    expect(deleteMock).toHaveBeenCalledTimes(1);
-    expect(deleteEqMock).toHaveBeenCalledWith('id', 'p-1');
     expect(removeMock).toHaveBeenCalledWith(['o-1/p-1.jpg']);
     expect(removeMock).toHaveBeenCalledWith(['o-1/p-1.webm']);
+    expect(rpcMock).toHaveBeenCalledWith('delete_pictogram', { p_pictogram_id: 'p-1' });
+    // The boards scrub + row delete happen inside the RPC — no table traffic.
+    expect(fromMock).not.toHaveBeenCalled();
   });
 
   it('skips storage cleanup for stock-prefixed previous paths', async () => {
@@ -363,24 +358,22 @@ describe('runHandler · deletePicto', () => {
       kind: 'deletePicto',
       pictogramId: 'p-1',
       previousImagePath: 'stock:park',
-      scrubFromBoardIds: [],
     };
     await runHandler(entry);
-    expect(deleteMock).toHaveBeenCalled();
+    expect(rpcMock).toHaveBeenCalledWith('delete_pictogram', { p_pictogram_id: 'p-1' });
     expect(removeMock).not.toHaveBeenCalled();
   });
 
-  it('skips the boards round-trip when scrubFromBoardIds is empty', async () => {
+  it('classifies a coded RPC error as unretryable', async () => {
+    rpcMock.mockResolvedValue({
+      error: { code: '42501', message: 'denied', details: '', hint: '' },
+    });
     const entry: DeletePictogramEntry = {
       ...baseProps,
       kind: 'deletePicto',
       pictogramId: 'p-1',
-      scrubFromBoardIds: [],
     };
-    await runHandler(entry);
-    expect(selectMock).not.toHaveBeenCalled();
-    expect(inMock).not.toHaveBeenCalled();
-    expect(deleteEqMock).toHaveBeenCalledWith('id', 'p-1');
+    await expect(runHandler(entry)).rejects.toBeInstanceOf(UnretryableOutboxError);
   });
 });
 

--- a/src/lib/outbox/handlers.ts
+++ b/src/lib/outbox/handlers.ts
@@ -142,35 +142,13 @@ const handleReplacePictogramImage = async (entry: ReplacePictogramImageEntry): P
 };
 
 const handleDeletePictogram = async (entry: DeletePictogramEntry): Promise<void> => {
-  // Order matters: scrub boards' step_ids → clean up storage → delete the
-  // pictograms row last. step_ids is a uuid[] with no FK, so we have to
-  // strip references manually before the row goes away (otherwise boards
-  // that referenced it keep dangling UUIDs). Storage cleanup runs *before*
-  // the row delete so a transient storage failure throws and the outbox
-  // retries the whole entry — once the row is gone, a retry can't re-derive
-  // which keys to remove. Each step is idempotent on retry: the SELECT
-  // re-reads current step_ids, the UPDATEs are no-ops where already
-  // scrubbed, the storage removes return success on missing keys, and the
-  // final DELETE returns no error if the row is already gone.
-  //
-  // The boards scrub takes one SELECT plus N sequential UPDATE calls (one
-  // per actually-referencing board); idempotent so retries are safe.
-  if (entry.scrubFromBoardIds.length > 0) {
-    const { data: rows, error: readErr } = await supabase
-      .from('boards')
-      .select('id, step_ids')
-      .in('id', entry.scrubFromBoardIds);
-    if (readErr) throw readErr;
-    for (const row of rows ?? []) {
-      const next = row.step_ids.filter((id: string) => id !== entry.pictogramId);
-      if (next.length === row.step_ids.length) continue;
-      const { error: updErr } = await supabase
-        .from('boards')
-        .update({ step_ids: next })
-        .eq('id', row.id);
-      if (updErr) throw updErr;
-    }
-  }
+  // The boards scrub + row delete run server-side in the `delete_pictogram`
+  // RPC, one transaction, with the referencing boards recomputed at execution
+  // time (#280) — no stale client-cache scrub list. Storage cleanup runs
+  // *before* the RPC so a transient storage failure throws and the outbox
+  // retries the whole entry. Each step is idempotent on retry: the storage
+  // removes return success on missing keys, and the RPC is a no-op once the
+  // row is gone.
   if (isUploadedStoragePath(entry.previousImagePath)) {
     await removeFromBucket(IMAGES_BUCKET, [entry.previousImagePath]);
     invalidateSignedUrl(IMAGES_BUCKET, entry.previousImagePath);
@@ -179,7 +157,9 @@ const handleDeletePictogram = async (entry: DeletePictogramEntry): Promise<void>
     await removeFromBucket(AUDIO_BUCKET, [entry.previousAudioPath]);
     invalidateSignedUrl(AUDIO_BUCKET, entry.previousAudioPath);
   }
-  const { error } = await supabase.from('pictograms').delete().eq('id', entry.pictogramId);
+  const { error } = await supabase.rpc('delete_pictogram', {
+    p_pictogram_id: entry.pictogramId,
+  });
   if (error) throw error;
 };
 

--- a/src/lib/outbox/types.ts
+++ b/src/lib/outbox/types.ts
@@ -92,12 +92,6 @@ export interface DeletePictogramEntry extends OutboxEntryBase {
   /** Storage paths to clean up. Stock-prefixed paths are skipped by the handler. */
   previousImagePath?: string;
   previousAudioPath?: string;
-  /**
-   * Boards whose `step_ids` reference this pictogram. Scrubbed via
-   * `array_remove` before the row is deleted, so we don't leave dangling
-   * UUIDs in any board the user owns.
-   */
-  scrubFromBoardIds: string[];
 }
 
 export interface RenameKidEntry extends OutboxEntryBase {

--- a/src/lib/queries/pictograms.mutations.ts
+++ b/src/lib/queries/pictograms.mutations.ts
@@ -244,7 +244,6 @@ export const useReplacePictogramImage = (): UseMutationResult<
 
 export interface DeletePictogramInput {
   pictogramId: string;
-  scrubFromBoardIds: string[];
   previousImagePath?: string;
   previousAudioPath?: string;
 }
@@ -279,11 +278,10 @@ export const useDeletePictogram = (): UseMutationResult<
       );
       return { previousPictograms, previousBoards };
     },
-    mutationFn: ({ pictogramId, scrubFromBoardIds, previousImagePath, previousAudioPath }) =>
+    mutationFn: ({ pictogramId, previousImagePath, previousAudioPath }) =>
       enqueueAndDrain({
         kind: 'deletePicto',
         pictogramId,
-        scrubFromBoardIds,
         ...(previousImagePath ? { previousImagePath } : {}),
         ...(previousAudioPath ? { previousAudioPath } : {}),
       }),

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -241,7 +241,7 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      delete_pictogram: { Args: { p_pictogram_id: string }; Returns: undefined }
     }
     Enums: {
       [_ in never]: never

--- a/src/ui/PictogramSheet/PictogramSheet.test.tsx
+++ b/src/ui/PictogramSheet/PictogramSheet.test.tsx
@@ -17,7 +17,6 @@ const deleteMock =
   vi.fn<
     (input: {
       pictogramId: string;
-      scrubFromBoardIds: string[];
       previousImagePath?: string;
       previousAudioPath?: string;
     }) => Promise<void>
@@ -140,7 +139,6 @@ describe('PictogramSheet', () => {
     await waitFor(() => {
       expect(deleteMock).toHaveBeenCalledWith({
         pictogramId: 'p1',
-        scrubFromBoardIds: ['b1', 'b2'],
       });
       expect(onClose).toHaveBeenCalled();
     });

--- a/src/ui/PictogramSheet/PictogramSheet.tsx
+++ b/src/ui/PictogramSheet/PictogramSheet.tsx
@@ -104,7 +104,6 @@ export const PictogramSheet = ({ picto, onClose }: Props): JSX.Element => {
     try {
       await deleteMut.mutateAsync({
         pictogramId: picto.id,
-        scrubFromBoardIds: referencedBoardIds,
         ...(picto.style === 'photo' && picto.imagePath
           ? { previousImagePath: picto.imagePath }
           : {}),

--- a/supabase/migrations/20260610110409_add_delete_pictogram_rpc.sql
+++ b/supabase/migrations/20260610110409_add_delete_pictogram_rpc.sql
@@ -1,0 +1,36 @@
+-- Atomic pictogram deletion RPC (#280).
+--
+-- `boards.step_ids` is a bare uuid[] with no FK, so deleting a pictogram
+-- used to require the client to scrub references itself: SELECT + N UPDATEs
+-- + DELETE from the browser, with the scrub list computed from the client
+-- cache at enqueue time. Non-atomic (a crash mid-way leaves partial state)
+-- and the stale scrub list could miss boards edited between enqueue and
+-- drain, leaving dangling step_ids forever. This function recomputes the
+-- referencing boards at execution time and runs scrub + delete in one
+-- transaction. Storage cleanup stays client-side.
+--
+-- SECURITY INVOKER on purpose: RLS scopes the UPDATE to boards the caller
+-- can write and the DELETE to pictograms they own, so no authorization code
+-- is needed here and the rest_surface_contract_test invariant (no SECURITY
+-- DEFINER functions in public) holds. Idempotent: a retry after success
+-- (outbox redelivery) finds nothing to scrub or delete and is a no-op.
+create function public.delete_pictogram(p_pictogram_id uuid)
+returns void
+language plpgsql
+security invoker
+set search_path = public
+as $$
+begin
+  update boards
+     set step_ids = array_remove(step_ids, p_pictogram_id)
+   where step_ids @> array[p_pictogram_id];
+  delete from pictograms where id = p_pictogram_id;
+end;
+$$;
+
+-- Per the grant contract in 20260427000000_tighten_grants.sql: anon has no
+-- surface in this app, so strip the default PUBLIC execute grant and pin
+-- execute per role. (Safe to revoke here — unlike the private RLS helpers,
+-- this function is never evaluated inside a policy.)
+revoke all on function public.delete_pictogram(uuid) from public, anon;
+grant execute on function public.delete_pictogram(uuid) to authenticated, service_role;

--- a/supabase/tests/delete_pictogram_rpc_test.sql
+++ b/supabase/tests/delete_pictogram_rpc_test.sql
@@ -1,0 +1,89 @@
+-- Tests for the `delete_pictogram` RPC (#280).
+--
+-- Pictogram deletion used to run SELECT + N UPDATEs + DELETE from the
+-- browser, with the scrub list computed from the client cache at enqueue
+-- time — non-atomic, and stale lists left dangling step_ids. The RPC
+-- scrubs `boards.step_ids` server-side and deletes the row in one
+-- transaction. SECURITY INVOKER: RLS scopes the scrub to boards the
+-- caller can write and the delete to pictograms they own, so a stranger
+-- calling it is a no-op.
+--
+-- Run with: supabase test db
+BEGIN;
+SELECT plan(6);
+
+INSERT INTO auth.users (id, email)
+VALUES
+  ('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', 'alice@test.local'),
+  ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', 'bob@test.local');
+
+-- A pictogram of Alice's, referenced (twice) from every board she owns.
+-- Setup runs as postgres so RLS doesn't apply; the duplicate entry checks
+-- that array_remove strips all occurrences, not just the first.
+INSERT INTO public.pictograms (id, owner_id, label, style, glyph, tint)
+VALUES ('dddddddd-0000-4000-8000-000000000280',
+        'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', 'Doomed', 'illus', 'star', 'sun');
+
+UPDATE public.boards
+   SET step_ids = step_ids || ARRAY['dddddddd-0000-4000-8000-000000000280',
+                                    'dddddddd-0000-4000-8000-000000000280']::uuid[]
+ WHERE owner_id = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+CREATE TEMP TABLE expected AS
+  SELECT (SELECT count(*)::int FROM public.boards
+           WHERE owner_id = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa') AS boards;
+GRANT SELECT ON expected TO authenticated;
+
+SELECT cmp_ok((SELECT boards FROM expected), '>', 0,
+  'setup: Alice has at least one seeded board to scrub');
+
+-- ── 1-2. A stranger's call is a no-op (RLS floor) ──────────────────────────
+
+SET LOCAL ROLE authenticated;
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb","role":"authenticated"}';
+SELECT public.delete_pictogram('dddddddd-0000-4000-8000-000000000280');
+RESET ROLE;
+
+SELECT is(
+  (SELECT count(*)::int FROM public.pictograms
+    WHERE id = 'dddddddd-0000-4000-8000-000000000280'),
+  1,
+  'stranger call leaves the pictogram row intact'
+);
+SELECT is(
+  (SELECT count(*)::int FROM public.boards
+    WHERE step_ids @> ARRAY['dddddddd-0000-4000-8000-000000000280']::uuid[]),
+  (SELECT boards FROM expected),
+  'stranger call leaves board references intact'
+);
+
+-- ── 3-5. The owner's call scrubs and deletes atomically ────────────────────
+
+SET LOCAL ROLE authenticated;
+SET LOCAL "request.jwt.claims" TO
+  '{"sub":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","role":"authenticated"}';
+SELECT public.delete_pictogram('dddddddd-0000-4000-8000-000000000280');
+
+-- Idempotent: a retry after success (outbox redelivery) must not error.
+SELECT lives_ok(
+  $$SELECT public.delete_pictogram('dddddddd-0000-4000-8000-000000000280')$$,
+  'repeat call after deletion is a no-op'
+);
+RESET ROLE;
+
+SELECT is(
+  (SELECT count(*)::int FROM public.pictograms
+    WHERE id = 'dddddddd-0000-4000-8000-000000000280'),
+  0,
+  'owner call deletes the pictogram row'
+);
+SELECT is(
+  (SELECT count(*)::int FROM public.boards
+    WHERE step_ids @> ARRAY['dddddddd-0000-4000-8000-000000000280']::uuid[]),
+  0,
+  'owner call scrubs every step_ids reference (including duplicates)'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Closes #280.

## Problem
`boards.step_ids` is a bare `uuid[]` with no FK, so `handleDeletePictogram` ran SELECT + N UPDATEs (scrub) + storage removes + DELETE from the browser:
- The sequence wasn't atomic — a crash mid-way left partial state.
- The scrub list was computed from the **client cache at enqueue time**; a board edited between enqueue and drain could keep a dangling pictogram ID forever (invisible rot, since `buildSteps` filters missing pictos).

## Fix
New `public.delete_pictogram(p_pictogram_id uuid)` RPC (migration `20260610110409`, created via supabase CLI per AGENTS.md) that scrubs `step_ids` via `array_remove` across all referencing boards — recomputed at execution time — and deletes the row, in one transaction.

**SECURITY INVOKER on purpose**: RLS scopes the scrub to boards the caller can write and the delete to pictograms they own, so the function needs no authorization code and the `rest_surface_contract_test` invariant (no SECURITY DEFINER in `public`) holds. Grants follow the tighten-grants contract (revoked from `anon`/PUBLIC, granted to `authenticated`/`service_role`; safe to revoke since it's never evaluated inside a policy).

The outbox handler shrinks to storage removes (kept client-side, before the RPC so transient storage failures retry the whole entry) + one `.rpc()` call. `scrubFromBoardIds` is dropped from the payload, mutation input, and enqueue site; old queued IDB entries carrying it are ignored harmlessly. `referencingBoardIds` stays — it still powers the "Used on N boards" delete warning.

Note: the issue says `text[]`; the schema was rebuilt with `uuid`/`uuid[]` in `20260425000000_real_auth_onboarding.sql`, so the RPC takes `uuid`.

## Tests
- New pgTAP `supabase/tests/delete_pictogram_rpc_test.sql`: stranger's call is a no-op (RLS floor), owner's call scrubs every reference (incl. duplicates) and deletes the row, repeat call is idempotent. Written first, watched fail, then green.
- `handlers.test.ts` deletePicto suite rewritten against the RPC (single call, no table traffic, stock-path skip, coded-error classification).
- `supabase test db` 146/146, `npm run test` 396/396, typecheck + lint clean.