### PR TITLE
ci: reserve Supabase ports from ephemeral assignment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
           # failing the types-drift step. Bump deliberately after verifying
           # `supabase gen types typescript --local` works without a token.
           version: 2.105.0
+      - name: Reserve Supabase ports from ephemeral assignment (#310)
+        # Supabase's fixed host ports (5432x) sit inside the kernel's ephemeral
+        # source-port range (32768–60999). A runner process's outbound connection
+        # can land on one, and `supabase start` then dies binding it (EADDRINUSE).
+        run: sudo sysctl -w net.ipv4.ip_local_reserved_ports=54320-54329
       - run: supabase start
       - name: Regenerate supabase types and fail on drift (#132)
         run: |


### PR DESCRIPTION
Closes #310.

One-line fix for the `supabase start` port-bind flake: reserve 54320–54329 from the kernel's automatic source-port assignment before starting the stack, so no runner process's outbound connection can occupy a Supabase host port at bind time.

Root cause, both observed instances (db/54322 on 2026-05-17, inbucket/54324 on 2026-06-12), and rejected alternatives are documented in #310. Reserved ports stay explicitly bindable, so `supabase start` itself is unaffected — this PR's green `verify` run is the demonstration.