### PR TITLE
fix(outbox): guard board updates against cross-device overwrites (#281)

### DIFF
--- a/docs/outbox.md
+++ b/docs/outbox.md
@@ -76,11 +76,12 @@ themselves are happy-path only.
 - **Conflict** (boards only, #281): `updateBoard` entries carry the server
   `updated_at` they were computed against and update conditionally; zero
   rows back means another device wrote the board since, and the entry fails
-  with "couldn't sync — board changed on another device" instead of
-  silently overwriting. Your own queued edits don't trip the guard: each
-  landed replay feeds the produced `updated_at` forward (in-memory board
-  clock + persisted into the remaining queue, see `board-clock.ts`). After
-  a conflict, **Retry** strips the guard — applying your version becomes an
+  instead of silently overwriting. The indicator's pill names it ("board
+  changed on another device", via `conflictCount` in the status feed). Your
+  own queued edits don't trip the guard: every landed replay — guarded or
+  not — feeds the produced `updated_at` forward (in-memory board clock +
+  persisted into the remaining queue, see `board-clock.ts`). After a
+  conflict, **Retry** strips the guard — applying your version becomes an
   explicit choice — and **Discard** keeps the other device's version.
 
 ## Rules for writing a handler

--- a/docs/outbox.md
+++ b/docs/outbox.md
@@ -73,6 +73,15 @@ themselves are happy-path only.
   user sees the error. On the slow path the entry is marked `failed`; the
   OfflineIndicator surfaces it with **Retry** (resets failed entries to
   pending with a fresh attempt budget, #277) and **Discard**.
+- **Conflict** (boards only, #281): `updateBoard` entries carry the server
+  `updated_at` they were computed against and update conditionally; zero
+  rows back means another device wrote the board since, and the entry fails
+  with "couldn't sync — board changed on another device" instead of
+  silently overwriting. Your own queued edits don't trip the guard: each
+  landed replay feeds the produced `updated_at` forward (in-memory board
+  clock + persisted into the remaining queue, see `board-clock.ts`). After
+  a conflict, **Retry** strips the guard — applying your version becomes an
+  explicit choice — and **Discard** keeps the other device's version.
 
 ## Rules for writing a handler
 
@@ -97,8 +106,10 @@ New entry kind? Add the interface in `types.ts`, the handler in
 
 ## Known limits
 
-- Replays are last-write-wins per column; concurrent edits to a shared board
-  can silently discard one side (#281).
+- Board updates are conflict-guarded (#281), but the guard is column-blind:
+  a rename on one device and a step edit on another touch different columns
+  yet still surface as a conflict prompt rather than merging. Non-board
+  tables (pictogram renames, audio swaps) still replay last-write-wins.
 - Cross-tab serialization (#278, #289) relies on the Web Locks API; in an
   environment without `navigator.locks` only the per-tab re-entrancy guard
   applies.

--- a/src/lib/outbox/board-clock.ts
+++ b/src/lib/outbox/board-clock.ts
@@ -1,0 +1,48 @@
+/**
+ * Per-board record of the newest server `updated_at` this device has
+ * produced (#281).
+ *
+ * The `boards_set_updated_at` trigger bumps `updated_at` on every UPDATE —
+ * including our own. Entries enqueued before an earlier write for the same
+ * board has replayed carry a baseline that our own replay immediately
+ * invalidates; guarding with the raw baseline would conflict against
+ * ourselves (offline edit chains, rapid online edits racing the refetch).
+ * Successful updateBoard handlers note the timestamp the server returned,
+ * and `resolveExpectedUpdatedAt` substitutes it when it is newer than an
+ * entry's own baseline.
+ *
+ * In-memory only: a reload starts empty and the first replay re-seeds it
+ * from its own baseline. Cross-tab handoff is covered by the drain loop
+ * persisting resolved baselines back into pending entries (see `drain.ts`).
+ * Keep this module import-free — `vitest.setup.ts` resets it globally, so it
+ * must stay loadable outside the app graph like `drain-state.ts`.
+ */
+const newestByBoard = new Map<string, string>();
+
+export const noteBoardUpdatedAt = (boardId: string, updatedAt: string): void => {
+  const known = newestByBoard.get(boardId);
+  if (known === undefined || Date.parse(updatedAt) >= Date.parse(known)) {
+    newestByBoard.set(boardId, updatedAt);
+  }
+};
+
+/**
+ * The guard an updateBoard entry should use right now: the newer of the
+ * entry's own baseline and the last timestamp this device produced for the
+ * board. An `undefined` baseline means the entry is unguarded — never invent
+ * a guard for it (Retry-after-conflict relies on a stripped guard staying
+ * stripped).
+ */
+export const resolveExpectedUpdatedAt = (
+  boardId: string,
+  baseline: string | undefined,
+): string | undefined => {
+  if (baseline === undefined) return undefined;
+  const known = newestByBoard.get(boardId);
+  if (known === undefined) return baseline;
+  return Date.parse(known) >= Date.parse(baseline) ? known : baseline;
+};
+
+export const __resetBoardClockForTests = (): void => {
+  newestByBoard.clear();
+};

--- a/src/lib/outbox/drain-state.ts
+++ b/src/lib/outbox/drain-state.ts
@@ -7,6 +7,11 @@ export interface OutboxStatus {
   online: boolean;
   pendingCount: number;
   failedCount: number;
+  /**
+   * How many of the failed entries are board conflicts (#281) — lets the
+   * indicator name the conflict instead of only counting generic failures.
+   */
+  conflictCount: number;
   draining: boolean;
 }
 
@@ -21,6 +26,7 @@ const initialStatus = (): OutboxStatus => ({
   online: typeof navigator === 'undefined' ? true : navigator.onLine,
   pendingCount: 0,
   failedCount: 0,
+  conflictCount: 0,
   draining: false,
 });
 

--- a/src/lib/outbox/drain.ts
+++ b/src/lib/outbox/drain.ts
@@ -1,3 +1,4 @@
+import { resolveExpectedUpdatedAt } from './board-clock';
 import { drainState, drainSubscribers, type OutboxStatus } from './drain-state';
 import { runHandler, UnretryableOutboxError } from './handlers';
 import { deleteEntry, getEntry, listEntries, putEntry } from './store';
@@ -38,25 +39,50 @@ export const subscribeStatus = (fn: (s: OutboxStatus) => void): (() => void) => 
 
 export const getStatus = (): OutboxStatus => drainState.lastStatus;
 
+/**
+ * A landed updateBoard bumps the server's `updated_at`, staling the guard on
+ * every queued entry for the same board (#281). The handler's board clock
+ * already covers this tab; persisting the resolved baseline into IDB covers
+ * the tab that picks the queue up later with an empty clock. Only refreshes
+ * existing guards — unguarded entries (pre-#281, stripped by Retry) must stay
+ * unguarded. Runs inside the drain's cross-tab lock, like every queue rewrite.
+ */
+const forwardBoardGuards = async (done: OutboxEntry): Promise<void> => {
+  if (done.kind !== 'updateBoard') return;
+  for (const e of await listEntries()) {
+    if (e.kind !== 'updateBoard' || e.boardId !== done.boardId) continue;
+    if (e.status !== 'pending' || e.expectedUpdatedAt === undefined) continue;
+    const resolved = resolveExpectedUpdatedAt(e.boardId, e.expectedUpdatedAt);
+    if (resolved !== undefined && resolved !== e.expectedUpdatedAt) {
+      await putEntry({ ...e, expectedUpdatedAt: resolved });
+    }
+  }
+};
+
 const runOne = async (entry: OutboxEntry): Promise<'ok' | 'transient' | 'failed'> => {
   try {
     await runHandler(entry);
     await deleteEntry(entry.id);
+    await forwardBoardGuards(entry);
     return 'ok';
   } catch (err) {
     // Another tab's drain may have completed this entry and deleted it while
     // our attempt was in flight (our duplicate write then fails, e.g. on a
     // unique-key violation). Re-creating the entry as failed/pending would
     // resurrect a write that already succeeded (#278).
-    if ((await getEntry(entry.id)) === undefined) return 'ok';
-    const attemptCount = entry.attemptCount + 1;
+    const current = await getEntry(entry.id);
+    if (current === undefined) return 'ok';
+    // Rewrite from the fresh IDB copy, not the loop's snapshot: an earlier
+    // entry in this same drain pass may have forwarded this entry's conflict
+    // baseline (#281), and `entry` predates that.
+    const attemptCount = current.attemptCount + 1;
     const message = err instanceof Error ? err.message : 'unknown error';
     if (err instanceof UnretryableOutboxError) {
-      await putEntry({ ...entry, attemptCount, status: 'failed', lastError: message });
+      await putEntry({ ...current, attemptCount, status: 'failed', lastError: message });
       return 'failed';
     }
     const status = attemptCount >= MAX_ATTEMPTS_BEFORE_FAILED ? 'failed' : 'pending';
-    await putEntry({ ...entry, attemptCount, status, lastError: message });
+    await putEntry({ ...current, attemptCount, status, lastError: message });
     return status === 'failed' ? 'failed' : 'transient';
   }
 };

--- a/src/lib/outbox/drain.ts
+++ b/src/lib/outbox/drain.ts
@@ -1,6 +1,6 @@
 import { resolveExpectedUpdatedAt } from './board-clock';
 import { drainState, drainSubscribers, type OutboxStatus } from './drain-state';
-import { runHandler, UnretryableOutboxError } from './handlers';
+import { BOARD_CONFLICT_MESSAGE, runHandler, UnretryableOutboxError } from './handlers';
 import { deleteEntry, getEntry, listEntries, putEntry } from './store';
 import type { OutboxEntry } from './types';
 
@@ -11,10 +11,12 @@ export { __resetDrainForTests } from './drain-state';
 
 const emit = async (): Promise<void> => {
   const entries = await listEntries();
+  const failed = entries.filter((e) => e.status === 'failed');
   const next: OutboxStatus = {
     online: typeof navigator === 'undefined' ? true : navigator.onLine,
     pendingCount: entries.filter((e) => e.status === 'pending').length,
-    failedCount: entries.filter((e) => e.status === 'failed').length,
+    failedCount: failed.length,
+    conflictCount: failed.filter((e) => e.lastError === BOARD_CONFLICT_MESSAGE).length,
     draining: drainState.draining,
   };
   drainState.lastStatus = next;

--- a/src/lib/outbox/handlers.test.ts
+++ b/src/lib/outbox/handlers.test.ts
@@ -20,7 +20,14 @@ interface MockPostgrestError {
 }
 
 const eqMock = vi.fn<(c: string, v: string) => Promise<{ error: MockPostgrestError | null }>>();
-const updateMock = vi.fn(() => ({ eq: eqMock }));
+const guardSelectMock =
+  vi.fn<
+    (
+      cols: string,
+    ) => Promise<{ data: { updated_at: string }[] | null; error: MockPostgrestError | null }>
+  >();
+const matchMock = vi.fn((_filter: Record<string, string>) => ({ select: guardSelectMock }));
+const updateMock = vi.fn(() => ({ eq: eqMock, match: matchMock }));
 const insertMock = vi.fn<(row: unknown) => Promise<{ error: MockPostgrestError | null }>>();
 const inMock = vi.fn<
   (
@@ -70,7 +77,8 @@ vi.mock('@/lib/telemetry', () => ({
   captureException: (err: unknown, ctx?: unknown) => captureExceptionMock(err, ctx),
 }));
 
-const { runHandler, UnretryableOutboxError } = await import('./handlers');
+const { BOARD_CONFLICT_MESSAGE, runHandler, UnretryableOutboxError } = await import('./handlers');
+const { __resetBoardClockForTests } = await import('./board-clock');
 
 const baseProps = {
   id: '01HZZA',
@@ -81,6 +89,8 @@ const baseProps = {
 
 beforeEach(() => {
   eqMock.mockReset();
+  guardSelectMock.mockReset();
+  matchMock.mockClear();
   updateMock.mockClear();
   insertMock.mockReset();
   inMock.mockReset();
@@ -131,6 +141,94 @@ describe('runHandler · updateBoard', () => {
       patch: { name: 'X' },
     };
     await expect(runHandler(entry)).rejects.toBeInstanceOf(UnretryableOutboxError);
+  });
+});
+
+describe('runHandler · updateBoard conflict guard (#281)', () => {
+  const T0 = '2026-06-11T10:00:00.000001+00:00';
+  const T1 = '2026-06-11T10:00:01.000001+00:00';
+  const T2 = '2026-06-11T10:00:02.000001+00:00';
+
+  const guarded = (expectedUpdatedAt: string, boardId = 'b-1'): UpdateBoardEntry => ({
+    ...baseProps,
+    kind: 'updateBoard',
+    boardId,
+    patch: { step_ids: ['s-1'] },
+    expectedUpdatedAt,
+  });
+
+  beforeEach(() => {
+    __resetBoardClockForTests();
+  });
+
+  it('updates conditionally on the baseline and resolves when a row matches', async () => {
+    guardSelectMock.mockResolvedValue({ data: [{ updated_at: T1 }], error: null });
+    await runHandler(guarded(T0));
+    expect(updateMock).toHaveBeenCalledWith({ step_ids: ['s-1'] });
+    expect(matchMock).toHaveBeenCalledWith({ id: 'b-1', updated_at: T0 });
+    expect(eqMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects with the conflict message when zero rows match the baseline', async () => {
+    guardSelectMock.mockResolvedValue({ data: [], error: null });
+    await expect(runHandler(guarded(T0))).rejects.toMatchObject({
+      name: 'UnretryableOutboxError',
+      message: BOARD_CONFLICT_MESSAGE,
+    });
+  });
+
+  it('keeps the unguarded path for entries without a baseline', async () => {
+    eqMock.mockResolvedValue({ error: null });
+    const entry: UpdateBoardEntry = {
+      ...baseProps,
+      kind: 'updateBoard',
+      boardId: 'b-1',
+      patch: { name: 'X' },
+    };
+    await runHandler(entry);
+    expect(eqMock).toHaveBeenCalledWith('id', 'b-1');
+    expect(matchMock).not.toHaveBeenCalled();
+  });
+
+  it('replaces a stale baseline with the updated_at its own prior write produced', async () => {
+    // Two entries enqueued against the same snapshot (offline chain): the
+    // first replay bumps the server clock, so the second must guard against
+    // the produced T1, not its own stale T0 — guarding with T0 would
+    // conflict against ourselves.
+    guardSelectMock
+      .mockResolvedValueOnce({ data: [{ updated_at: T1 }], error: null })
+      .mockResolvedValueOnce({ data: [{ updated_at: T2 }], error: null });
+    await runHandler(guarded(T0));
+    await runHandler(guarded(T0));
+    expect(matchMock).toHaveBeenNthCalledWith(2, { id: 'b-1', updated_at: T1 });
+  });
+
+  it('prefers a newer entry baseline over an older produced timestamp', async () => {
+    // A refetch can hand a later edit a baseline newer than anything this
+    // device produced; the device clock must not drag the guard backwards.
+    guardSelectMock
+      .mockResolvedValueOnce({ data: [{ updated_at: T1 }], error: null })
+      .mockResolvedValueOnce({ data: [{ updated_at: T2 }], error: null });
+    await runHandler(guarded(T0));
+    await runHandler(guarded(T2));
+    expect(matchMock).toHaveBeenNthCalledWith(2, { id: 'b-1', updated_at: T2 });
+  });
+
+  it('scopes produced timestamps per board', async () => {
+    guardSelectMock
+      .mockResolvedValueOnce({ data: [{ updated_at: T1 }], error: null })
+      .mockResolvedValueOnce({ data: [{ updated_at: T2 }], error: null });
+    await runHandler(guarded(T0, 'b-1'));
+    await runHandler(guarded(T0, 'b-2'));
+    expect(matchMock).toHaveBeenNthCalledWith(2, { id: 'b-2', updated_at: T0 });
+  });
+
+  it('wraps coded DB errors from the guarded path in UnretryableOutboxError', async () => {
+    guardSelectMock.mockResolvedValue({
+      data: null,
+      error: { code: '42501', message: 'permission denied', details: '', hint: '' },
+    });
+    await expect(runHandler(guarded(T0))).rejects.toBeInstanceOf(UnretryableOutboxError);
   });
 });
 

--- a/src/lib/outbox/handlers.test.ts
+++ b/src/lib/outbox/handlers.test.ts
@@ -20,14 +20,20 @@ interface MockPostgrestError {
 }
 
 const eqMock = vi.fn<(c: string, v: string) => Promise<{ error: MockPostgrestError | null }>>();
-const guardSelectMock =
-  vi.fn<
-    (
-      cols: string,
-    ) => Promise<{ data: { updated_at: string }[] | null; error: MockPostgrestError | null }>
-  >();
+type UpdateSelectResult = Promise<{
+  data: { updated_at: string }[] | null;
+  error: MockPostgrestError | null;
+}>;
+const guardSelectMock = vi.fn<(cols: string) => UpdateSelectResult>();
+const unguardedSelectMock = vi.fn<(cols: string) => UpdateSelectResult>();
 const matchMock = vi.fn((_filter: Record<string, string>) => ({ select: guardSelectMock }));
-const updateMock = vi.fn(() => ({ eq: eqMock, match: matchMock }));
+// `.eq()` serves two chain shapes: pictogram/kid handlers await it as the
+// terminal, the unguarded boards path chains `.select('updated_at')` off it.
+// Mirrors supabase-js, where the filter builder is a thenable with `.select`.
+const updateMock = vi.fn(() => ({
+  eq: (c: string, v: string) => Object.assign(eqMock(c, v), { select: unguardedSelectMock }),
+  match: matchMock,
+}));
 const insertMock = vi.fn<(row: unknown) => Promise<{ error: MockPostgrestError | null }>>();
 const inMock = vi.fn<
   (
@@ -90,6 +96,7 @@ const baseProps = {
 beforeEach(() => {
   eqMock.mockReset();
   guardSelectMock.mockReset();
+  unguardedSelectMock.mockReset();
   matchMock.mockClear();
   updateMock.mockClear();
   insertMock.mockReset();
@@ -104,6 +111,10 @@ beforeEach(() => {
   storageFromMock.mockClear();
   // Defaults: every supabase call succeeds.
   eqMock.mockResolvedValue({ error: null });
+  unguardedSelectMock.mockResolvedValue({
+    data: [{ updated_at: '2026-06-11T09:00:00.000001+00:00' }],
+    error: null,
+  });
   insertMock.mockResolvedValue({ error: null });
   inMock.mockResolvedValue({ data: [], error: null });
   deleteEqMock.mockResolvedValue({ error: null });
@@ -131,7 +142,8 @@ describe('runHandler · updateBoard', () => {
   });
 
   it('wraps coded DB errors in UnretryableOutboxError', async () => {
-    eqMock.mockResolvedValue({
+    unguardedSelectMock.mockResolvedValue({
+      data: null,
       error: { code: '42501', message: 'permission denied', details: '', hint: '' },
     });
     const entry: UpdateBoardEntry = {
@@ -212,6 +224,24 @@ describe('runHandler · updateBoard conflict guard (#281)', () => {
     await runHandler(guarded(T0));
     await runHandler(guarded(T2));
     expect(matchMock).toHaveBeenNthCalledWith(2, { id: 'b-1', updated_at: T2 });
+  });
+
+  it('feeds the board clock from unguarded successes too', async () => {
+    // An unguarded replay (pre-#281 entry, or a conflict retry with the
+    // guard stripped) bumps the server clock like any other write. A queued
+    // guarded entry for the same board must not self-conflict against it.
+    unguardedSelectMock.mockResolvedValue({ data: [{ updated_at: T1 }], error: null });
+    await runHandler({ ...baseProps, kind: 'updateBoard', boardId: 'b-1', patch: { name: 'X' } });
+    guardSelectMock.mockResolvedValue({ data: [{ updated_at: T2 }], error: null });
+    await runHandler(guarded(T0));
+    expect(matchMock).toHaveBeenCalledWith({ id: 'b-1', updated_at: T1 });
+  });
+
+  it('keeps zero rows on the unguarded path a silent success (board already gone)', async () => {
+    unguardedSelectMock.mockResolvedValue({ data: [], error: null });
+    await expect(
+      runHandler({ ...baseProps, kind: 'updateBoard', boardId: 'b-1', patch: { name: 'X' } }),
+    ).resolves.toBeUndefined();
   });
 
   it('scopes produced timestamps per board', async () => {

--- a/src/lib/outbox/handlers.ts
+++ b/src/lib/outbox/handlers.ts
@@ -83,9 +83,19 @@ const handleUpdateBoard = async (entry: UpdateBoardEntry): Promise<void> => {
   if (expected === undefined) {
     // Unguarded last-write-wins: pre-#281 persisted entries, conflict
     // retries with the guard stripped, and edits made before the board
-    // query delivered a baseline.
-    const { error } = await supabase.from('boards').update(entry.patch).eq('id', entry.boardId);
+    // query delivered a baseline. Zero rows back stays a silent success
+    // (board already deleted/hidden — pre-#281 semantics). The clock note
+    // is not optional: an unguarded replay bumps the server's updated_at
+    // like any write, and queued guarded entries for the same board must
+    // not self-conflict against it.
+    const { data, error } = await supabase
+      .from('boards')
+      .update(entry.patch)
+      .eq('id', entry.boardId)
+      .select('updated_at');
     if (error) throw error;
+    const row = data?.[0];
+    if (row !== undefined) noteBoardUpdatedAt(entry.boardId, row.updated_at);
     return;
   }
   // Conditional update (#281): zero rows back means `updated_at` moved —

--- a/src/lib/outbox/handlers.ts
+++ b/src/lib/outbox/handlers.ts
@@ -9,6 +9,7 @@ import {
 import { supabase } from '@/lib/supabase';
 import { captureException } from '@/lib/telemetry';
 
+import { noteBoardUpdatedAt, resolveExpectedUpdatedAt } from './board-clock';
 import type {
   ClearPictogramAudioEntry,
   CreatePhotoPictogramEntry,
@@ -70,9 +71,37 @@ const reportCleanupFailure = (err: unknown): void => {
   });
 };
 
+/**
+ * `lastError` of an entry that failed the optimistic-concurrency check below.
+ * `retryFailed` matches on it to strip the guard, turning Retry into an
+ * explicit "apply my version anyway" — #281 only forbids *silent* overwrites.
+ */
+export const BOARD_CONFLICT_MESSAGE = "couldn't sync — board changed on another device";
+
 const handleUpdateBoard = async (entry: UpdateBoardEntry): Promise<void> => {
-  const { error } = await supabase.from('boards').update(entry.patch).eq('id', entry.boardId);
+  const expected = resolveExpectedUpdatedAt(entry.boardId, entry.expectedUpdatedAt);
+  if (expected === undefined) {
+    // Unguarded last-write-wins: pre-#281 persisted entries, conflict
+    // retries with the guard stripped, and edits made before the board
+    // query delivered a baseline.
+    const { error } = await supabase.from('boards').update(entry.patch).eq('id', entry.boardId);
+    if (error) throw error;
+    return;
+  }
+  // Conditional update (#281): zero rows back means `updated_at` moved —
+  // another device wrote the board since this entry's baseline. Permanent
+  // failure, so the indicator offers Retry (overwrite) / Discard instead of
+  // silently clobbering the other side. The returned `updated_at` feeds the
+  // board clock so this device's own queued edits don't trip the guard.
+  const { data, error } = await supabase
+    .from('boards')
+    .update(entry.patch)
+    .match({ id: entry.boardId, updated_at: expected })
+    .select('updated_at');
   if (error) throw error;
+  const row = data?.[0];
+  if (row === undefined) throw new UnretryableOutboxError(BOARD_CONFLICT_MESSAGE);
+  noteBoardUpdatedAt(entry.boardId, row.updated_at);
 };
 
 const handleCreatePhotoPictogram = async (entry: CreatePhotoPictogramEntry): Promise<void> => {

--- a/src/lib/outbox/index.ts
+++ b/src/lib/outbox/index.ts
@@ -10,7 +10,7 @@ import {
   subscribeStatus,
   withCrossTabLock,
 } from './drain';
-import { runHandler, UnretryableOutboxError } from './handlers';
+import { BOARD_CONFLICT_MESSAGE, runHandler, UnretryableOutboxError } from './handlers';
 import { deleteEntry, listEntries, putEntry } from './store';
 import type { OutboxEntry } from './types';
 
@@ -102,11 +102,20 @@ export const enqueueAndDrain = async (input: EntryInput): Promise<void> => {
  * another tab can't land between the list and the put and get resurrected as
  * pending (#289). `drain()` takes the same (non-reentrant) lock, so it must
  * stay outside the callback.
+ *
+ * Entries that failed the board conflict guard lose their guard here: their
+ * baseline is permanently behind the other device's write, so a guarded
+ * retry can only re-conflict. Stripping it turns Retry into "apply my
+ * version anyway" — the overwrite #281 forbids is the *silent* one, and the
+ * user is choosing it explicitly now. Other failures keep their guard.
  */
 export const retryFailed = async (): Promise<void> => {
   await withCrossTabLock(async () => {
     const failed = (await listEntries()).filter((e) => e.status === 'failed');
-    for (const { lastError: _lastError, ...entry } of failed) {
+    for (const { lastError, ...entry } of failed) {
+      if (entry.kind === 'updateBoard' && lastError === BOARD_CONFLICT_MESSAGE) {
+        delete entry.expectedUpdatedAt;
+      }
       await putEntry({ ...entry, status: 'pending', attemptCount: 0 });
     }
   });

--- a/src/lib/outbox/outbox.test.ts
+++ b/src/lib/outbox/outbox.test.ts
@@ -10,7 +10,14 @@ interface MockPostgrestError {
   hint: string;
 }
 const eqMock = vi.fn<(c: string, v: string) => Promise<{ error: MockPostgrestError | null }>>();
-const updateMock = vi.fn(() => ({ eq: eqMock }));
+const guardSelectMock =
+  vi.fn<
+    (
+      cols: string,
+    ) => Promise<{ data: { updated_at: string }[] | null; error: MockPostgrestError | null }>
+  >();
+const matchMock = vi.fn((_filter: Record<string, string>) => ({ select: guardSelectMock }));
+const updateMock = vi.fn(() => ({ eq: eqMock, match: matchMock }));
 const fromMock = vi.fn((_table: string) => ({ update: updateMock }));
 
 vi.mock('@/lib/supabase', () => ({
@@ -20,6 +27,8 @@ vi.mock('@/lib/supabase', () => ({
 const { deleteEntry, listEntries, putEntry } = await import('./store');
 const { drain, getStatus, refreshStatus, startOutbox, subscribeStatus } = await import('./drain');
 const { discardEntry, enqueueAndDrain, retryFailed } = await import('./index');
+const { BOARD_CONFLICT_MESSAGE } = await import('./handlers');
+const { __resetBoardClockForTests } = await import('./board-clock');
 
 const baseEntry = (over: Partial<UpdateBoardEntry> = {}): UpdateBoardEntry => ({
   id: '01HZZZZZZZZZZZZZZZZZZZZZZZ',
@@ -42,6 +51,8 @@ beforeEach(async () => {
   updateMock.mockClear();
   fromMock.mockClear();
   eqMock.mockReset();
+  guardSelectMock.mockReset();
+  matchMock.mockClear();
   // Default: handler succeeds.
   eqMock.mockResolvedValue({ error: null });
 });
@@ -313,6 +324,107 @@ describe('retryFailed', () => {
     await retryFailed();
     const entries = await listEntries();
     expect(entries[0]?.attemptCount).toBe(2);
+  });
+});
+
+describe('conflict guard (#281)', () => {
+  const T0 = '2026-06-11T10:00:00.000001+00:00';
+  const T1 = '2026-06-11T10:00:01.000001+00:00';
+  const T2 = '2026-06-11T10:00:02.000001+00:00';
+
+  it('marks a conflicted entry failed with the conflict message', async () => {
+    guardSelectMock.mockResolvedValue({ data: [], error: null });
+    await putEntry(baseEntry({ id: '01HZZA', expectedUpdatedAt: T0 }));
+    await drain();
+    const entries = await listEntries();
+    expect(entries[0]?.status).toBe('failed');
+    expect(entries[0]?.lastError).toBe(BOARD_CONFLICT_MESSAGE);
+  });
+
+  it('persists forwarded baselines so another tab can continue the chain', async () => {
+    // A and B were enqueued against the same snapshot. A lands (server clock
+    // moves to T1); B fails transiently and stays queued. The forwarded
+    // baseline must be in IDB, not just this tab's memory — the tab that
+    // picks the queue up later starts with an empty board clock.
+    guardSelectMock
+      .mockResolvedValueOnce({ data: [{ updated_at: T1 }], error: null })
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    await putEntry(baseEntry({ id: '01HZZA', expectedUpdatedAt: T0 }));
+    await putEntry(baseEntry({ id: '01HZZB', expectedUpdatedAt: T0 }));
+    await drain();
+    const [b] = await listEntries();
+    expect(b?.id).toBe('01HZZB');
+    expect(b?.kind === 'updateBoard' && b.expectedUpdatedAt).toBe(T1);
+    // "Another tab": same IDB queue, fresh module state.
+    __resetBoardClockForTests();
+    guardSelectMock.mockResolvedValueOnce({ data: [{ updated_at: T2 }], error: null });
+    await drain();
+    expect(matchMock).toHaveBeenLastCalledWith({ id: 'board-1', updated_at: T1 });
+    expect(await listEntries()).toEqual([]);
+  });
+
+  it('does not forward baselines onto other boards or unguarded entries', async () => {
+    guardSelectMock
+      .mockResolvedValueOnce({ data: [{ updated_at: T1 }], error: null })
+      .mockRejectedValue(new TypeError('Failed to fetch'));
+    eqMock.mockRejectedValue(new TypeError('Failed to fetch'));
+    await putEntry(baseEntry({ id: '01HZZA', expectedUpdatedAt: T0 }));
+    await putEntry(baseEntry({ id: '01HZZB', boardId: 'board-2', expectedUpdatedAt: T0 }));
+    await putEntry(baseEntry({ id: '01HZZC' }));
+    await drain();
+    const entries = await listEntries();
+    const other = entries.find((e) => e.id === '01HZZB');
+    const unguarded = entries.find((e) => e.id === '01HZZC');
+    expect(other?.kind === 'updateBoard' && other.expectedUpdatedAt).toBe(T0);
+    expect(unguarded?.kind === 'updateBoard' && unguarded.expectedUpdatedAt).toBeUndefined();
+  });
+
+  it('fast path: a conflict rejects the mutation without enqueueing', async () => {
+    guardSelectMock.mockResolvedValue({ data: [], error: null });
+    await expect(
+      enqueueAndDrain({
+        kind: 'updateBoard',
+        boardId: 'b',
+        patch: { step_ids: [] },
+        expectedUpdatedAt: T0,
+      }),
+    ).rejects.toMatchObject({ message: BOARD_CONFLICT_MESSAGE });
+    expect(await listEntries()).toEqual([]);
+  });
+
+  it('retryFailed strips the guard from conflict-failed entries — Retry is an explicit overwrite', async () => {
+    await putEntry(
+      baseEntry({
+        id: '01HZZA',
+        status: 'failed',
+        attemptCount: 1,
+        expectedUpdatedAt: T0,
+        lastError: BOARD_CONFLICT_MESSAGE,
+      }),
+    );
+    await retryFailed();
+    // Replayed through the unguarded eq path; a kept guard would re-conflict
+    // forever, making the Retry button a dead end.
+    expect(eqMock).toHaveBeenCalledWith('id', 'board-1');
+    expect(matchMock).not.toHaveBeenCalled();
+    expect(await listEntries()).toEqual([]);
+  });
+
+  it('retryFailed keeps the guard on entries that failed for other reasons', async () => {
+    guardSelectMock.mockResolvedValue({ data: [{ updated_at: T1 }], error: null });
+    await putEntry(
+      baseEntry({
+        id: '01HZZA',
+        status: 'failed',
+        attemptCount: 3,
+        expectedUpdatedAt: T0,
+        lastError: 'Failed to fetch',
+      }),
+    );
+    await retryFailed();
+    expect(matchMock).toHaveBeenCalledWith({ id: 'board-1', updated_at: T0 });
+    expect(eqMock).not.toHaveBeenCalled();
+    expect(await listEntries()).toEqual([]);
   });
 });
 

--- a/src/lib/outbox/outbox.test.ts
+++ b/src/lib/outbox/outbox.test.ts
@@ -9,13 +9,15 @@ interface MockPostgrestError {
   details: string;
   hint: string;
 }
-const eqMock = vi.fn<(c: string, v: string) => Promise<{ error: MockPostgrestError | null }>>();
-const guardSelectMock =
-  vi.fn<
-    (
-      cols: string,
-    ) => Promise<{ data: { updated_at: string }[] | null; error: MockPostgrestError | null }>
-  >();
+type UpdateSelectResult = Promise<{
+  data: { updated_at: string }[] | null;
+  error: MockPostgrestError | null;
+}>;
+const guardSelectMock = vi.fn<(cols: string) => UpdateSelectResult>();
+const unguardedSelectMock = vi.fn<(cols: string) => UpdateSelectResult>();
+// Unguarded chain: `.update().eq('id', ...).select('updated_at')`. eqMock
+// stays a spy on the (column, value) pair; the select call is the terminal.
+const eqMock = vi.fn((_c: string, _v: string) => ({ select: unguardedSelectMock }));
 const matchMock = vi.fn((_filter: Record<string, string>) => ({ select: guardSelectMock }));
 const updateMock = vi.fn(() => ({ eq: eqMock, match: matchMock }));
 const fromMock = vi.fn((_table: string) => ({ update: updateMock }));
@@ -50,11 +52,15 @@ beforeEach(async () => {
   setOnline(true);
   updateMock.mockClear();
   fromMock.mockClear();
-  eqMock.mockReset();
+  eqMock.mockClear();
   guardSelectMock.mockReset();
+  unguardedSelectMock.mockReset();
   matchMock.mockClear();
   // Default: handler succeeds.
-  eqMock.mockResolvedValue({ error: null });
+  unguardedSelectMock.mockResolvedValue({
+    data: [{ updated_at: '2026-06-11T09:00:00.000001+00:00' }],
+    error: null,
+  });
 });
 
 afterEach(() => {
@@ -108,7 +114,7 @@ describe('outbox drain', () => {
   });
 
   it('marks an entry as failed after MAX_ATTEMPTS transient failures', async () => {
-    eqMock.mockRejectedValue(new TypeError('Failed to fetch'));
+    unguardedSelectMock.mockRejectedValue(new TypeError('Failed to fetch'));
     await putEntry(baseEntry({ id: '01HZZA' }));
     await drain();
     await drain();
@@ -120,7 +126,8 @@ describe('outbox drain', () => {
   });
 
   it('marks an entry as failed immediately on a coded (non-retryable) error', async () => {
-    eqMock.mockResolvedValue({
+    unguardedSelectMock.mockResolvedValue({
+      data: null,
       error: { code: '42501', message: 'permission denied', details: '', hint: '' },
     });
     await putEntry(baseEntry({ id: '01HZZA' }));
@@ -132,9 +139,12 @@ describe('outbox drain', () => {
   });
 
   it('stops on a transient failure so order is preserved across the queue', async () => {
-    eqMock
+    unguardedSelectMock
       .mockRejectedValueOnce(new TypeError('Failed to fetch'))
-      .mockResolvedValue({ error: null });
+      .mockResolvedValue({
+        data: [{ updated_at: '2026-06-11T09:00:01.000001+00:00' }],
+        error: null,
+      });
     await putEntry(baseEntry({ id: '01HZZA' }));
     await putEntry(baseEntry({ id: '01HZZB' }));
     await drain();
@@ -216,11 +226,14 @@ describe('cross-tab coordination (#278, #289)', () => {
 
   it('does not resurrect an entry another tab completed mid-flight (permanent error)', async () => {
     await putEntry(baseEntry({ id: '01HZZA' }));
-    eqMock.mockImplementation(async () => {
+    unguardedSelectMock.mockImplementation(async () => {
       // Another tab finished this entry and deleted it while our attempt was
       // in flight; our duplicate write then hits a unique-key violation.
       await deleteEntry('01HZZA');
-      return { error: { code: '23505', message: 'duplicate key', details: '', hint: '' } };
+      return {
+        data: null,
+        error: { code: '23505', message: 'duplicate key', details: '', hint: '' },
+      };
     });
     await drain();
     expect(await listEntries()).toEqual([]);
@@ -228,7 +241,7 @@ describe('cross-tab coordination (#278, #289)', () => {
 
   it('does not resurrect an entry another tab completed mid-flight (transient error)', async () => {
     await putEntry(baseEntry({ id: '01HZZA' }));
-    eqMock.mockImplementation(async () => {
+    unguardedSelectMock.mockImplementation(async () => {
       await deleteEntry('01HZZA');
       throw new TypeError('Failed to fetch');
     });
@@ -305,7 +318,7 @@ describe('retryFailed', () => {
   });
 
   it('grants a failed entry a fresh retry budget', async () => {
-    eqMock.mockRejectedValue(new TypeError('Failed to fetch'));
+    unguardedSelectMock.mockRejectedValue(new TypeError('Failed to fetch'));
     await putEntry(
       baseEntry({ id: '01HZZA', status: 'failed', attemptCount: 3, lastError: 'Failed to fetch' }),
     );
@@ -367,7 +380,7 @@ describe('conflict guard (#281)', () => {
     guardSelectMock
       .mockResolvedValueOnce({ data: [{ updated_at: T1 }], error: null })
       .mockRejectedValue(new TypeError('Failed to fetch'));
-    eqMock.mockRejectedValue(new TypeError('Failed to fetch'));
+    unguardedSelectMock.mockRejectedValue(new TypeError('Failed to fetch'));
     await putEntry(baseEntry({ id: '01HZZA', expectedUpdatedAt: T0 }));
     await putEntry(baseEntry({ id: '01HZZB', boardId: 'board-2', expectedUpdatedAt: T0 }));
     await putEntry(baseEntry({ id: '01HZZC' }));
@@ -410,6 +423,56 @@ describe('conflict guard (#281)', () => {
     expect(await listEntries()).toEqual([]);
   });
 
+  it('a guard-stripped retry still feeds the board clock — queued edits do not self-conflict', async () => {
+    // A conflict-failed and the user tapped Retry (guard stripped); B was
+    // queued meanwhile against the still-stale cached baseline. A's unguarded
+    // replay bumps the server clock like any write, so B must guard against
+    // the value A produced, not its own T0 — otherwise the device conflicts
+    // with itself and the pill cries wolf.
+    await putEntry(
+      baseEntry({
+        id: '01HZZA',
+        status: 'failed',
+        attemptCount: 1,
+        expectedUpdatedAt: T0,
+        lastError: BOARD_CONFLICT_MESSAGE,
+      }),
+    );
+    await putEntry(baseEntry({ id: '01HZZB', expectedUpdatedAt: T0 }));
+    unguardedSelectMock.mockResolvedValue({ data: [{ updated_at: T1 }], error: null });
+    guardSelectMock.mockResolvedValue({ data: [{ updated_at: T2 }], error: null });
+    await retryFailed();
+    expect(matchMock).toHaveBeenCalledWith({ id: 'board-1', updated_at: T1 });
+    expect(await listEntries()).toEqual([]);
+  });
+
+  it('reports conflict failures separately in the status feed', async () => {
+    // One conflict, one unrelated permanent failure: the pill needs to know
+    // a conflict is among them to name it (#281's promised message).
+    guardSelectMock.mockResolvedValue({ data: [], error: null });
+    unguardedSelectMock.mockResolvedValue({
+      data: null,
+      error: { code: '42501', message: 'permission denied', details: '', hint: '' },
+    });
+    await putEntry(baseEntry({ id: '01HZZA', expectedUpdatedAt: T0 }));
+    await putEntry(baseEntry({ id: '01HZZB', boardId: 'board-2' }));
+    await drain();
+    expect(getStatus().failedCount).toBe(2);
+    expect(getStatus().conflictCount).toBe(1);
+  });
+
+  it('a fast-path transient failure preserves the guard on the queued entry', async () => {
+    guardSelectMock.mockRejectedValue(new TypeError('Failed to fetch'));
+    await enqueueAndDrain({
+      kind: 'updateBoard',
+      boardId: 'board-1',
+      patch: { name: 'x' },
+      expectedUpdatedAt: T0,
+    });
+    const [e] = await listEntries();
+    expect(e?.kind === 'updateBoard' && e.expectedUpdatedAt).toBe(T0);
+  });
+
   it('retryFailed keeps the guard on entries that failed for other reasons', async () => {
     guardSelectMock.mockResolvedValue({ data: [{ updated_at: T1 }], error: null });
     await putEntry(
@@ -444,13 +507,13 @@ describe('subscribeStatus', () => {
 
 describe('enqueueAndDrain', () => {
   it('online + success: bypasses IDB entirely', async () => {
-    eqMock.mockResolvedValue({ error: null });
     await enqueueAndDrain({ kind: 'updateBoard', boardId: 'b', patch: { name: 'x' } });
     expect(await listEntries()).toEqual([]);
   });
 
   it('online + non-retryable: rejects without enqueueing', async () => {
-    eqMock.mockResolvedValue({
+    unguardedSelectMock.mockResolvedValue({
+      data: null,
       error: { code: 'PGRST116', message: 'not found', details: '', hint: '' },
     });
     await expect(
@@ -460,7 +523,7 @@ describe('enqueueAndDrain', () => {
   });
 
   it('online + transient: enqueues and resolves', async () => {
-    eqMock.mockRejectedValue(new TypeError('Failed to fetch'));
+    unguardedSelectMock.mockRejectedValue(new TypeError('Failed to fetch'));
     await enqueueAndDrain({ kind: 'updateBoard', boardId: 'b', patch: { name: 'x' } });
     const entries = await listEntries();
     expect(entries).toHaveLength(1);

--- a/src/lib/outbox/types.ts
+++ b/src/lib/outbox/types.ts
@@ -38,6 +38,16 @@ export interface UpdateBoardEntry extends OutboxEntryBase {
   kind: 'updateBoard';
   boardId: string;
   patch: BoardRowPatch;
+  /**
+   * Server `updated_at` the patch was computed against. When present the
+   * handler updates conditionally and a zero-row result means another device
+   * wrote the board since — surfaced as a failed entry instead of a silent
+   * overwrite (#281). Absent on entries persisted before the guard existed
+   * and when the board cache had no baseline; those replay as plain
+   * last-write-wins, and `retryFailed` strips it to make Retry-after-conflict
+   * an explicit overwrite.
+   */
+  expectedUpdatedAt?: string;
 }
 
 export interface CreatePhotoPictogramEntry extends OutboxEntryBase {

--- a/src/lib/queries/boards.mutations.test.tsx
+++ b/src/lib/queries/boards.mutations.test.tsx
@@ -11,14 +11,15 @@ interface MockPostgrestError {
   details: string;
   hint: string;
 }
-const eqMock =
-  vi.fn<(column: string, value: string) => Promise<{ error: MockPostgrestError | null }>>();
-const guardSelectMock =
-  vi.fn<
-    (
-      cols: string,
-    ) => Promise<{ data: { updated_at: string }[] | null; error: MockPostgrestError | null }>
-  >();
+interface UpdateSelectResult {
+  data: { updated_at: string }[] | null;
+  error: MockPostgrestError | null;
+}
+const guardSelectMock = vi.fn<(cols: string) => Promise<UpdateSelectResult>>();
+const unguardedSelectMock = vi.fn<(cols: string) => Promise<UpdateSelectResult>>();
+// Unguarded chain: `.update().eq('id', ...).select('updated_at')`. eqMock
+// stays a spy on the (column, value) pair; the select call is the terminal.
+const eqMock = vi.fn((_c: string, _v: string) => ({ select: unguardedSelectMock }));
 const matchMock = vi.fn((_filter: Record<string, string>) => ({ select: guardSelectMock }));
 const updateMock = vi.fn(() => ({ eq: eqMock, match: matchMock }));
 const fromMock = vi.fn((_table: string) => ({ update: updateMock }));
@@ -52,7 +53,12 @@ const makeWrapper = (qc: QueryClient) => {
 
 describe('useRenameBoard (useBoardPatch)', () => {
   beforeEach(() => {
-    eqMock.mockReset();
+    eqMock.mockClear();
+    unguardedSelectMock.mockReset();
+    unguardedSelectMock.mockResolvedValue({
+      data: [{ updated_at: '2026-06-11T09:00:00.000001+00:00' }],
+      error: null,
+    });
     updateMock.mockClear();
     fromMock.mockClear();
   });
@@ -62,10 +68,10 @@ describe('useRenameBoard (useBoardPatch)', () => {
     qc.setQueryData(boardQueryKey('morning'), seed);
 
     // Block the mutation so we can observe the optimistic state.
-    let resolveEq: (v: { error: null }) => void = () => {
+    let resolveEq: (v: UpdateSelectResult) => void = () => {
       throw new Error('resolver not assigned');
     };
-    eqMock.mockReturnValue(new Promise((r) => (resolveEq = r)));
+    unguardedSelectMock.mockReturnValue(new Promise((r) => (resolveEq = r)));
 
     const { result } = renderHook(() => useRenameBoard(), { wrapper: makeWrapper(qc) });
 
@@ -77,7 +83,7 @@ describe('useRenameBoard (useBoardPatch)', () => {
       expect(qc.getQueryData<Board>(boardQueryKey('morning'))?.name).toBe('Sunrise');
     });
 
-    resolveEq({ error: null });
+    resolveEq({ data: [{ updated_at: '2026-06-11T09:00:00.000001+00:00' }], error: null });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
   });
 
@@ -91,7 +97,8 @@ describe('useRenameBoard (useBoardPatch)', () => {
     // permanent — that's the path that triggers React Query's onError,
     // which rolls the optimistic patch back. A plain TypeError without
     // a code would instead enqueue silently.
-    eqMock.mockResolvedValueOnce({
+    unguardedSelectMock.mockResolvedValueOnce({
+      data: null,
       error: { code: '42501', message: 'row-level-security', details: '', hint: '' },
     });
 
@@ -108,7 +115,12 @@ describe('useRenameBoard (useBoardPatch)', () => {
 
 describe('useBoardPatch conflict baseline (#281)', () => {
   beforeEach(() => {
-    eqMock.mockReset();
+    eqMock.mockClear();
+    unguardedSelectMock.mockReset();
+    unguardedSelectMock.mockResolvedValue({
+      data: [{ updated_at: '2026-06-11T09:00:00.000001+00:00' }],
+      error: null,
+    });
     guardSelectMock.mockReset();
     matchMock.mockClear();
     updateMock.mockClear();
@@ -148,7 +160,6 @@ describe('useBoardPatch conflict baseline (#281)', () => {
       defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
     });
     qc.setQueryData(boardQueryKey('morning'), seed);
-    eqMock.mockResolvedValueOnce({ error: null });
 
     const { result } = renderHook(() => useRenameBoard(), { wrapper: makeWrapper(qc) });
     act(() => {
@@ -163,7 +174,12 @@ describe('useBoardPatch conflict baseline (#281)', () => {
 
 describe('useSetStepIds', () => {
   beforeEach(() => {
-    eqMock.mockReset();
+    eqMock.mockClear();
+    unguardedSelectMock.mockReset();
+    unguardedSelectMock.mockResolvedValue({
+      data: [{ updated_at: '2026-06-11T09:00:00.000001+00:00' }],
+      error: null,
+    });
     updateMock.mockClear();
     fromMock.mockClear();
   });
@@ -179,8 +195,6 @@ describe('useSetStepIds', () => {
       defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
     });
     qc.setQueryData(boardQueryKey('morning'), { ...seed, stepIds: ['a'] });
-
-    eqMock.mockResolvedValueOnce({ error: null });
 
     const { result } = renderHook(() => useSetStepIds(), { wrapper: makeWrapper(qc) });
 
@@ -202,7 +216,8 @@ describe('useSetStepIds', () => {
     });
     qc.setQueryData(boardQueryKey('morning'), { ...seed, stepIds: ['a'] });
 
-    eqMock.mockResolvedValueOnce({
+    unguardedSelectMock.mockResolvedValueOnce({
+      data: null,
       error: { code: '42501', message: 'row-level-security', details: '', hint: '' },
     });
 
@@ -221,14 +236,13 @@ describe('useSetStepIds', () => {
     });
     qc.setQueryData(boardQueryKey('morning'), { ...seed, stepIds: ['a'] });
 
-    // First attempt fails (RLS), second succeeds. Between the two, the
-    // cache has shifted — retry must re-merge against the new state, not
-    // replay the original computed array.
-    eqMock
-      .mockResolvedValueOnce({
-        error: { code: '42501', message: 'row-level-security', details: '', hint: '' },
-      })
-      .mockResolvedValueOnce({ error: null });
+    // First attempt fails (RLS), second succeeds (beforeEach default).
+    // Between the two, the cache has shifted — retry must re-merge against
+    // the new state, not replay the original computed array.
+    unguardedSelectMock.mockResolvedValueOnce({
+      data: null,
+      error: { code: '42501', message: 'row-level-security', details: '', hint: '' },
+    });
 
     const { result } = renderHook(() => useSetStepIds(), { wrapper: makeWrapper(qc) });
 
@@ -254,7 +268,8 @@ describe('useSetStepIds', () => {
     });
     qc.setQueryData(boardQueryKey('morning'), { ...seed, stepIds: ['a'] });
 
-    eqMock.mockResolvedValueOnce({
+    unguardedSelectMock.mockResolvedValueOnce({
+      data: null,
       error: { code: '42501', message: 'row-level-security', details: '', hint: '' },
     });
 

--- a/src/lib/queries/boards.mutations.test.tsx
+++ b/src/lib/queries/boards.mutations.test.tsx
@@ -13,7 +13,14 @@ interface MockPostgrestError {
 }
 const eqMock =
   vi.fn<(column: string, value: string) => Promise<{ error: MockPostgrestError | null }>>();
-const updateMock = vi.fn(() => ({ eq: eqMock }));
+const guardSelectMock =
+  vi.fn<
+    (
+      cols: string,
+    ) => Promise<{ data: { updated_at: string }[] | null; error: MockPostgrestError | null }>
+  >();
+const matchMock = vi.fn((_filter: Record<string, string>) => ({ select: guardSelectMock }));
+const updateMock = vi.fn(() => ({ eq: eqMock, match: matchMock }));
 const fromMock = vi.fn((_table: string) => ({ update: updateMock }));
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: (table: string) => fromMock(table) } }));
@@ -96,6 +103,61 @@ describe('useRenameBoard (useBoardPatch)', () => {
 
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(qc.getQueryData<Board>(boardQueryKey('morning'))?.name).toBe('Morning routine');
+  });
+});
+
+describe('useBoardPatch conflict baseline (#281)', () => {
+  beforeEach(() => {
+    eqMock.mockReset();
+    guardSelectMock.mockReset();
+    matchMock.mockClear();
+    updateMock.mockClear();
+    fromMock.mockClear();
+  });
+
+  it('guards the update with the cached serverUpdatedAt', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    qc.setQueryData(boardQueryKey('morning'), {
+      ...seed,
+      serverUpdatedAt: '2026-06-11T10:00:00.000001+00:00',
+    });
+    guardSelectMock.mockResolvedValueOnce({
+      data: [{ updated_at: '2026-06-11T10:00:01.000001+00:00' }],
+      error: null,
+    });
+
+    const { result } = renderHook(() => useRenameBoard(), { wrapper: makeWrapper(qc) });
+    act(() => {
+      result.current.mutate({ boardId: 'morning', name: 'Sunrise' });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(matchMock).toHaveBeenCalledWith({
+      id: 'morning',
+      updated_at: '2026-06-11T10:00:00.000001+00:00',
+    });
+    expect(eqMock).not.toHaveBeenCalled();
+  });
+
+  it('stays unguarded when the cached board predates serverUpdatedAt', async () => {
+    // Boards rehydrated from a query cache persisted before #281 have no
+    // baseline; their writes must keep the plain last-write-wins path.
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    qc.setQueryData(boardQueryKey('morning'), seed);
+    eqMock.mockResolvedValueOnce({ error: null });
+
+    const { result } = renderHook(() => useRenameBoard(), { wrapper: makeWrapper(qc) });
+    act(() => {
+      result.current.mutate({ boardId: 'morning', name: 'Sunrise' });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(eqMock).toHaveBeenCalledWith('id', 'morning');
+    expect(matchMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/queries/boards.mutations.ts
+++ b/src/lib/queries/boards.mutations.ts
@@ -24,12 +24,19 @@ const useBoardPatch = <Input extends { boardId: string }>(
 ): UseMutationResult<void, Error, Input, { previous: Board | undefined }> => {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (input) =>
-      enqueueAndDrain({
+    mutationFn: (input) => {
+      // Conflict-guard baseline (#281): the server updated_at of the board
+      // this edit was computed against. Cache misses and boards rehydrated
+      // from a pre-#281 persisted cache have none — those writes stay
+      // unguarded last-write-wins.
+      const baseline = qc.getQueryData<Board>(boardQueryKey(input.boardId))?.serverUpdatedAt;
+      return enqueueAndDrain({
         kind: 'updateBoard',
         boardId: input.boardId,
         patch: toRowPatch(input),
-      }),
+        ...(baseline === undefined ? {} : { expectedUpdatedAt: baseline }),
+      });
+    },
     onMutate: async (input) => {
       const { boardId } = input;
       await qc.cancelQueries({ queryKey: boardQueryKey(boardId) });

--- a/src/lib/queries/boards.read.ts
+++ b/src/lib/queries/boards.read.ts
@@ -26,6 +26,7 @@ export const rowToBoard = (row: BoardRow): Board => ({
   kidReorderable: row.kid_reorderable,
   accent: row.accent as AccentBg,
   updatedLabel: formatUpdated(row.updated_at),
+  serverUpdatedAt: row.updated_at,
 });
 
 export const boardsQueryKey = ['boards'] as const;

--- a/src/lib/queries/boards.test.ts
+++ b/src/lib/queries/boards.test.ts
@@ -40,6 +40,11 @@ describe('rowToBoard', () => {
     expect(recent.updatedLabel).toMatch(/just now|m ago/);
   });
 
+  it('exposes the raw updated_at as serverUpdatedAt — the conflict-guard baseline (#281)', () => {
+    const b = rowToBoard(row({ updated_at: '2026-06-11T10:00:00.000001+00:00' }));
+    expect(b.serverUpdatedAt).toBe('2026-06-11T10:00:00.000001+00:00');
+  });
+
   it('returns a fresh stepIds array (not a Postgres reference)', () => {
     const src = row();
     const b = rowToBoard(src);

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -79,6 +79,13 @@ export interface Board {
   kidReorderable: boolean;
   accent: AccentBg;
   updatedLabel: string;
+  /**
+   * Raw server `updated_at`, the optimistic-concurrency baseline for guarded
+   * board updates (#281). Optional because boards rehydrated from a query
+   * cache persisted before this field existed lack it — their writes degrade
+   * to unguarded last-write-wins until the next refetch.
+   */
+  serverUpdatedAt?: string;
 }
 
 export interface Kid {

--- a/src/widgets/OfflineIndicator/OfflineIndicator.test.tsx
+++ b/src/widgets/OfflineIndicator/OfflineIndicator.test.tsx
@@ -61,12 +61,26 @@ describe('OfflineIndicator', () => {
       online: true,
       pendingCount: 0,
       failedCount: 2,
+      conflictCount: 0,
       draining: false,
     });
     render(<OfflineIndicator />);
     expect(screen.getByRole('status')).toHaveTextContent(/2 sync changes failed/);
+    expect(screen.getByRole('status')).not.toHaveTextContent(/board changed/);
     expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Discard' })).toBeInTheDocument();
+  });
+
+  it('names the conflict when a failed entry is one (#281)', () => {
+    useOutboxStatusMock.mockReturnValue({
+      online: true,
+      pendingCount: 0,
+      failedCount: 2,
+      conflictCount: 1,
+      draining: false,
+    });
+    render(<OfflineIndicator />);
+    expect(screen.getByRole('status')).toHaveTextContent(/board changed on another device/);
   });
 
   it('Retry resets failed entries via retryFailed, not a plain drain kick (#277)', () => {

--- a/src/widgets/OfflineIndicator/OfflineIndicator.tsx
+++ b/src/widgets/OfflineIndicator/OfflineIndicator.tsx
@@ -16,7 +16,7 @@ const discardAllFailed = async (): Promise<void> => {
  * row with Retry + Discard.
  */
 export const OfflineIndicator = (): JSX.Element | null => {
-  const { online, pendingCount, failedCount, draining } = useOutboxStatus();
+  const { online, pendingCount, failedCount, conflictCount, draining } = useOutboxStatus();
 
   if (online && pendingCount === 0 && failedCount === 0 && !draining) return null;
 
@@ -25,6 +25,9 @@ export const OfflineIndicator = (): JSX.Element | null => {
       <div role="status" className={`${styles.pill} ${styles.pillFailed}`}>
         <span className={styles.label}>
           {failedCount} sync {failedCount === 1 ? 'change' : 'changes'} failed
+          {/* Name the conflict (#281): for these entries Retry means "apply
+              my version anyway", so the label must say what happened. */}
+          {conflictCount > 0 ? ' — board changed on another device' : ''}
         </span>
         <button type="button" className={styles.action} onClick={() => void retryFailed()}>
           Retry

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -7,6 +7,7 @@ import 'fake-indexeddb/auto';
 import { clear } from 'idb-keyval';
 import { afterEach, vi } from 'vitest';
 
+import { __resetBoardClockForTests } from './src/lib/outbox/board-clock';
 import { __resetDrainForTests } from './src/lib/outbox/drain-state';
 import { __resetSpeechForTests } from './src/lib/speech';
 import { __resetSignedUrlCache } from './src/lib/storage-cache';
@@ -60,4 +61,5 @@ afterEach(async () => {
   __resetSignedUrlCache();
   __resetSpeechForTests();
   __resetDrainForTests();
+  __resetBoardClockForTests();
 });


### PR DESCRIPTION
Closes #281.

## Problem

Board replays were whole-column last-write-wins. With `board_members` sharing plus offline queues, two devices can each edit the same board; the later drain silently discards the other parent's edits — no error, no indication. `step_ids` is the worst case: a whole board layout vanishes.

## Approach

The issue's proposed cheap detectability fix, plus the machinery needed to keep it from conflicting with itself:

- **Conditional update**: `updateBoard` entries carry the server `updated_at` they were computed against (new optional `Board.serverUpdatedAt`, read from the query cache at enqueue) and the handler updates via `match({ id, updated_at }).select('updated_at')`. Zero rows back → `UnretryableOutboxError("couldn't sync — board changed on another device")` → the existing failed-entry pill.
- **No self-conflicts**: the `boards_set_updated_at` trigger bumps `updated_at` on *our own* writes too, so the naive guard would false-conflict on offline edit chains (N queued edits, same stale baseline) and rapid online edits racing the refetch. A per-board in-memory clock (`board-clock.ts`) records each timestamp our replays produce and substitutes it when newer than an entry's baseline.
- **Cross-tab handoff**: the drain persists forwarded baselines into the remaining queued entries (inside the cross-tab lock it already holds), so a different tab can continue the chain with an empty clock. This surfaced a latent bug: the drain's failure path rewrote entries from a pre-forwarding loop snapshot, clobbering the forwarded guard — it now rewrites from the fresh IDB copy.
- **Conflict resolution UX**: `retryFailed` strips the guard from conflict-failed entries — a guarded retry can only re-conflict forever. Retry = apply my version anyway (the overwrite #281 forbids is the *silent* one), Discard = keep the other device's version.
- **Backward compatible**: entries persisted before this change and boards rehydrated from a pre-upgrade query cache have no baseline and keep plain LWW semantics.

No schema change — `boards.updated_at` and its trigger already exist.

## Known limits (documented in docs/outbox.md)

- The guard is column-blind: concurrent edits to *different* columns also surface as a conflict prompt instead of merging. Recoverable with one Retry tap; preferred over per-column machinery.
- Non-board tables still replay LWW.

## Verification

- TDD throughout; new coverage: guarded/unguarded handler paths, conflict classification, offline-chain self-conflict prevention, baseline forwarding persistence across a simulated tab handoff, retry-strip scoped to conflict failures only, mutation-layer baseline pass-through, `rowToBoard` mapping.
- `npm run typecheck`, `npm run lint` (0 warnings), full `npm run test`: 419/419.