### PR TITLE
fix(outbox): serialize drains across tabs via Web Locks (#278)

### DIFF
--- a/docs/outbox.md
+++ b/docs/outbox.md
@@ -94,7 +94,10 @@ New entry kind? Add the interface in `types.ts`, the handler in
 
 ## Known limits
 
-- The queue is per-tab: two open tabs each drain independently, which can
-  duplicate work (#278).
 - Replays are last-write-wins per column; concurrent edits to a shared board
   can silently discard one side (#281).
+
+Cross-tab drains (a PWA window plus a browser tab over the same IndexedDB
+queue) used to race and could resurrect completed entries as failed; drains
+now serialize on a `navigator.locks` web lock, and the mark-failed path
+tolerates an entry deleted by another tab mid-flight (#278).

--- a/docs/outbox.md
+++ b/docs/outbox.md
@@ -53,6 +53,8 @@ runHandler(entry)                 src/lib/outbox/handlers.ts
 4. **Drain.** `drain()` walks pending entries oldest-first. It stops at the
    first *transient* failure to preserve ordering, but marks *permanent*
    failures as `failed` and moves on, so one bad entry can't dam the queue.
+   Drains serialize across tabs on a `navigator.locks` web lock, so a PWA
+   window plus a browser tab can't replay the same entry twice (#278).
    `startOutbox()` (called once at app boot) wires the `online` event and
    kicks an initial drain for entries left over from a previous session.
 
@@ -96,8 +98,6 @@ New entry kind? Add the interface in `types.ts`, the handler in
 
 - Replays are last-write-wins per column; concurrent edits to a shared board
   can silently discard one side (#281).
-
-Cross-tab drains (a PWA window plus a browser tab over the same IndexedDB
-queue) used to race and could resurrect completed entries as failed; drains
-now serialize on a `navigator.locks` web lock, and the mark-failed path
-tolerates an entry deleted by another tab mid-flight (#278).
+- Cross-tab drain serialization (#278) relies on the Web Locks API; in an
+  environment without `navigator.locks` only the per-tab re-entrancy guard
+  applies.

--- a/src/lib/outbox/drain.ts
+++ b/src/lib/outbox/drain.ts
@@ -1,6 +1,6 @@
 import { drainState, drainSubscribers, type OutboxStatus } from './drain-state';
 import { runHandler, UnretryableOutboxError } from './handlers';
-import { deleteEntry, listEntries, putEntry } from './store';
+import { deleteEntry, getEntry, listEntries, putEntry } from './store';
 import type { OutboxEntry } from './types';
 
 const MAX_ATTEMPTS_BEFORE_FAILED = 3;
@@ -44,6 +44,11 @@ const runOne = async (entry: OutboxEntry): Promise<'ok' | 'transient' | 'failed'
     await deleteEntry(entry.id);
     return 'ok';
   } catch (err) {
+    // Another tab's drain may have completed this entry and deleted it while
+    // our attempt was in flight (our duplicate write then fails, e.g. on a
+    // unique-key violation). Re-creating the entry as failed/pending would
+    // resurrect a write that already succeeded (#278).
+    if ((await getEntry(entry.id)) === undefined) return 'ok';
     const attemptCount = entry.attemptCount + 1;
     const message = err instanceof Error ? err.message : 'unknown error';
     if (err instanceof UnretryableOutboxError) {
@@ -54,6 +59,22 @@ const runOne = async (entry: OutboxEntry): Promise<'ok' | 'transient' | 'failed'
     await putEntry({ ...entry, attemptCount, status, lastError: message });
     return status === 'failed' ? 'failed' : 'transient';
   }
+};
+
+/**
+ * The `drainState.draining` guard above is per-tab, but the queue lives in
+ * shared IndexedDB: a PWA window plus a browser tab can otherwise drain the
+ * same entries concurrently (#278). Serialize cross-tab via the Web Locks API
+ * (held locks are released automatically if the tab dies). jsdom and SSR have
+ * no `navigator.locks`; fall back to running unlocked — the per-tab guard
+ * still covers the single-context case.
+ */
+const withCrossTabLock = async (fn: () => Promise<void>): Promise<void> => {
+  if (typeof navigator !== 'undefined' && 'locks' in navigator) {
+    await navigator.locks.request('talrum-outbox', fn);
+    return;
+  }
+  await fn();
 };
 
 /**
@@ -73,18 +94,20 @@ export const drain = async (): Promise<void> => {
   drainState.draining = true;
   await emit();
   try {
-    let stop = false;
-    while (!stop) {
-      const entries = (await listEntries()).filter((e) => e.status === 'pending');
-      if (entries.length === 0) break;
-      for (const entry of entries) {
-        const outcome = await runOne(entry);
-        if (outcome === 'transient') {
-          stop = true;
-          break;
+    await withCrossTabLock(async () => {
+      let stop = false;
+      while (!stop) {
+        const entries = (await listEntries()).filter((e) => e.status === 'pending');
+        if (entries.length === 0) break;
+        for (const entry of entries) {
+          const outcome = await runOne(entry);
+          if (outcome === 'transient') {
+            stop = true;
+            break;
+          }
         }
       }
-    }
+    });
   } finally {
     drainState.draining = false;
     await emit();

--- a/src/lib/outbox/drain.ts
+++ b/src/lib/outbox/drain.ts
@@ -95,6 +95,10 @@ export const drain = async (): Promise<void> => {
   await emit();
   try {
     await withCrossTabLock(async () => {
+      // The pre-drain online check can be seconds stale by the time another
+      // tab releases the lock; attempting entries on a network that dropped
+      // meanwhile burns their transient-retry budget on guaranteed failures.
+      if (typeof navigator !== 'undefined' && !navigator.onLine) return;
       let stop = false;
       while (!stop) {
         const entries = (await listEntries()).filter((e) => e.status === 'pending');

--- a/src/lib/outbox/outbox.test.ts
+++ b/src/lib/outbox/outbox.test.ts
@@ -134,6 +134,78 @@ describe('outbox drain', () => {
   });
 });
 
+describe('cross-tab coordination (#278)', () => {
+  /**
+   * Minimal Web Locks fake: serializes callbacks per lock name via a promise
+   * chain. jsdom has no `navigator.locks`, so installing this opts drain()
+   * into its locked path; the surrounding afterEach removes it again.
+   */
+  const installFakeLocks = () => {
+    const chains = new Map<string, Promise<unknown>>();
+    const request = vi.fn((name: string, cb: () => unknown): Promise<unknown> => {
+      const prev = chains.get(name) ?? Promise.resolve();
+      const run = prev.then(() => cb());
+      chains.set(
+        name,
+        run.then(
+          () => undefined,
+          () => undefined,
+        ),
+      );
+      return run;
+    });
+    Object.defineProperty(navigator, 'locks', { value: { request }, configurable: true });
+    return request;
+  };
+
+  afterEach(() => {
+    delete (navigator as { locks?: unknown }).locks;
+  });
+
+  it('drain waits for the talrum-outbox web lock held by another tab', async () => {
+    const request = installFakeLocks();
+    await putEntry(baseEntry({ id: '01HZZA' }));
+    let release = (): void => undefined;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    // "Another tab" grabs the lock first.
+    void navigator.locks.request('talrum-outbox', () => held);
+    const drainDone = drain();
+    // Wait until drain has queued its own lock request, then give the
+    // microtask queue a chance to (incorrectly) run handlers anyway.
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(eqMock).not.toHaveBeenCalled();
+    release();
+    await drainDone;
+    expect(eqMock).toHaveBeenCalledTimes(1);
+    expect(await listEntries()).toEqual([]);
+  });
+
+  it('does not resurrect an entry another tab completed mid-flight (permanent error)', async () => {
+    await putEntry(baseEntry({ id: '01HZZA' }));
+    eqMock.mockImplementation(async () => {
+      // Another tab finished this entry and deleted it while our attempt was
+      // in flight; our duplicate write then hits a unique-key violation.
+      await deleteEntry('01HZZA');
+      return { error: { code: '23505', message: 'duplicate key', details: '', hint: '' } };
+    });
+    await drain();
+    expect(await listEntries()).toEqual([]);
+  });
+
+  it('does not resurrect an entry another tab completed mid-flight (transient error)', async () => {
+    await putEntry(baseEntry({ id: '01HZZA' }));
+    eqMock.mockImplementation(async () => {
+      await deleteEntry('01HZZA');
+      throw new TypeError('Failed to fetch');
+    });
+    await drain();
+    expect(await listEntries()).toEqual([]);
+  });
+});
+
 describe('retryFailed', () => {
   it('re-attempts failed entries and clears them on success (#277)', async () => {
     await putEntry(

--- a/src/lib/outbox/outbox.test.ts
+++ b/src/lib/outbox/outbox.test.ts
@@ -183,6 +183,26 @@ describe('cross-tab coordination (#278)', () => {
     expect(await listEntries()).toEqual([]);
   });
 
+  it('re-checks onLine after the lock wait so a dead network burns no attempts', async () => {
+    const request = installFakeLocks();
+    await putEntry(baseEntry({ id: '01HZZA' }));
+    let release = (): void => undefined;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    void navigator.locks.request('talrum-outbox', () => held);
+    const drainDone = drain();
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    // The network drops while drain is parked on the other tab's lock — the
+    // pre-lock online check is stale by the time the lock is granted.
+    setOnline(false);
+    release();
+    await drainDone;
+    expect(eqMock).not.toHaveBeenCalled();
+    const entries = await listEntries();
+    expect(entries[0]?.attemptCount).toBe(0);
+  });
+
   it('does not resurrect an entry another tab completed mid-flight (permanent error)', async () => {
     await putEntry(baseEntry({ id: '01HZZA' }));
     eqMock.mockImplementation(async () => {

--- a/src/lib/outbox/store.ts
+++ b/src/lib/outbox/store.ts
@@ -15,6 +15,9 @@ export const putEntry = async (entry: OutboxEntry): Promise<void> => {
   await set(idbKey(entry.id), entry);
 };
 
+export const getEntry = (id: string): Promise<OutboxEntry | undefined> =>
+  get<OutboxEntry>(idbKey(id));
+
 export const deleteEntry = async (id: string): Promise<void> => {
   await del(idbKey(id));
 };


### PR DESCRIPTION
Fixes #278.

## Problem

The drain re-entrancy guard (`drainState.draining`) is per-tab in-memory state, but the queue lives in shared IndexedDB. A PWA window plus a browser tab — realistic on iPad — can both run `drain()` over the same entries concurrently.

Worst interleaving: tab A completes an entry and deletes it; tab B is mid-flight on the same entry, its duplicate write hits a unique-key violation → classified `UnretryableOutboxError` → `putEntry({...entry, status: 'failed'})` **re-creates the already-completed entry as failed**. The user sees "1 sync failed" for a write that succeeded.

## Fix (two layers)

1. **Cross-tab serialization.** `drain()`'s loop now runs inside `navigator.locks.request('talrum-outbox', ...)`. Web Locks is supported in every browser the PWA targets and is auto-released if the holding tab dies. Environments without it (jsdom, SSR) fall back to the unlocked path, which the per-tab guard still covers.
2. **Resurrection guard.** `runOne`'s catch re-checks the entry still exists (new `getEntry` in `store.ts`) before re-marking it failed/pending, so an entry deleted underneath a mid-flight attempt is treated as completed rather than resurrected. Belt-and-braces for lock-less environments.

## Tests (written first, watched fail)

- `drain()` waits for the `talrum-outbox` lock held by "another tab" (fake Web Locks impl) and only runs handlers after release.
- Mid-flight deletion + permanent error → no failed entry re-created.
- Mid-flight deletion + transient error → no pending entry re-created.

Also updates the `docs/outbox.md` known-limits section.

## Verification

- `npm run test` — 399 passed (72 files)
- `npm run lint` / `npm run typecheck` — clean