### PR TITLE
ci: set SUPABASE_AUTH_* env vars to silence unset-var warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ concurrency:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    env:
+      # config.toml env-interpolates auth.site_url / additional_redirect_urls;
+      # unset, every supabase CLI call warns (#260). CI never exercises auth
+      # redirects — these are the local-dev values from the config.toml comment.
+      SUPABASE_AUTH_SITE_URL: http://127.0.0.1:3000
+      SUPABASE_AUTH_REDIRECT_URL: https://127.0.0.1:3000
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6


### PR DESCRIPTION
Closes #260.

`supabase/config.toml` env-interpolates `auth.site_url` and `additional_redirect_urls` so local dev and prod can diverge (`supabase config push --env-file`). The `verify` job never sets either variable, so every supabase CLI invocation — `start`, the types-drift check, `test:db`, `functions serve`, `stop` — prints `WARN: environment variable is unset: SUPABASE_AUTH_SITE_URL` / `SUPABASE_AUTH_REDIRECT_URL`, 14 lines per run (see run 27342815266).

Fix: pin the documented local-dev values (from the `config.toml` comment) as job-level `env:` on `verify`. CI never exercises auth redirects, so the values are inert — this is purely log noise removal. The `migration-drift` job and the deploy workflows don't emit the warning, so they're untouched.

**Verification:** this PR's own CI run should contain zero `environment variable is unset` lines.