### PR TITLE
fix(speech): prefer device-locale voice in default auto-pick

### DIFF
--- a/src/lib/speech.test.ts
+++ b/src/lib/speech.test.ts
@@ -51,7 +51,12 @@ afterEach(() => {
     (globalThis as { speechSynthesis: SpeechSynthesis }).speechSynthesis = originalSynth;
   else delete (globalThis as { speechSynthesis?: SpeechSynthesis }).speechSynthesis;
   (globalThis as { SpeechSynthesisUtterance: unknown }).SpeechSynthesisUtterance = originalUtter;
+  vi.restoreAllMocks();
 });
+
+const stubDeviceLocale = (locale: string): void => {
+  vi.spyOn(window.navigator, 'language', 'get').mockReturnValue(locale);
+};
 
 describe('speak()', () => {
   it('cancels in-flight speech and speaks the requested text', () => {
@@ -81,7 +86,8 @@ describe('speak()', () => {
     expect(isSpeechSupported()).toBe(false);
   });
 
-  it('prefers an English voice when multiple languages are available', () => {
+  it('prefers an English voice on an English-locale device', () => {
+    stubDeviceLocale('en-US');
     const { synth, utters } = makeFakeSynth([
       { name: 'Xander', lang: 'nl-NL' },
       { name: 'Karen', lang: 'en-AU' },
@@ -89,6 +95,45 @@ describe('speak()', () => {
     (globalThis as { speechSynthesis: unknown }).speechSynthesis = synth;
 
     speak('apple');
+
+    expect(utters[0]?.voice?.name).toBe('Karen');
+  });
+
+  it('prefers a voice matching the device locale over English (#304)', () => {
+    stubDeviceLocale('da-DK');
+    const { synth, utters } = makeFakeSynth([
+      { name: 'Samantha', lang: 'en-US' },
+      { name: 'Sara', lang: 'da-DK' },
+    ]);
+    (globalThis as { speechSynthesis: unknown }).speechSynthesis = synth;
+
+    speak('støj');
+
+    expect(utters[0]?.voice?.name).toBe('Sara');
+  });
+
+  it('matches the locale language across region and separator variants', () => {
+    stubDeviceLocale('da');
+    const { synth, utters } = makeFakeSynth([
+      { name: 'Samantha', lang: 'en-US' },
+      { name: 'Sara', lang: 'da_DK' },
+    ]);
+    (globalThis as { speechSynthesis: unknown }).speechSynthesis = synth;
+
+    speak('støj');
+
+    expect(utters[0]?.voice?.name).toBe('Sara');
+  });
+
+  it('falls back to an English voice when nothing matches the device locale', () => {
+    stubDeviceLocale('da-DK');
+    const { synth, utters } = makeFakeSynth([
+      { name: 'Xander', lang: 'nl-NL' },
+      { name: 'Karen', lang: 'en-AU' },
+    ]);
+    (globalThis as { speechSynthesis: unknown }).speechSynthesis = synth;
+
+    speak('støj');
 
     expect(utters[0]?.voice?.name).toBe('Karen');
   });

--- a/src/lib/speech.ts
+++ b/src/lib/speech.ts
@@ -15,10 +15,20 @@ let listenerAttached = false;
 const getSynth = (): SpeechSynthesis | null =>
   typeof window !== 'undefined' && 'speechSynthesis' in window ? window.speechSynthesis : null;
 
+/** Primary BCP-47 subtag, lowercased: 'da-DK', 'da_DK' (Android), 'da' → 'da'. */
+const primarySubtag = (lang: string): string => lang.toLowerCase().split(/[-_]/)[0] ?? '';
+
+/**
+ * Default-voice heuristic: prefer the device locale's language — a Danish
+ * household's iPad should read Danish labels with a Danish voice (#304) —
+ * then English (the app's own copy), then anything.
+ */
 const pickVoice = (voices: readonly SpeechSynthesisVoice[]): SpeechSynthesisVoice | null => {
   if (voices.length === 0) return null;
-  const en = voices.filter((v) => v.lang.startsWith('en'));
-  const pool = en.length > 0 ? en : voices;
+  const deviceLang = primarySubtag(navigator.language);
+  const matchesDevice = voices.filter((v) => primarySubtag(v.lang) === deviceLang);
+  const english = voices.filter((v) => primarySubtag(v.lang) === 'en');
+  const pool = matchesDevice.length > 0 ? matchesDevice : english.length > 0 ? english : voices;
   return pool.find((v) => /female|samantha|karen|victoria/i.test(v.name)) ?? pool[0] ?? null;
 };
 


### PR DESCRIPTION
## What

`pickVoice()` hardcoded English-first, so with the "Default (auto-pick)" voice a Danish household's iPad read Danish labels ("støj") with an en-US voice — anglicized non-words, which defeats the AAC purpose of the tap (kid can't map pictogram↔word, listener can't understand the device).

Now the heuristic prefers voices whose primary BCP-47 subtag matches `navigator.language` (handles `da-DK` / Android's `da_DK` / bare `da`), then falls back to English, then anything. English-locale devices behave exactly as before; a Danish-locale iPad auto-picks its shipped Danish voice ("Sara") with no settings visit.

## Scope

**Refs #304 — does not close it.** This is the cheap default-behavior fix only. Still open under #304: the explicit per-account language setting, kid-mode copy localisation (`kidCopy.ts`), and the settings voice-picker's English-first sort order.

## Verification

- New tests: da-DK locale picks the da voice over English; `da`/`da_DK` subtag/separator variants match; no-locale-match falls back to English; existing en-locale behavior pinned explicitly.
- Red→green: both locale-preference tests failed against the old heuristic.
- `typecheck`, `lint`, full `npm run test` (439/439) green locally.