### PR TITLE
docs: commit AGENTS.md with real project context; add outbox write-path guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,194 @@
+# AGENTS.md
+
+Drop-in operating instructions for coding agents. Read this file before every task.
+
+**Working code only. Finish the job. Plausibility is not correctness.**
+
+This file follows the [AGENTS.md](https://agents.md) open standard (Linux Foundation / Agentic AI Foundation). Claude Code, Codex, Cursor, Windsurf, Copilot, Aider, Devin, Amp read it natively. For tools that look elsewhere, symlink:
+
+```bash
+ln -s AGENTS.md CLAUDE.md
+ln -s AGENTS.md GEMINI.md
+```
+
+---
+
+## 0. Non-negotiables
+
+These rules override everything else in this file when in conflict:
+
+1. **No flattery, no filler.** Skip openers like "Great question", "You're absolutely right", "Excellent idea", "I'd be happy to". Start with the answer or the action.
+2. **Disagree when you disagree.** If the user's premise is wrong, say so before doing the work. Agreeing with false premises to be polite is the single worst failure mode in coding agents.
+3. **Never fabricate.** Not file paths, not commit hashes, not API names, not test results, not library functions. If you don't know, read the file, run the command, or say "I don't know, let me check."
+4. **Stop when confused.** If the task has two plausible interpretations, ask. Do not pick silently and proceed.
+5. **Touch only what you must.** Every changed line must trace directly to the user's request. No drive-by refactors, reformatting, or "while I was in there" cleanups.
+
+---
+
+## 1. Before writing code
+
+**Goal: understand the problem and the codebase before producing a diff.**
+
+- State your plan in one or two sentences before editing. For anything non-trivial, produce a numbered list of steps with a verification check for each.
+- Read the files you will touch. Read the files that call the files you will touch. Claude Code: use subagents for exploration so the main context stays clean.
+- Match existing patterns in the codebase. If the project uses pattern X, use pattern X, even if you'd do it differently in a greenfield repo.
+- Surface assumptions out loud: "I'm assuming you want X, Y, Z. If that's wrong, say so." Do not bury assumptions inside the implementation.
+- If two approaches exist, present both with tradeoffs. Do not pick one silently. Exception: trivial tasks (typo, rename, log line) where the diff fits in one sentence.
+
+---
+
+## 2. Writing code: simplicity first
+
+**Goal: the minimum code that solves the stated problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code. No configurability, flexibility, or hooks that were not requested.
+- No error handling for impossible scenarios. Handle the failures that can actually happen.
+- If the solution runs 200 lines and could be 50, rewrite it before showing it.
+- If you find yourself adding "for future extensibility", stop. Future extensibility is a future decision.
+- Bias toward deleting code over adding code. Shipping less is almost always better.
+
+The test: would a senior engineer reading the diff call this overcomplicated? If yes, simplify.
+
+---
+
+## 3. Surgical changes
+
+**Goal: clean, reviewable diffs. Change only what the request requires.**
+
+- Do not "improve" adjacent code, comments, formatting, or imports that are not part of the task.
+- Do not refactor code that works just because you are in the file.
+- Do not delete pre-existing dead code unless asked. If you notice it, mention it in the summary.
+- Do clean up orphans created by your own changes (unused imports, variables, functions your edit made obsolete).
+- Match the project's existing style exactly: indentation, quotes, naming, file layout.
+
+The test: every changed line traces directly to the user's request. If a line fails that test, revert it.
+
+---
+
+## 4. Goal-driven execution
+
+**Goal: define success as something you can verify, then loop until verified.**
+
+Rewrite vague asks into verifiable goals before starting:
+
+- "Add validation" becomes "Write tests for invalid inputs (empty, malformed, oversized), then make them pass."
+- "Fix the bug" becomes "Write a failing test that reproduces the reported symptom, then make it pass."
+- "Refactor X" becomes "Ensure the existing test suite passes before and after, and no public API changes."
+- "Make it faster" becomes "Benchmark the current hot path, identify the bottleneck with profiling, change it, show the benchmark is faster."
+
+For every task:
+
+1. State the success criteria before writing code.
+2. Write the verification (test, script, benchmark, screenshot diff) where practical.
+3. Run the verification. Read the output. Do not claim success without checking.
+4. If the verification fails, fix the cause, not the test.
+
+---
+
+## 5. Tool use and verification
+
+- Prefer running the code to guessing about the code. If a test suite exists, run it. If a linter exists, run it. If a type checker exists, run it.
+- Never report "done" based on a plausible-looking diff alone. Plausibility is not correctness.
+- When debugging, address root causes, not symptoms. Suppressing the error is not fixing the error.
+- For UI changes, verify visually: screenshot before, screenshot after, describe the diff.
+- Use CLI tools (gh, aws, gcloud, kubectl) when they exist. They are more context-efficient than reading docs or hitting APIs unauthenticated.
+- When reading logs, errors, or stack traces, read the whole thing. Half-read traces produce wrong fixes.
+
+---
+
+## 6. Session hygiene
+
+- Context is the constraint. Long sessions with accumulated failed attempts perform worse than fresh sessions with a better prompt.
+- After two failed corrections on the same issue, stop. Summarize what you learned and ask the user to reset the session with a sharper prompt.
+- Use subagents (Claude Code: "use subagents to investigate X") for exploration tasks that would otherwise pollute the main context with dozens of file reads.
+- When committing, write descriptive commit messages (subject under 72 chars, body explains the why). No "update file" or "fix bug" commits. No "Co-Authored-By: Claude" attribution unless the project explicitly wants it.
+
+---
+
+## 7. Communication style
+
+- Direct, not diplomatic. "This won't scale because X" beats "That's an interesting approach, but have you considered...".
+- Concise by default. Two or three short paragraphs unless the user asks for depth. No padding, no restating the question, no ceremonial closings.
+- When a question has a clear answer, give it. When it does not, say so and give your best read on the tradeoffs.
+- Celebrate only what matters: shipping, solving genuinely hard problems, metrics that moved. Not feature ideas, not scope creep, not "wouldn't it be cool if".
+- No excessive bullet points, no unprompted headers, no emoji. Prose is usually clearer than structure for short answers.
+
+---
+
+## 8. When to ask, when to proceed
+
+**Ask before proceeding when:**
+- The request has two plausible interpretations and the choice materially affects the output.
+- The change touches something you've been told is load-bearing, versioned, or has a migration path.
+- You need a credential, a secret, or a production resource you don't have access to.
+- The user's stated goal and the literal request appear to conflict.
+
+**Proceed without asking when:**
+- The task is trivial and reversible (typo, rename a local variable, add a log line).
+- The ambiguity can be resolved by reading the code or running a command.
+- The user has already answered the question once in this session.
+
+---
+
+## 9. Self-improvement loop
+
+**This file is living. Keep it short by keeping it honest.**
+
+After every session where the agent did something wrong:
+
+1. Ask: was the mistake because this file lacks a rule, or because the agent ignored a rule?
+2. If lacking: add the rule under "Project Learnings" below, written as concretely as possible ("Always use X for Y" not "be careful with Y").
+3. If ignored: the rule may be too long, too vague, or buried. Tighten it or move it up.
+4. Every few weeks, prune. For each line, ask: "Would removing this cause the agent to make a mistake?" If no, delete. Bloated AGENTS.md files get ignored wholesale.
+
+---
+
+## 10. Project context
+
+### Stack
+- TypeScript (strict), React 19, Vite. State: TanStack React Query v5 (+ IDB persistence). Routing: react-router-dom 7. Styling: CSS Modules + theme tokens. DnD: dnd-kit.
+- Backend: Supabase (Postgres + Auth + Storage); edge functions in Deno.
+- Package manager: npm. Runtime targets: Cloudflare Pages (SPA), Supabase Cloud (DB), full-screen iPad landscape 1194×834 as the design surface.
+
+### Commands
+- Install: `npm install`
+- Run locally: `supabase start && supabase db reset && npm run dev` (OTPs land in Inbucket at http://127.0.0.1:54324)
+- Build: `npm run build`
+- Test (all): `npm run test`
+- Test (single file): `npx vitest run src/path/to/file.test.ts`
+- DB tests (pgTAP): `npm run test:db` — single file: `supabase test db supabase/tests/<file>.sql`
+- Lint: `npm run lint` (zero warnings) and `npm run lint:css`
+- Typecheck: `npm run typecheck`
+- After editing a migration: `supabase db reset && npm run types:db`, commit the migration **and** the regenerated `src/types/supabase.ts`
+
+Prefer single-file or single-test runs during iteration. Full suites are for the final verification pass.
+
+### Layout
+- Source lives in: `src/` — layered `app → routes → features → lib/ui/layouts → theme/types`; ESLint forbids upward imports. See the README architecture section.
+- Tests live in: colocated `*.test.ts(x)` next to source; pgTAP SQL tests in `supabase/tests/`.
+- Do not modify: `src/types/supabase.ts` (generated — regenerate with `npm run types:db`).
+
+### Conventions specific to this repo
+- DB reads go through `src/lib/queries/*` react-query hooks; writes go through the `src/lib/outbox` queue (`enqueueAndDrain`) — see `docs/outbox.md`; storage URL minting through `src/lib/storage`. All ESLint-enforced.
+- `features/` never import each other — compose at the route layer.
+- Colors and spacing in `*.module.css` must use theme tokens; stylelint blocks raw hex/rgb/hsl and raw `px` in padding/margin/gap.
+- Testing: Vitest + Testing Library; assert what users see, not internal state.
+- Migrations: `supabase migration new <snake_case_name>`; SQL functions pin `set search_path = public`; follow the grant pattern in `20260427000000_tighten_grants.sql` (revoke anon/PUBLIC, grant authenticated/service_role).
+
+### Forbidden
+- Hand-editing `src/types/supabase.ts`.
+- SECURITY DEFINER functions in the `public` schema (pinned by `supabase/tests/rest_surface_contract_test.sql`).
+- Stacked PRs — branch every PR off `main`; squash-merge with `--delete-branch`.
+- Pro-tier Supabase features (HIBP password checks, PITR, …) — the project runs on the free tier.
+
+---
+
+## 11. Project Learnings
+
+**Accumulated corrections. This section is for the agent to maintain, not just the human.**
+
+When the user corrects your approach, append a one-line rule here before ending the session. Write it concretely ("Always use X for Y"), never abstractly ("be careful with Y"). If an existing line already covers the correction, tighten it instead of adding a new one. Remove lines when the underlying issue goes away (model upgrades, refactors, process changes).
+
+- For Supabase schema work (push migrations, regenerate types, `db reset`), always use the official `supabase` CLI — never the Supabase MCP server. The MCP `apply_migration` stamps apply-time timestamps into `supabase_migrations.schema_migrations.version` instead of the file's timestamp prefix, which makes future `supabase db push --linked` see local files as missing and try to re-apply (schema conflict). MCP `generate_typescript_types` only emits the `public` schema, missing `graphql_public` that the CLI includes. MCP is fine for read-only inspection (list_tables, get_advisors, ad-hoc SELECT) but not for writes that need to match what CI does.
+- RLS helper functions (SECURITY DEFINER) live in the `private` schema, never `public`. PostgREST exposes every function in schemas listed under `[api].schemas` (currently `["public", "graphql_public"]`) as `/rest/v1/rpc/<name>`; helpers like `is_board_owner` are internal RLS plumbing, not API surface. Policies reference them by qualified name `private.X(...)` (Postgres rewrites this automatically when you do `ALTER FUNCTION ... SET SCHEMA private`). DO NOT revoke EXECUTE on these helpers from anon/authenticated/PUBLIC — empirically that crashes Postgres mid-policy-evaluation. The schema move is sufficient to clear the advisor lints (0028 + 0029) because PostgREST only exposes functions in configured schemas. Pinned by `supabase/tests/rest_surface_contract_test.sql`.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Data-access rules — pinned by `no-restricted-imports` / `no-restricted-syntax`
 in `eslint.config.js`:
 
 - DB reads go through `src/lib/queries/*` (react-query hooks).
-- Writes go through `src/lib/outbox` (offline-tolerant queue).
+- Writes go through `src/lib/outbox` (offline-tolerant queue) — the full
+  write-path lifecycle is in [docs/outbox.md](./docs/outbox.md).
 - Storage URL minting goes through `src/lib/storage`.
 - Auth subscription is centralized in `src/app/AuthGate`; sign-in/out helpers
   live in `src/lib/auth/`.

--- a/docs/outbox.md
+++ b/docs/outbox.md
@@ -1,0 +1,98 @@
+# The outbox: lifecycle of a write
+
+Every mutation in Talrum goes through `src/lib/outbox` instead of calling
+Supabase directly. The goal: a parent on a flaky tablet connection can rename
+a pictogram, lose Wi-Fi, close the lid, and the write still lands — without
+the UI ever blocking on the network. This page is the narrative; the inline
+doc comments in `src/lib/outbox/*` carry the per-decision detail.
+
+## The shape
+
+```
+mutation hook (lib/queries/*.mutations.ts)
+  │  onMutate: optimistic patch into the React Query cache
+  ▼
+enqueueAndDrain(entry)            src/lib/outbox/index.ts
+  │ online + empty queue → run the handler immediately (fast path)
+  │ otherwise            → persist entry to IndexedDB, drain replays it
+  ▼
+drain()                           src/lib/outbox/drain.ts
+  │ FIFO over pending entries; retries, retry ceiling, status events
+  ▼
+runHandler(entry)                 src/lib/outbox/handlers.ts
+     one handler per entry kind: Supabase table writes, RPCs, Storage I/O
+```
+
+- **`types.ts`** — one interface per entry kind (`updateBoard`,
+  `deletePicto`, …), discriminated on `kind`. Entries are plain objects (plus
+  `Blob`s) because they must survive IndexedDB round-trips.
+- **`store.ts`** — IndexedDB persistence via `idb-keyval`. One key per entry
+  (`outbox:{ulid}`); ULID key order = enqueue order, so FIFO is free.
+- **`drain.ts`** — the replay loop plus the status feed
+  (`pendingCount` / `failedCount` / `draining` / `online`) that
+  `useOutboxStatus` exposes and `ui/OfflineIndicator` renders.
+- **`handlers.ts`** — the only code that talks to Supabase for writes, and
+  the single place errors are classified (`runHandler` wraps every handler).
+
+## One write, step by step
+
+1. **Optimistic patch.** The mutation hook's `onMutate` writes the expected
+   result into the React Query cache, so the UI updates instantly. `onError`
+   restores the pre-mutation snapshot; `onSettled`/`onSuccess` invalidate so
+   the next refetch reconciles with the server.
+2. **Fast path (online, empty queue).** `enqueueAndDrain` runs the handler
+   immediately — no IndexedDB detour. The fast path requires an *empty
+   pending queue*: jumping ahead of older queued entries would let their
+   replay overwrite this newer write with stale data (#279).
+3. **Slow path.** Offline, or online with a backlog: the entry is persisted
+   to IndexedDB and `drain()` (or the next `online` event) replays it. The
+   promise resolves as soon as the entry is persisted — the UI keeps its
+   optimistic state and the indicator shows the pending count.
+4. **Drain.** `drain()` walks pending entries oldest-first. It stops at the
+   first *transient* failure to preserve ordering, but marks *permanent*
+   failures as `failed` and moves on, so one bad entry can't dam the queue.
+   `startOutbox()` (called once at app boot) wires the `online` event and
+   kicks an initial drain for entries left over from a previous session.
+
+## Error classification: transient vs permanent
+
+All classification lives in `classifyAndThrow` in `handlers.ts` — handlers
+themselves are happy-path only.
+
+- **Transient** (network `TypeError`, 5xx): the entry stays `pending` and is
+  retried on the next drain, up to 3 attempts, after which it flips to
+  `failed` so it can't retry forever.
+- **Permanent** (`UnretryableOutboxError`: coded Postgres errors such as RLS
+  denials, 4xx storage errors): no retry. On the fast path the mutation
+  promise rejects, so React Query rolls back the optimistic patch and the
+  user sees the error. On the slow path the entry is marked `failed`; the
+  OfflineIndicator surfaces it with **Retry** (resets failed entries to
+  pending with a fresh attempt budget, #277) and **Discard**.
+
+## Rules for writing a handler
+
+New entry kind? Add the interface in `types.ts`, the handler in
+`handlers.ts`, a `dispatch` case, and a mutation hook. Handlers must be:
+
+- **Idempotent.** A drain can replay an entry that already (partially)
+  succeeded — e.g. the fast path crashed after the Storage upload but before
+  the table write. Re-running must converge, not error. Server-side
+  `array_remove`/`ON DELETE CASCADE`/RPC no-ops are the usual tools; see
+  `delete_pictogram` (#280).
+- **Authorization-free.** RLS is the security boundary; a handler running
+  against someone else's rows should fail (or no-op) at the database, never
+  by client-side checks.
+- **Order-aware.** Within one entry, put the steps whose failure should
+  *retry the whole entry* first (e.g. Storage cleanup before the row
+  delete). Best-effort cleanup that must never fail the write uses
+  `.catch(reportCleanupFailure)`, which logs to telemetry instead of
+  throwing.
+- **Happy-path only.** Throw raw Supabase/Storage errors; `runHandler` owns
+  classification. Never catch-and-swallow.
+
+## Known limits
+
+- The queue is per-tab: two open tabs each drain independently, which can
+  duplicate work (#278).
+- Replays are last-write-wins per column; concurrent edits to a shared board
+  can silently discard one side (#281).


### PR DESCRIPTION
## Why

- The README's conventions section links to `AGENTS.md`, but the file never existed in the repo (it lived only as a gitignored local `CLAUDE.md`), and its **Project context** section was all `TODO` placeholders. New developers hit a dead link and agents got no project facts.
- The outbox is the most novel subsystem in the app — every mutation flows through it — but its narrative was scattered across doc comments in `index.ts`, `drain.ts`, `handlers.ts`, and the mutation hooks.

## What

- **`AGENTS.md`** (new, tracked): the agent operating rules with section 10 filled in for real — stack, commands (incl. single-file test runs and the migration → `types:db` loop), layout, repo conventions (lint-enforced data-access rules, token-only CSS, migration/grant patterns), and a Forbidden list (hand-editing generated types, SECURITY DEFINER in `public`, stacked PRs, Pro-tier Supabase features). Accumulated Supabase learnings carried over verbatim; the 'how this file was built' boilerplate section dropped. `CLAUDE.md` stays gitignored — locally it's now a symlink to this file, per the AGENTS.md standard.
- **`docs/outbox.md`** (new): one-page lifecycle of a write — optimistic cache patch → `enqueueAndDrain` fast/slow path → drain loop → transient/permanent classification — plus the four rules for writing a new handler (idempotent, authorization-free, order-aware, happy-path only) and known limits (#278, #281).
- **`README.md`**: link the outbox doc from the data-access rules.

Docs only — no code changes.