### PR TITLE
fix(ci): pin supabase CLI to 2.105.0 — v2.106.0 breaks local gen types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,11 @@ jobs:
       - run: npm run test:functions
       - uses: supabase/setup-cli@v2
         with:
-          version: latest
+          # Pinned: v2.106.0 (2026-06-11) ported `gen types` to the new TS CLI
+          # and broke `--local` generation ("Access token not provided"),
+          # failing the types-drift step. Bump deliberately after verifying
+          # `supabase gen types typescript --local` works without a token.
+          version: 2.105.0
       - run: supabase start
       - name: Regenerate supabase types and fail on drift (#132)
         run: |
@@ -90,6 +94,7 @@ jobs:
       - run: npm ci
       - uses: supabase/setup-cli@v2
         with:
-          version: latest
+          # Same pin as the verify job — keep both jobs on one CLI version.
+          version: 2.105.0
       - run: supabase link --project-ref "$PROJECT_REF"
       - run: npm run migrations:check-drift

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,12 @@ jobs:
       # redirects — these are the local-dev values from the config.toml comment.
       SUPABASE_AUTH_SITE_URL: http://127.0.0.1:3000
       SUPABASE_AUTH_REDIRECT_URL: https://127.0.0.1:3000
+      # The CLI's telemetry writer can crash ("NotFound: FileSystem.rename
+      # ~/.supabase/telemetry.json.tmp...") when two invocations run
+      # concurrently — observed 2026-06-11 when `supabase status` raced the
+      # backgrounded `functions serve`. CI needs no telemetry; this is the
+      # CLI's documented opt-out.
+      DO_NOT_TRACK: '1'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -57,7 +63,11 @@ jobs:
           # gateway is up but the function isn't — accepting it here lets the
           # e2e step run against a stalled function and exit non-zero with no
           # useful diagnostics. Require a 4xx (handler response) instead.
-          API_URL="$(supabase status -o json | jq -r '.API_URL')"
+          # Reuse the URL captured into .env.local above — another
+          # `supabase status` here would run concurrently with the
+          # backgrounded serve, the exact telemetry race that emptied
+          # API_URL and failed this step on 2026-06-11.
+          API_URL="$(grep '^SUPABASE_URL=' supabase/functions/.env.local | cut -d= -f2-)"
           ready=0
           for i in {1..30}; do
             STATUS=$(curl -sS --max-time 2 -o /dev/null -w '%{http_code}' \
@@ -85,6 +95,8 @@ jobs:
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+      # Same telemetry opt-out as the verify job.
+      DO_NOT_TRACK: '1'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6


### PR DESCRIPTION
CI on #297 failed at the types-drift step with `Access token not provided` from `supabase gen types typescript --local` — a command that needs no token.

Cause: supabase CLI v2.106.0 (published 2026-06-11 12:01 UTC, two minutes before the failing run) ported `gen types` to the new TypeScript CLI (supabase/cli#5514), and the ported version demands an access token even for `--local` generation. Both CI jobs install `version: latest`, so the regression landed the moment upstream released. Main's run at 11:39 (pre-release, v2.105.0) passed the identical step.

Fix: pin both `supabase/setup-cli` steps to 2.105.0 — the last release before the port — with a comment stating the unpin condition. This also removes weather-dependence from CI generally; future CLI bumps become deliberate.

Once merged, re-running #297's checks picks the pin up automatically (PR CI runs against the merge ref).