### PR TITLE
fix(outbox): run retryFailed reset + discardEntry under the cross-tab lock (#289)

### DIFF
--- a/docs/outbox.md
+++ b/docs/outbox.md
@@ -53,8 +53,9 @@ runHandler(entry)                 src/lib/outbox/handlers.ts
 4. **Drain.** `drain()` walks pending entries oldest-first. It stops at the
    first *transient* failure to preserve ordering, but marks *permanent*
    failures as `failed` and moves on, so one bad entry can't dam the queue.
-   Drains serialize across tabs on a `navigator.locks` web lock, so a PWA
-   window plus a browser tab can't replay the same entry twice (#278).
+   Drains — and the Retry/Discard queue rewrites (#289) — serialize across
+   tabs on a `navigator.locks` web lock, so a PWA window plus a browser tab
+   can't replay the same entry twice (#278).
    `startOutbox()` (called once at app boot) wires the `online` event and
    kicks an initial drain for entries left over from a previous session.
 
@@ -98,6 +99,6 @@ New entry kind? Add the interface in `types.ts`, the handler in
 
 - Replays are last-write-wins per column; concurrent edits to a shared board
   can silently discard one side (#281).
-- Cross-tab drain serialization (#278) relies on the Web Locks API; in an
+- Cross-tab serialization (#278, #289) relies on the Web Locks API; in an
   environment without `navigator.locks` only the per-tab re-entrancy guard
   applies.

--- a/src/lib/outbox/drain.ts
+++ b/src/lib/outbox/drain.ts
@@ -68,8 +68,12 @@ const runOne = async (entry: OutboxEntry): Promise<'ok' | 'transient' | 'failed'
  * (held locks are released automatically if the tab dies). jsdom and SSR have
  * no `navigator.locks`; fall back to running unlocked — the per-tab guard
  * still covers the single-context case.
+ *
+ * Also wraps the queue rewrites in `retryFailed`/`discardEntry` (#289). The
+ * lock is exclusive and non-reentrant: never call `drain()` (or anything else
+ * that takes the lock) from inside the callback.
  */
-const withCrossTabLock = async (fn: () => Promise<void>): Promise<void> => {
+export const withCrossTabLock = async (fn: () => Promise<void>): Promise<void> => {
   if (typeof navigator !== 'undefined' && 'locks' in navigator) {
     await navigator.locks.request('talrum-outbox', fn);
     return;

--- a/src/lib/outbox/index.ts
+++ b/src/lib/outbox/index.ts
@@ -8,6 +8,7 @@ import {
   refreshStatus,
   startOutbox,
   subscribeStatus,
+  withCrossTabLock,
 } from './drain';
 import { runHandler, UnretryableOutboxError } from './handlers';
 import { deleteEntry, listEntries, putEntry } from './store';
@@ -96,18 +97,29 @@ export const enqueueAndDrain = async (input: EntryInput): Promise<void> => {
  * Reset every failed entry to pending (fresh retry budget, stale lastError
  * dropped) and drain. The indicator's "Retry" — a plain `drain()` skips
  * failed entries, so without the reset the button is a no-op (#277).
+ *
+ * The list-then-put loop runs under the cross-tab lock so a Discard in
+ * another tab can't land between the list and the put and get resurrected as
+ * pending (#289). `drain()` takes the same (non-reentrant) lock, so it must
+ * stay outside the callback.
  */
 export const retryFailed = async (): Promise<void> => {
-  const failed = (await listEntries()).filter((e) => e.status === 'failed');
-  for (const { lastError: _lastError, ...entry } of failed) {
-    await putEntry({ ...entry, status: 'pending', attemptCount: 0 });
-  }
+  await withCrossTabLock(async () => {
+    const failed = (await listEntries()).filter((e) => e.status === 'failed');
+    for (const { lastError: _lastError, ...entry } of failed) {
+      await putEntry({ ...entry, status: 'pending', attemptCount: 0 });
+    }
+  });
   await drain();
 };
 
-/** Drop a single failed entry from the queue (the indicator's "Discard"). */
+/**
+ * Drop a single failed entry from the queue (the indicator's "Discard").
+ * Takes the cross-tab lock: an unlocked delete could land inside another
+ * tab's `retryFailed` reset loop, which would re-create the entry (#289).
+ */
 export const discardEntry = async (id: string): Promise<void> => {
-  await deleteEntry(id);
+  await withCrossTabLock(() => deleteEntry(id));
 };
 
 /** Inspect the queue (e.g. to render a per-entry error list). */

--- a/src/lib/outbox/outbox.test.ts
+++ b/src/lib/outbox/outbox.test.ts
@@ -174,7 +174,7 @@ describe('cross-tab coordination (#278, #289)', () => {
     const drainDone = drain();
     // Wait until drain has queued its own lock request, then give the
     // microtask queue a chance to (incorrectly) run handlers anyway.
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2), { timeout: 5000 });
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(eqMock).not.toHaveBeenCalled();
     release();
@@ -192,7 +192,7 @@ describe('cross-tab coordination (#278, #289)', () => {
     });
     void navigator.locks.request('talrum-outbox', () => held);
     const drainDone = drain();
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2), { timeout: 5000 });
     // The network drops while drain is parked on the other tab's lock — the
     // pre-lock online check is stale by the time the lock is granted.
     setOnline(false);
@@ -237,7 +237,7 @@ describe('cross-tab coordination (#278, #289)', () => {
     const retryDone = retryFailed();
     // Once a second lock request is queued, an unlocked reset loop would
     // already have flipped the entry to pending — it must still be parked.
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2), { timeout: 5000 });
     expect((await listEntries())[0]?.status).toBe('failed');
     // The other tab's discard lands before the lock is released.
     await deleteEntry('01HZZA');
@@ -256,7 +256,7 @@ describe('cross-tab coordination (#278, #289)', () => {
     });
     void navigator.locks.request('talrum-outbox', () => held);
     const discardDone = discardEntry('01HZZA');
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2), { timeout: 5000 });
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(await listEntries()).toHaveLength(1);
     release();

--- a/src/lib/outbox/outbox.test.ts
+++ b/src/lib/outbox/outbox.test.ts
@@ -19,7 +19,7 @@ vi.mock('@/lib/supabase', () => ({
 
 const { deleteEntry, listEntries, putEntry } = await import('./store');
 const { drain, getStatus, startOutbox, subscribeStatus } = await import('./drain');
-const { enqueueAndDrain, retryFailed } = await import('./index');
+const { discardEntry, enqueueAndDrain, retryFailed } = await import('./index');
 
 const baseEntry = (over: Partial<UpdateBoardEntry> = {}): UpdateBoardEntry => ({
   id: '01HZZZZZZZZZZZZZZZZZZZZZZZ',
@@ -134,7 +134,7 @@ describe('outbox drain', () => {
   });
 });
 
-describe('cross-tab coordination (#278)', () => {
+describe('cross-tab coordination (#278, #289)', () => {
   /**
    * Minimal Web Locks fake: serializes callbacks per lock name via a promise
    * chain. jsdom has no `navigator.locks`, so installing this opts drain()
@@ -222,6 +222,45 @@ describe('cross-tab coordination (#278)', () => {
       throw new TypeError('Failed to fetch');
     });
     await drain();
+    expect(await listEntries()).toEqual([]);
+  });
+
+  it('retryFailed cannot resurrect an entry another tab discards while it waits (#289)', async () => {
+    const request = installFakeLocks();
+    await putEntry(baseEntry({ id: '01HZZA', status: 'failed', attemptCount: 3 }));
+    let release = (): void => undefined;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    // Another tab holds the lock, mid-discard.
+    void navigator.locks.request('talrum-outbox', () => held);
+    const retryDone = retryFailed();
+    // Once a second lock request is queued, an unlocked reset loop would
+    // already have flipped the entry to pending — it must still be parked.
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    expect((await listEntries())[0]?.status).toBe('failed');
+    // The other tab's discard lands before the lock is released.
+    await deleteEntry('01HZZA');
+    release();
+    await retryDone;
+    expect(await listEntries()).toEqual([]);
+    expect(eqMock).not.toHaveBeenCalled();
+  });
+
+  it('discardEntry waits for the talrum-outbox lock (#289)', async () => {
+    const request = installFakeLocks();
+    await putEntry(baseEntry({ id: '01HZZA', status: 'failed', attemptCount: 3 }));
+    let release = (): void => undefined;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    void navigator.locks.request('talrum-outbox', () => held);
+    const discardDone = discardEntry('01HZZA');
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(await listEntries()).toHaveLength(1);
+    release();
+    await discardDone;
     expect(await listEntries()).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes #289. Follow-up to #288, which added the `talrum-outbox` web lock for drains.

## Problem

`retryFailed`'s list-then-put reset loop ran outside the lock. A `discardEntry` in another tab landing between `listEntries()` and `putEntry()` re-created the just-discarded entry as pending — the subsequent drain then replayed a write the user explicitly threw away.

## Fix

- `withCrossTabLock` is now exported from `drain.ts` (doc comment notes it's non-reentrant).
- `retryFailed` runs its reset loop under the lock; `drain()` stays outside the callback (it takes the same lock).
- `discardEntry` takes the lock too — locking only the reset loop wouldn't close the race, since an unlocked delete can still interleave. With both sides serialized, either order yields a correct outcome: discard-first means the reset loop never sees the entry; retry-first means the discard wins afterwards.

Both indicator buttons fire these fire-and-forget (`void retryFailed()`), so the rare wait for an in-flight drain doesn't block the UI.

## Tests (written first, watched fail)

- `retryFailed` parked on a lock held by "another tab" must not have reset the entry yet; the other tab discards before releasing → entry stays gone, handler never runs.
- `discardEntry` waits for the lock and only deletes after release.

## Verification

- `npm run test` — 402 passed, plus the outbox suite green across 6 consecutive full-suite runs (one unrelated test flaked once under load on an early run and never reproduced; its output was lost before it could be identified)
- `npm run lint` / `npm run typecheck` — clean

Related: filed #290 (pre-existing: Discard never emits a status refresh, pill lingers) noticed while reading the widget call sites.