### PR TITLE
fix(nav): KID button targets the most recent non-empty board

### DIFF
--- a/src/app/routes/BoardBuilderRoute.tsx
+++ b/src/app/routes/BoardBuilderRoute.tsx
@@ -6,14 +6,15 @@ import { BoardErrorBanner } from '@/features/board-builder/BoardErrorBanner';
 import { BoardNotFound } from '@/features/board-builder/BoardNotFound';
 import { PictoPicker } from '@/features/board-builder/pictogram-picker/PictoPicker';
 import { ShareModal } from '@/features/board-builder/ShareModal';
+import { useKidModeNav } from '@/layouts/useKidModeNav';
 import { useParentNav } from '@/layouts/useParentNav';
 import { useSessionUser } from '@/lib/auth/session';
-import { isNotFoundError, useBoard, useBoards, useSetStepIds } from '@/lib/queries/boards';
+import { isNotFoundError, useBoard, useSetStepIds } from '@/lib/queries/boards';
 
 export const BoardBuilderRoute = (): JSX.Element | null => {
   const { boardId = '' } = useParams();
   const boardQuery = useBoard(boardId);
-  const boardsQuery = useBoards();
+  const fallbackKidMode = useKidModeNav();
   const setStepIds = useSetStepIds();
   const board = boardQuery.data;
   const navigate = useNavigate();
@@ -54,15 +55,12 @@ export const BoardBuilderRoute = (): JSX.Element | null => {
   if (boardQuery.isError || (boardQuery.isSuccess && !board)) {
     const variant =
       isNotFoundError(boardQuery.error) || (boardQuery.isSuccess && !board) ? 'not-found' : 'error';
-    const fallbackKid = boardsQuery.data?.find((b) => b.kind === 'sequence');
     return (
       <BoardNotFound
         variant={variant}
         onBack={() => navigate('/')}
         onRetry={() => void boardQuery.refetch()}
-        onKidMode={() => {
-          if (fallbackKid) navigate(`/kid/sequence/${fallbackKid.id}`);
-        }}
+        {...(fallbackKidMode ? { onKidMode: fallbackKidMode } : {})}
         onNav={onNav}
       />
     );

--- a/src/app/routes/KidsRoute.test.tsx
+++ b/src/app/routes/KidsRoute.test.tsx
@@ -81,7 +81,7 @@ describe('KidsRoute', () => {
     expect(screen.getByRole('heading', { name: /add a kid/i })).toBeInTheDocument();
   });
 
-  it('clicking KID navigates into the first sequence board (regression: #71)', async () => {
+  it('clicking KID navigates into the most recent non-empty board (regression: #71, #301)', async () => {
     useBoardsMock.mockReturnValue({
       data: [
         {
@@ -92,7 +92,7 @@ describe('KidsRoute', () => {
           kind: 'sequence',
           labelsVisible: true,
           voiceMode: 'tts',
-          stepIds: [],
+          stepIds: ['p1'],
           kidReorderable: false,
           accent: 'sage',
           updatedLabel: 'just now',

--- a/src/app/routes/KidsRoute.tsx
+++ b/src/app/routes/KidsRoute.tsx
@@ -17,7 +17,7 @@ export const KidsRoute = (): JSX.Element => {
       <ParentShell
         active="kids"
         onNav={onNav}
-        onKidMode={onKidMode}
+        {...(onKidMode ? { onKidMode } : {})}
         title="Kids"
         subtitle="Tap a kid to rename, delete, or set them as active."
         right={

--- a/src/app/routes/LibraryRoute.test.tsx
+++ b/src/app/routes/LibraryRoute.test.tsx
@@ -64,7 +64,7 @@ describe('LibraryRoute', () => {
     expect(screen.getByText('Apple')).toBeInTheDocument();
   });
 
-  it('clicking KID navigates into the first sequence board (regression: #71)', async () => {
+  it('clicking KID navigates into the most recent non-empty board (regression: #71, #301)', async () => {
     useBoardsMock.mockReturnValue({
       data: [
         {
@@ -75,7 +75,7 @@ describe('LibraryRoute', () => {
           kind: 'sequence',
           labelsVisible: true,
           voiceMode: 'tts',
-          stepIds: [],
+          stepIds: ['p1'],
           kidReorderable: false,
           accent: 'sage',
           updatedLabel: 'just now',

--- a/src/app/routes/LibraryRoute.tsx
+++ b/src/app/routes/LibraryRoute.tsx
@@ -12,7 +12,7 @@ export const LibraryRoute = (): JSX.Element => {
     <ParentShell
       active="library"
       onNav={onNav}
-      onKidMode={onKidMode}
+      {...(onKidMode ? { onKidMode } : {})}
       title="Library"
       subtitle="Every pictogram in your library — tap one to rename, replace its photo, or delete."
     >

--- a/src/app/routes/ParentHomeRoute.tsx
+++ b/src/app/routes/ParentHomeRoute.tsx
@@ -58,7 +58,7 @@ export const ParentHomeRoute = (): JSX.Element => {
       <ParentHome
         {...(activeKid ? { kidName: activeKid.name } : {})}
         onOpenBoard={(id) => navigate(`/boards/${id}/edit`)}
-        onKidMode={onKidMode}
+        {...(onKidMode ? { onKidMode } : {})}
         onNav={onNav}
         onNewKid={() => setNewKidOpen(true)}
         onNewBoard={() => setNewBoardOpen(true)}

--- a/src/app/routes/SettingsRoute.test.tsx
+++ b/src/app/routes/SettingsRoute.test.tsx
@@ -75,7 +75,7 @@ describe('SettingsRoute', () => {
     expect(screen.getByRole('link', { name: /privacy policy/i })).toBeInTheDocument();
   });
 
-  it('clicking KID navigates into the first sequence board (regression: #71)', async () => {
+  it('clicking KID navigates into the most recent non-empty board (regression: #71, #301)', async () => {
     useBoardsMock.mockReturnValue({
       data: [
         {
@@ -86,7 +86,7 @@ describe('SettingsRoute', () => {
           kind: 'sequence',
           labelsVisible: true,
           voiceMode: 'tts',
-          stepIds: [],
+          stepIds: ['p1'],
           kidReorderable: false,
           accent: 'sage',
           updatedLabel: 'just now',

--- a/src/app/routes/SettingsRoute.tsx
+++ b/src/app/routes/SettingsRoute.tsx
@@ -13,7 +13,12 @@ export const SettingsRoute = (): JSX.Element => {
   const onNav = useParentNav();
   const onKidMode = useKidModeNav();
   return (
-    <ParentShell active="settings" onNav={onNav} onKidMode={onKidMode} title="Settings">
+    <ParentShell
+      active="settings"
+      onNav={onNav}
+      {...(onKidMode ? { onKidMode } : {})}
+      title="Settings"
+    >
       <AccountSection />
       <PinManagementSection />
       <SpeechPrefsSection />

--- a/src/features/board-builder/BoardNotFound.tsx
+++ b/src/features/board-builder/BoardNotFound.tsx
@@ -11,7 +11,7 @@ interface BoardNotFoundProps {
   variant: BoardLoadFailureVariant;
   onBack: () => void;
   onRetry?: () => void;
-  onKidMode: () => void;
+  onKidMode?: () => void;
   onNav?: (id: ParentNavKey) => void;
 }
 
@@ -35,7 +35,7 @@ export const BoardNotFound = ({
 }: BoardNotFoundProps): JSX.Element => {
   const { title, body } = COPY[variant];
   return (
-    <ParentShell active="home" onKidMode={onKidMode} {...(onNav ? { onNav } : {})}>
+    <ParentShell active="home" {...(onKidMode ? { onKidMode } : {})} {...(onNav ? { onNav } : {})}>
       <div className={styles.wrap}>
         <h1 className={styles.title}>{title}</h1>
         <p className={styles.body}>{body}</p>

--- a/src/layouts/ParentShell.module.css
+++ b/src/layouts/ParentShell.module.css
@@ -73,6 +73,12 @@
   box-shadow: var(--tal-shadow-1);
 }
 
+.kidBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
 .main {
   flex: 1;
   min-width: 0;

--- a/src/layouts/ParentShell.tsx
+++ b/src/layouts/ParentShell.tsx
@@ -27,7 +27,8 @@ interface ParentShellProps {
   onNav?: (id: ParentNavKey) => void;
   /**
    * Page-specific kid-mode entry point. Each route picks the right board
-   * (e.g. ParentHome → first sequence board; BoardBuilder → this board).
+   * (most routes via useKidModeNav; BoardBuilder → the board being edited).
+   * Omitted when no board qualifies — the button renders disabled.
    */
   onKidMode?: () => void;
   title?: string;
@@ -68,7 +69,7 @@ export const ParentShell = ({
           })}
         </nav>
         <div className={styles.bottom}>
-          <button type="button" className={styles.kidBtn} onClick={onKidMode}>
+          <button type="button" className={styles.kidBtn} onClick={onKidMode} disabled={!onKidMode}>
             <LockIcon size={22} />
             <span>KID</span>
           </button>

--- a/src/layouts/useKidModeNav.test.tsx
+++ b/src/layouts/useKidModeNav.test.tsx
@@ -1,0 +1,102 @@
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Board } from '@/types/domain';
+import type { Kid } from '@/types/domain';
+
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+const useBoardsMock = vi.fn(() => ({ data: [] as Board[] }));
+vi.mock('@/lib/queries/boards', () => ({
+  useBoards: () => useBoardsMock(),
+}));
+
+const useActiveKidMock = vi.fn((): Kid | null => null);
+vi.mock('@/lib/queries/kids', () => ({
+  useActiveKid: () => useActiveKidMock(),
+}));
+
+const { useKidModeNav } = await import('./useKidModeNav');
+
+// Boards arrive from useBoards sorted by updated_at desc; fixtures below are
+// listed in that order.
+const board = (over: Partial<Board>): Board => ({
+  id: 'b1',
+  ownerId: 'owner',
+  kidId: 'k1',
+  name: 'Board',
+  kind: 'sequence',
+  labelsVisible: true,
+  voiceMode: 'tts',
+  stepIds: ['p1'],
+  kidReorderable: false,
+  accent: 'sage',
+  updatedLabel: 'just now',
+  serverUpdatedAt: '2026-01-01T00:00:00Z',
+  ...over,
+});
+
+const kid = (id: string): Kid => ({ id, ownerId: 'owner', name: id });
+
+const wrapper = ({ children }: { children: ReactNode }): ReactNode => (
+  <MemoryRouter>{children}</MemoryRouter>
+);
+
+const run = (): (() => void) | undefined =>
+  renderHook(() => useKidModeNav(), { wrapper }).result.current;
+
+beforeEach(() => {
+  navigateMock.mockReset();
+  useBoardsMock.mockReturnValue({ data: [] });
+  useActiveKidMock.mockReturnValue(null);
+});
+
+describe('useKidModeNav', () => {
+  it("prefers the active kid's most recent non-empty board over a newer board of another kid", () => {
+    useBoardsMock.mockReturnValue({
+      data: [
+        board({ id: 'other-kid-newer', kidId: 'k2' }),
+        board({ id: 'active-kid-board', kidId: 'k1', kind: 'choice' }),
+      ],
+    });
+    useActiveKidMock.mockReturnValue(kid('k1'));
+
+    run()?.();
+    expect(navigateMock).toHaveBeenCalledWith('/kid/choice/active-kid-board');
+  });
+
+  it("skips empty boards and falls back to another kid's non-empty board", () => {
+    useBoardsMock.mockReturnValue({
+      data: [
+        board({ id: 'active-but-empty', kidId: 'k1', stepIds: [] }),
+        board({ id: 'other-kid-full', kidId: 'k2' }),
+      ],
+    });
+    useActiveKidMock.mockReturnValue(kid('k1'));
+
+    run()?.();
+    expect(navigateMock).toHaveBeenCalledWith('/kid/sequence/other-kid-full');
+  });
+
+  it('routes by board kind', () => {
+    useBoardsMock.mockReturnValue({ data: [board({ id: 'c1', kind: 'choice' })] });
+
+    run()?.();
+    expect(navigateMock).toHaveBeenCalledWith('/kid/choice/c1');
+  });
+
+  it('returns undefined when every board is empty, so the KID button can disable', () => {
+    useBoardsMock.mockReturnValue({ data: [board({ stepIds: [] })] });
+    expect(run()).toBeUndefined();
+  });
+
+  it('returns undefined when there are no boards at all', () => {
+    expect(run()).toBeUndefined();
+  });
+});

--- a/src/layouts/useKidModeNav.ts
+++ b/src/layouts/useKidModeNav.ts
@@ -2,17 +2,26 @@ import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useBoards } from '@/lib/queries/boards';
+import { useActiveKid } from '@/lib/queries/kids';
 
-// Resolves the parent shell's KID button into a navigation into the first
-// sequence board the user owns. Routes that don't have their own board
-// context (Library, Kids, Settings, ParentHome) share this hook so the KID
-// button works consistently from anywhere in the parent shell. BoardBuilder
-// keeps its own wiring because it launches into the board being edited.
-export const useKidModeNav = (): (() => void) => {
+// Resolves the parent shell's KID button into the board a kid would actually
+// want: the most recently updated non-empty board (useBoards returns boards
+// sorted by updated_at desc), preferring the active kid's boards and falling
+// back to any kid's. Empty boards are skipped — kid mode's empty state is a
+// dead end. Returns undefined when no board qualifies so the shell can
+// disable the button instead of silently doing nothing. Routes that don't
+// have their own board context (Library, Kids, Settings, ParentHome) share
+// this hook; BoardBuilder keeps its own wiring because it launches into the
+// board being edited.
+export const useKidModeNav = (): (() => void) | undefined => {
   const navigate = useNavigate();
   const boardsQuery = useBoards();
-  const firstSequence = boardsQuery.data?.find((b) => b.kind === 'sequence');
-  return useCallback(() => {
-    if (firstSequence) navigate(`/kid/sequence/${firstSequence.id}`);
-  }, [navigate, firstSequence]);
+  const activeKid = useActiveKid();
+  const nonEmpty = boardsQuery.data?.filter((b) => b.stepIds.length > 0) ?? [];
+  const target = nonEmpty.find((b) => b.kidId === activeKid?.id) ?? nonEmpty[0];
+  const targetPath = target ? `/kid/${target.kind}/${target.id}` : undefined;
+  const go = useCallback(() => {
+    if (targetPath) navigate(targetPath);
+  }, [navigate, targetPath]);
+  return targetPath ? go : undefined;
 };


### PR DESCRIPTION
Closes #301.

Observed on prod: pressing KID landed on the empty "Untitled board" while a populated choice board existed.

`useKidModeNav` now picks the most recently updated **non-empty** board (boards already arrive sorted by `updated_at` desc), preferring the **active kid's** boards and falling back across kids, and routes by board kind (`/kid/choice/…` or `/kid/sequence/…`). When nothing qualifies it returns `undefined` and the ParentShell KID button renders disabled instead of silently no-opping. `BoardBuilderRoute`'s not-found screen had a duplicate of the old first-sequence logic and now shares the hook.

Tests: new `useKidModeNav.test.tsx` covers active-kid preference, empty-board skipping, kind routing, and the disabled case; the three #71 regression route tests updated to non-empty fixtures. Full suite (435), typecheck, eslint, stylelint all pass.