### PR TITLE
fix(settings): show build commit next to the version

### DIFF
--- a/src/features/settings/AppVersionSection.test.tsx
+++ b/src/features/settings/AppVersionSection.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { AppVersionSection } from './AppVersionSection';
+
+describe('AppVersionSection', () => {
+  it('shows the package version and the build commit', () => {
+    render(<AppVersionSection />);
+    expect(screen.getByText(`${__APP_VERSION__} (${__APP_COMMIT__})`)).toBeInTheDocument();
+    expect(__APP_COMMIT__).not.toBe('');
+  });
+});

--- a/src/features/settings/AppVersionSection.tsx
+++ b/src/features/settings/AppVersionSection.tsx
@@ -6,7 +6,10 @@ export const AppVersionSection = (): JSX.Element => (
   <section>
     <h2>About</h2>
     <p className={styles.line}>
-      Talrum version <code className={styles.version}>{__APP_VERSION__}</code>
+      Talrum version{' '}
+      <code className={styles.version}>
+        {__APP_VERSION__} ({__APP_COMMIT__})
+      </code>
     </p>
   </section>
 );

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -7,3 +7,11 @@
  * types change — bump package.json and the next cold boot starts fresh.
  */
 declare const __APP_VERSION__: string;
+
+/**
+ * Vite `define` replaces `__APP_COMMIT__` at build time with the short commit
+ * sha (`dev` when git is unavailable). Display-only — identifies the deployed
+ * build in Settings. Deliberately not part of the Sentry release name or the
+ * cache buster: those stay pinned to the package.json version.
+ */
+declare const __APP_COMMIT__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process';
 import { fileURLToPath, URL } from 'node:url';
 
 import { sentryVitePlugin } from '@sentry/vite-plugin';
@@ -10,6 +11,16 @@ import pkg from './package.json' with { type: 'json' };
 // Emit + upload + delete source maps in one flag, gated on the Sentry auth
 // token. Any path that emits maps must upload-and-delete them — otherwise
 // CF Pages publishes the unminified bundles as `.map` siblings.
+// package.json's version is never bumped (the app deploys continuously from
+// main), so the Settings "About" readout identifies builds by commit instead.
+const commitSha = ((): string => {
+  try {
+    return execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
+  } catch {
+    return 'dev';
+  }
+})();
+
 const sentryEnabled = Boolean(process.env.SENTRY_AUTH_TOKEN);
 const sentryPlugins = sentryEnabled
   ? [
@@ -99,6 +110,7 @@ export default defineConfig({
   },
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
+    __APP_COMMIT__: JSON.stringify(commitSha),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Closes #302.

The About readout was permanently `0.1.0` because `package.json` is never bumped. This adds a separate `__APP_COMMIT__` define (short sha via `git rev-parse`, `dev` fallback) shown in Settings as `0.1.0 (abc1234)`.

Deliberately a *separate* define rather than folding the sha into `__APP_VERSION__`: that value is also the runtime Sentry release name (must keep matching the `pkg.version` release the sourcemap upload uses, or symbolication breaks) and the react-query persisted-cache buster (per-commit busting would clear the offline cache on every deploy).