### PR TITLE
fix(outbox): emit status refresh after discardEntry (#290)

### DIFF
--- a/src/lib/outbox/index.ts
+++ b/src/lib/outbox/index.ts
@@ -117,9 +117,16 @@ export const retryFailed = async (): Promise<void> => {
  * Drop a single failed entry from the queue (the indicator's "Discard").
  * Takes the cross-tab lock: an unlocked delete could land inside another
  * tab's `retryFailed` reset loop, which would re-create the entry (#289).
+ *
+ * Unlike Retry (which ends in `drain()`, which emits), a discard does no
+ * draining, so it must push status itself — otherwise the "N failed" pill
+ * keeps its stale count until the next unrelated outbox event (#290). Mirrors
+ * the offline-enqueue path in `enqueueAndDrain`. refreshStatus stays outside
+ * the lock: it only reads IDB and the lock is non-reentrant.
  */
 export const discardEntry = async (id: string): Promise<void> => {
   await withCrossTabLock(() => deleteEntry(id));
+  await refreshStatus();
 };
 
 /** Inspect the queue (e.g. to render a per-entry error list). */

--- a/src/lib/outbox/outbox.test.ts
+++ b/src/lib/outbox/outbox.test.ts
@@ -18,7 +18,7 @@ vi.mock('@/lib/supabase', () => ({
 }));
 
 const { deleteEntry, listEntries, putEntry } = await import('./store');
-const { drain, getStatus, startOutbox, subscribeStatus } = await import('./drain');
+const { drain, getStatus, refreshStatus, startOutbox, subscribeStatus } = await import('./drain');
 const { discardEntry, enqueueAndDrain, retryFailed } = await import('./index');
 
 const baseEntry = (over: Partial<UpdateBoardEntry> = {}): UpdateBoardEntry => ({
@@ -261,6 +261,24 @@ describe('cross-tab coordination (#278, #289)', () => {
     expect(await listEntries()).toHaveLength(1);
     release();
     await discardDone;
+    expect(await listEntries()).toEqual([]);
+  });
+});
+
+describe('discardEntry', () => {
+  it('emits a status refresh so the failed pill drops without another outbox event (#290)', async () => {
+    await putEntry(baseEntry({ id: '01HZZA', status: 'failed', attemptCount: 3 }));
+    const seen: number[] = [];
+    const unsub = subscribeStatus((s) => seen.push(s.failedCount));
+    // Surface the "1 failed" state to subscribers up front so the post-discard
+    // drop is an observable transition, not just a coincidental end value.
+    await refreshStatus();
+    expect(seen[seen.length - 1]).toBe(1);
+    // No drain, no online/offline event follows — discardEntry must push the
+    // updated count itself, or the pill keeps its stale "1 failed".
+    await discardEntry('01HZZA');
+    unsub();
+    expect(seen[seen.length - 1]).toBe(0);
     expect(await listEntries()).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #290.

## Problem
`discardEntry` deletes the IDB entry but never calls `refreshStatus()`. `useOutboxStatus` only updates on emits (drain, online/offline, offline enqueue), so after pressing **Discard** the "N sync changes failed" pill keeps its stale count until some unrelated outbox event fires. **Retry** is fine because `retryFailed` ends in `drain()`, which emits.

## Fix
`await refreshStatus()` at the tail of `discardEntry`, mirroring the offline-enqueue path in `enqueueAndDrain`. `OfflineIndicator`'s `discardAllFailed` delegates to `discardEntry`, so both indicator paths are covered by the one change. `refreshStatus` stays outside the cross-tab lock (it only reads IDB; the lock is non-reentrant).

## Test
`OfflineIndicator.test.tsx` mocks the whole outbox module, so it can't catch this. The regression test lives in `outbox.test.ts`, where the store and drain are real: it subscribes to status, discards a failed entry, and asserts `failedCount` drops to 0 with no intervening drain or online/offline event. Verified it fails on `main` and passes with the fix.

Lint, typecheck, and the full `outbox.test.ts` suite (27 tests) pass.