### PR TITLE
ci(deploy): bump cloudflare/wrangler-action to v4 for Node 24 (#227)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -27,7 +27,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-      - uses: cloudflare/wrangler-action@v3
+      - uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## What

Bumps the deploy workflow's `cloudflare/wrangler-action` pin from `@v3` to `@v4`.

## Why

v3 runs on Node.js 20, which GitHub Actions has been forcing to Node 24 since **June 2, 2026** and removes from runner images on **September 16, 2026** — at which point the CF Pages deploy breaks (#227). Upstream shipped the Node 24-compatible release the issue was waiting on: [v4.0.0](https://github.com/cloudflare/wrangler-action/releases/tag/v4.0.0) (2026-05-12) declares `runs.using: node24`.

## Breaking-change check

v4.0.0's only breaking change is the default Wrangler CLI version moving from v3 to v4 (`latest`). This repo doesn't pin `wranglerVersion` (and has no local wrangler in `package.json`), and the `pages deploy dist --project-name=talrum --branch=main --commit-hash=...` invocation is unchanged in Wrangler v4, so no other workflow inputs change.

## Verification

One-line CI config change — the real verification is the `deploy-pages` run on `main` after merge: it should go green with no "Node.js 20 actions are deprecated" warning. I'll watch that run post-merge.

Closes #227