### PR TITLE
ci(ai-review): block confirmed logic + objective architecture findings

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -68,10 +68,13 @@ jobs:
             - No stacked PRs — every branch must be off `main`. Flag if the PR base is not `main`.
 
             VERDICT RULES:
-            - File a `REQUEST_CHANGES` review (via `gh pr review --request-changes`) ONLY for:
+            The line between blocking and advisory is CONFIDENCE, not category. Block only what you can prove; comment on everything you suspect.
+            - File a `REQUEST_CHANGES` review (via `gh pr review --request-changes`) for:
               * A confirmed security finding (RLS hole, secret leak, auth bypass, injection, PII exposure).
               * A clearly broken load-bearing invariant (e.g., a migration that drops a column the app still reads).
-            - For everything else, post as `COMMENT` review (`gh pr review --comment`) with inline comments.
+              * A confirmed logic bug you can trace to specific broken behavior — a silently swallowed failure, an off-by-one at a boundary, a data-losing race, a missing transaction boundary. Not "this might be wrong"; you must be able to name the input and the wrong output.
+              * An OBJECTIVE architecture violation: a drive-by / out-of-scope change unrelated to the PR's stated purpose (per the surgical-changes rule), or a function that demonstrably mixes IO, business logic, and presentation in one body. Objective means a reasonable reviewer could not disagree it's out of scope or mixed.
+            - Post as `COMMENT` review (`gh pr review --comment`) with inline comments for everything that is a judgment call: speculative abstractions, borderline SRP ("feels like two responsibilities"), DRY-extraction suggestions, naming, or any finding where you are not certain it is a real defect. When unsure whether something blocks, COMMENT — do not block.
             - NEVER post `APPROVE` — leave that to the human.
 
             OUTPUT DISCIPLINE:


### PR DESCRIPTION
## What

Widens the AI reviewer's `REQUEST_CHANGES` set beyond security + broken load-bearing invariants to also block:
- **Confirmed logic bugs** — traceable to specific broken behavior (silently swallowed failure, off-by-one at a boundary, data-losing race, missing transaction boundary). Not "might be wrong".
- **Objective architecture violations** — a drive-by / out-of-scope change unrelated to the PR's stated purpose, or a function demonstrably mixing IO + business logic + presentation.

## Design: gate on confidence, not category

Judgment calls (speculative abstractions, borderline SRP, DRY-extraction suggestions, naming) stay **non-blocking comments**. Making every architecture opinion a merge blocker would train the maintainer to dismiss `CHANGES_REQUESTED` reviews by habit, destroying the signal. The reviewer blocks what it can prove and comments on what it suspects.

## Context

Empirically motivated: a blind seeded-defect test (#292, closed) confirmed the reviewer reliably *detects* logic and architecture defects but, under the old rules, only filed them as advisory comments. This change gives those detections teeth without over-blocking.

Only the verdict-rules block of the prompt changed; detection scope is unchanged. The `.github/**` paths-ignore means this PR does not trigger a self-review.