### PR TITLE
feat(language): device-local app language for kid copy and TTS voice

### DIFF
--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -190,20 +190,23 @@ Shipped — initially mis-filed as a gap ([#303], closed). The PWA setup in
 - 💭 Document the recommended iPad setup (Add to Home Screen + Guided
   Access) for parents.
 
-### Epic 14 — Language matching 🔜
+### Epic 14 — Language matching ✅
 
 > As a Danish kid I hear Danish — not my Danish words read by an English
 > robot voice next to English prompts.
 
-Today board labels can be Danish while TTS auto-picks an English voice and
-all kid-mode copy is English. ([#304])
+The TTS default follows the device locale, an explicit language setting in
+Settings overrides it, and kid-mode copy ships in Danish and English.
+([#304])
 
-- 🔜 As a parent, I set my family's language; tapped pictograms are spoken
-  by a voice in that language, with graceful fallback when the device has
-  none.
-- 🔜 As a kid, the on-screen prompts ("Tap one to choose", "Ask a
+- ✅ As a parent, I set my family's language (per device, like the PIN and
+  speech prefs); tapped pictograms are spoken by a voice in that language,
+  with graceful fallback when the device has none.
+- ✅ As a kid, the on-screen prompts ("Tap one to choose", "Ask a
   grown-up…") are in my language. Danish first, given the actual user base.
 - 💭 Per-board language override, if households turn out to mix languages.
+- 💭 Per-account language synced to the DB — together with the other
+  device-local prefs — if multi-device households materialise.
 
 ### Epic 15 — Kid-initiated communication 💭
 

--- a/src/app/routes/SettingsRoute.test.tsx
+++ b/src/app/routes/SettingsRoute.test.tsx
@@ -69,6 +69,12 @@ describe('SettingsRoute', () => {
     expect(screen.getByRole('button', { name: /^sign out$/i })).toBeInTheDocument();
   });
 
+  it('renders the Language section (#304)', () => {
+    renderRoute();
+    expect(screen.getByRole('heading', { name: 'Language' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /automatic/i })).toBeInTheDocument();
+  });
+
   it('renders the Delete-my-account section', () => {
     renderRoute();
     expect(screen.getByRole('button', { name: /delete my account/i })).toBeInTheDocument();

--- a/src/app/routes/SettingsRoute.tsx
+++ b/src/app/routes/SettingsRoute.tsx
@@ -3,6 +3,7 @@ import type { JSX } from 'react';
 import { AccountSection } from '@/features/settings/AccountSection';
 import { AppVersionSection } from '@/features/settings/AppVersionSection';
 import { DeleteAccountSection } from '@/features/settings/DeleteAccountSection';
+import { LanguageSection } from '@/features/settings/LanguageSection';
 import { PinManagementSection } from '@/features/settings/PinManagementSection';
 import { SpeechPrefsSection } from '@/features/settings/SpeechPrefsSection';
 import { ParentShell } from '@/layouts/ParentShell';
@@ -21,6 +22,7 @@ export const SettingsRoute = (): JSX.Element => {
     >
       <AccountSection />
       <PinManagementSection />
+      <LanguageSection />
       <SpeechPrefsSection />
       <AppVersionSection />
       <DeleteAccountSection />

--- a/src/features/kid-choice/KidChoice.tsx
+++ b/src/features/kid-choice/KidChoice.tsx
@@ -1,7 +1,7 @@
 import { type JSX, useState } from 'react';
 
 import { KidModeLayout } from '@/layouts/KidModeLayout';
-import { kidCopy } from '@/lib/kidCopy';
+import { getKidCopy } from '@/lib/kidCopy';
 import { usePictogramsById } from '@/lib/queries/pictograms';
 import { speakPictogram } from '@/lib/voiceOut';
 import { accentForIndex, cssVar } from '@/theme/tokens';
@@ -18,6 +18,7 @@ interface KidChoiceProps {
 }
 
 export const KidChoice = ({ board, onExit }: KidChoiceProps): JSX.Element => {
+  const kidCopy = getKidCopy();
   const pictogramsById = usePictogramsById();
   const options: Pictogram[] = board.stepIds
     .map((id) => pictogramsById.get(id))

--- a/src/features/kid-sequence/KidSequence.tsx
+++ b/src/features/kid-sequence/KidSequence.tsx
@@ -1,7 +1,7 @@
 import { type JSX, useEffect, useRef, useState } from 'react';
 
 import { KidModeLayout } from '@/layouts/KidModeLayout';
-import { kidCopy } from '@/lib/kidCopy';
+import { getKidCopy } from '@/lib/kidCopy';
 import { useSetStepIds } from '@/lib/queries/boards';
 import { usePictogramsById } from '@/lib/queries/pictograms';
 import { speakPictogram } from '@/lib/voiceOut';
@@ -36,6 +36,7 @@ const buildSteps = (stepIds: readonly string[], byId: Map<string, Pictogram>): S
   });
 
 export const KidSequence = ({ board, onExit }: KidSequenceProps): JSX.Element => {
+  const kidCopy = getKidCopy();
   const pictogramsById = usePictogramsById();
   const steps = buildSteps(board.stepIds, pictogramsById);
   // Track the speaking flash by slot key, not pictogram id: a sequence may

--- a/src/features/settings/LanguageSection.module.css
+++ b/src/features/settings/LanguageSection.module.css
@@ -1,0 +1,29 @@
+.muted {
+  margin: 0;
+  font-size: 14px;
+  color: var(--tal-ink-soft);
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 80px 1fr 56px;
+  align-items: center;
+  gap: var(--tal-space-3);
+  margin-top: var(--tal-space-3);
+}
+
+.label {
+  font-size: 14px;
+  color: var(--tal-ink-soft);
+}
+
+.select {
+  font: inherit;
+  font-size: 14px;
+  padding: var(--tal-space-2) var(--tal-space-3);
+  border-radius: var(--tal-r-pill);
+  background: var(--tal-surface);
+  color: var(--tal-ink);
+  border: 1px solid var(--tal-line);
+  grid-column: 2 / span 2;
+}

--- a/src/features/settings/LanguageSection.test.tsx
+++ b/src/features/settings/LanguageSection.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { getLanguagePref } from '@/lib/language';
+
+import { LanguageSection } from './LanguageSection';
+
+beforeEach(() => {
+  window.localStorage.removeItem('talrum:language');
+});
+
+describe('LanguageSection', () => {
+  it('defaults to Automatic when no pref is stored', () => {
+    render(<LanguageSection />);
+    const select = screen.getByLabelText(/language/i) as HTMLSelectElement;
+    expect(select.value).toBe('');
+    expect(screen.getByRole('option', { name: /automatic/i })).toBeInTheDocument();
+  });
+
+  it('persists an explicit choice', async () => {
+    const user = userEvent.setup();
+    render(<LanguageSection />);
+
+    await user.selectOptions(screen.getByLabelText(/language/i), 'da');
+
+    expect(getLanguagePref()).toBe('da');
+  });
+
+  it('reflects a stored pref on mount and can return to Automatic', async () => {
+    window.localStorage.setItem('talrum:language', 'da');
+    const user = userEvent.setup();
+    render(<LanguageSection />);
+
+    const select = screen.getByLabelText(/language/i) as HTMLSelectElement;
+    expect(select.value).toBe('da');
+
+    await user.selectOptions(select, '');
+
+    expect(getLanguagePref()).toBeNull();
+    expect(window.localStorage.getItem('talrum:language')).toBeNull();
+  });
+});

--- a/src/features/settings/LanguageSection.tsx
+++ b/src/features/settings/LanguageSection.tsx
@@ -1,0 +1,34 @@
+import { type JSX, useState } from 'react';
+
+import { type AppLanguage, getLanguagePref, isAppLanguage, setLanguagePref } from '@/lib/language';
+
+import styles from './LanguageSection.module.css';
+
+export const LanguageSection = (): JSX.Element => {
+  const [pref, setPref] = useState<AppLanguage | null>(() => getLanguagePref());
+
+  const onChange = (e: React.ChangeEvent<HTMLSelectElement>): void => {
+    const next = isAppLanguage(e.target.value) ? e.target.value : null;
+    setPref(next);
+    setLanguagePref(next);
+  };
+
+  return (
+    <section>
+      <h2>Language</h2>
+      <p className={styles.muted}>
+        Language for kid mode and the reading voice. Changes apply on the next tap.
+      </p>
+      <div className={styles.row}>
+        <label htmlFor="app-language" className={styles.label}>
+          Language
+        </label>
+        <select id="app-language" className={styles.select} value={pref ?? ''} onChange={onChange}>
+          <option value="">Automatic (device language)</option>
+          <option value="da">Dansk</option>
+          <option value="en">English</option>
+        </select>
+      </div>
+    </section>
+  );
+};

--- a/src/features/settings/SpeechPrefsSection.test.tsx
+++ b/src/features/settings/SpeechPrefsSection.test.tsx
@@ -41,6 +41,7 @@ const originalUtter = (globalThis as { SpeechSynthesisUtterance?: unknown })
 
 beforeEach(() => {
   window.localStorage.removeItem('talrum:speech-prefs');
+  window.localStorage.removeItem('talrum:language');
   __resetSpeechForTests();
   (globalThis as { SpeechSynthesisUtterance: unknown }).SpeechSynthesisUtterance = StubUtterance;
 });
@@ -71,6 +72,24 @@ describe('SpeechPrefsSection', () => {
     expect(labels).toEqual([
       'Default (auto-pick)',
       'Daniel (en-GB)',
+      'Samantha (en-US)',
+      'Xander (nl-NL)',
+    ]);
+  });
+
+  it('sorts voices matching the language pref first (#304)', () => {
+    window.localStorage.setItem('talrum:language', 'da');
+    (globalThis as { speechSynthesis: unknown }).speechSynthesis = makeFakeSynth([
+      { name: 'Xander', lang: 'nl-NL', voiceURI: 'urn:x' },
+      { name: 'Samantha', lang: 'en-US', voiceURI: 'urn:s' },
+      { name: 'Sara', lang: 'da-DK', voiceURI: 'urn:sara' },
+    ]);
+    render(<SpeechPrefsSection />);
+    const select = screen.getByLabelText(/voice/i) as HTMLSelectElement;
+    const labels = Array.from(select.options).map((o) => o.textContent);
+    expect(labels).toEqual([
+      'Default (auto-pick)',
+      'Sara (da-DK)',
       'Samantha (en-US)',
       'Xander (nl-NL)',
     ]);

--- a/src/features/settings/SpeechPrefsSection.tsx
+++ b/src/features/settings/SpeechPrefsSection.tsx
@@ -1,5 +1,6 @@
 import { type JSX, useEffect, useState } from 'react';
 
+import { getVoiceLanguage, primarySubtag } from '@/lib/language';
 import { getAvailableVoices, isSpeechSupported, speak, subscribeVoices } from '@/lib/speech';
 import {
   clearSpeechPrefs,
@@ -17,10 +18,14 @@ interface VoiceOption {
 }
 
 const toVoiceOptions = (voices: readonly SpeechSynthesisVoice[]): VoiceOption[] => {
+  // Likely-wanted voices first: the target language (chosen app language,
+  // else device locale — #304), then English, then the rest.
+  const target = getVoiceLanguage();
+  const rank = (lang: string): number =>
+    primarySubtag(lang) === target ? 0 : primarySubtag(lang) === 'en' ? 1 : 2;
   const sorted = [...voices].sort((a, b) => {
-    const aEn = a.lang.startsWith('en') ? 0 : 1;
-    const bEn = b.lang.startsWith('en') ? 0 : 1;
-    if (aEn !== bEn) return aEn - bEn;
+    const byRank = rank(a.lang) - rank(b.lang);
+    if (byRank !== 0) return byRank;
     return a.name.localeCompare(b.name);
   });
   return sorted.map((v) => ({ uri: v.voiceURI, label: `${v.name} (${v.lang})` }));

--- a/src/layouts/KidModeLayout.tsx
+++ b/src/layouts/KidModeLayout.tsx
@@ -1,7 +1,7 @@
 import type { JSX, ReactNode } from 'react';
 
 import { TalrumLogo } from '@/layouts/TalrumLogo';
-import { kidCopy } from '@/lib/kidCopy';
+import { getKidCopy } from '@/lib/kidCopy';
 import type { ColorToken } from '@/theme/tokens';
 import { LockIcon } from '@/ui/icons';
 
@@ -50,7 +50,7 @@ export const KidModeLayout = ({
       </div>
       <button type="button" className={styles.exit} onClick={onExit}>
         <LockIcon size={14} />
-        {kidCopy.exitButton}
+        {getKidCopy().exitButton}
       </button>
     </div>
     <div className={styles.body}>{children}</div>

--- a/src/lib/kidCopy.test.ts
+++ b/src/lib/kidCopy.test.ts
@@ -1,13 +1,40 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { kidCopy } from './kidCopy';
+import { getKidCopy } from './kidCopy';
+import { setLanguagePref } from './language';
 
-describe('kidCopy', () => {
-  it('interpolates the picked label into the confirm CTA', () => {
-    expect(kidCopy.choice.letsGoTo('Park')).toBe("Let's go to Park");
+beforeEach(() => {
+  window.localStorage.removeItem('talrum:language');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('getKidCopy', () => {
+  it('serves English copy by default (en device locale, no pref)', () => {
+    expect(getKidCopy().choice.title).toBe('Pick one');
   });
 
-  it('interpolates the picked label into the re-speak aria label', () => {
-    expect(kidCopy.choice.hearAgain('Park')).toBe('Hear Park again');
+  it('serves Danish copy when the language pref is da (#304)', () => {
+    setLanguagePref('da');
+    expect(getKidCopy().emptyBoard.title).toBe('Denne tavle er tom');
+  });
+
+  it('serves Danish copy on a Danish-locale device with no pref', () => {
+    vi.spyOn(window.navigator, 'language', 'get').mockReturnValue('da-DK');
+    expect(getKidCopy().choice.title).toBe('Vælg ét');
+  });
+
+  it('interpolates the picked label into the confirm CTA in both languages', () => {
+    expect(getKidCopy().choice.letsGoTo('Park')).toBe("Let's go to Park");
+    setLanguagePref('da');
+    expect(getKidCopy().choice.letsGoTo('Park')).toBe('Lad os gå til Park');
+  });
+
+  it('interpolates the picked label into the re-speak aria label in both languages', () => {
+    expect(getKidCopy().choice.hearAgain('Park')).toBe('Hear Park again');
+    setLanguagePref('da');
+    expect(getKidCopy().choice.hearAgain('Park')).toBe('Hør Park igen');
   });
 });

--- a/src/lib/kidCopy.ts
+++ b/src/lib/kidCopy.ts
@@ -1,29 +1,87 @@
 /**
- * Single audit point for kid-visible strings. Add new kid-mode copy here
- * before referencing it from a component. Keep generic chrome (Cancel,
- * Delete) out — only strings the kid actually sees, plus the PIN flow
- * that gates kid-mode exit.
+ * Single audit point for kid-visible strings, in every supported language.
+ * Add new kid-mode copy here — to both tables — before referencing it from a
+ * component. Keep generic chrome (Cancel, Delete) out — only strings the kid
+ * actually sees, plus the PIN flow that gates kid-mode exit.
+ *
+ * Components call getKidCopy() during render, so a language change in
+ * settings applies on the next render without a reload (#304).
  */
-export const kidCopy = {
-  exitButton: 'Exit kid mode',
+
+import { type AppLanguage, getAppLanguage } from './language';
+
+export interface KidCopy {
+  exitButton: string;
   emptyBoard: {
-    title: 'This board is empty',
-    body: 'Ask a grown-up to add some pictograms.',
-  },
+    title: string;
+    body: string;
+  };
   choice: {
-    title: 'Pick one',
-    tapPlaceholder: 'Tap one to choose ✨',
-    letsGoTo: (label: string): string => `Let's go to ${label}`,
-    hearAgain: (label: string): string => `Hear ${label} again`,
-  },
+    title: string;
+    tapPlaceholder: string;
+    letsGoTo: (label: string) => string;
+    hearAgain: (label: string) => string;
+  };
   pin: {
-    verifyTitle: 'Enter PIN to exit',
-    verifySubtitle: 'Enter your 4-digit parent PIN.',
-    setupNewTitle: 'Set a parent PIN',
-    setupNewSubtitle: 'Choose a 4-digit PIN for exiting kid mode.',
-    setupConfirmTitle: 'Confirm your PIN',
-    setupConfirmSubtitle: 'Enter the same 4 digits again.',
-    mismatchError: "PINs don't match",
-    wrongPin: 'Wrong PIN',
+    verifyTitle: string;
+    verifySubtitle: string;
+    setupNewTitle: string;
+    setupNewSubtitle: string;
+    setupConfirmTitle: string;
+    setupConfirmSubtitle: string;
+    mismatchError: string;
+    wrongPin: string;
+  };
+}
+
+const copy: Record<AppLanguage, KidCopy> = {
+  en: {
+    exitButton: 'Exit kid mode',
+    emptyBoard: {
+      title: 'This board is empty',
+      body: 'Ask a grown-up to add some pictograms.',
+    },
+    choice: {
+      title: 'Pick one',
+      tapPlaceholder: 'Tap one to choose ✨',
+      letsGoTo: (label: string): string => `Let's go to ${label}`,
+      hearAgain: (label: string): string => `Hear ${label} again`,
+    },
+    pin: {
+      verifyTitle: 'Enter PIN to exit',
+      verifySubtitle: 'Enter your 4-digit parent PIN.',
+      setupNewTitle: 'Set a parent PIN',
+      setupNewSubtitle: 'Choose a 4-digit PIN for exiting kid mode.',
+      setupConfirmTitle: 'Confirm your PIN',
+      setupConfirmSubtitle: 'Enter the same 4 digits again.',
+      mismatchError: "PINs don't match",
+      wrongPin: 'Wrong PIN',
+    },
   },
-} as const;
+  da: {
+    exitButton: 'Afslut børnetilstand',
+    emptyBoard: {
+      title: 'Denne tavle er tom',
+      body: 'Bed en voksen om at tilføje nogle piktogrammer.',
+    },
+    choice: {
+      title: 'Vælg ét',
+      tapPlaceholder: 'Tryk på ét for at vælge ✨',
+      letsGoTo: (label: string): string => `Lad os gå til ${label}`,
+      hearAgain: (label: string): string => `Hør ${label} igen`,
+    },
+    pin: {
+      verifyTitle: 'Indtast PIN for at afslutte',
+      verifySubtitle: 'Indtast din 4-cifrede forældre-PIN.',
+      setupNewTitle: 'Vælg en forældre-PIN',
+      setupNewSubtitle: 'Vælg en 4-cifret PIN til at afslutte børnetilstand.',
+      setupConfirmTitle: 'Bekræft din PIN',
+      setupConfirmSubtitle: 'Indtast de samme 4 cifre igen.',
+      mismatchError: 'PIN-koderne er ikke ens',
+      wrongPin: 'Forkert PIN',
+    },
+  },
+};
+
+/** Kid copy for the resolved app language, resolved at call time. */
+export const getKidCopy = (): KidCopy => copy[getAppLanguage()];

--- a/src/lib/language.test.ts
+++ b/src/lib/language.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getAppLanguage, getLanguagePref, setLanguagePref } from './language';
+
+const stubDeviceLocale = (locale: string): void => {
+  vi.spyOn(window.navigator, 'language', 'get').mockReturnValue(locale);
+};
+
+beforeEach(() => {
+  window.localStorage.removeItem('talrum:language');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('language pref storage', () => {
+  it('round-trips an explicit choice', () => {
+    setLanguagePref('da');
+    expect(getLanguagePref()).toBe('da');
+  });
+
+  it('defaults to null when nothing is stored', () => {
+    expect(getLanguagePref()).toBeNull();
+  });
+
+  it('treats an unknown stored value as unset', () => {
+    window.localStorage.setItem('talrum:language', 'klingon');
+    expect(getLanguagePref()).toBeNull();
+  });
+
+  it('setLanguagePref(null) clears the stored choice', () => {
+    setLanguagePref('da');
+    setLanguagePref(null);
+    expect(getLanguagePref()).toBeNull();
+    expect(window.localStorage.getItem('talrum:language')).toBeNull();
+  });
+});
+
+describe('getAppLanguage()', () => {
+  it('returns the explicit pref regardless of device locale', () => {
+    stubDeviceLocale('en-US');
+    setLanguagePref('da');
+    expect(getAppLanguage()).toBe('da');
+  });
+
+  it('follows a Danish device locale when unset', () => {
+    stubDeviceLocale('da-DK');
+    expect(getAppLanguage()).toBe('da');
+  });
+
+  it('falls back to English for locales without copy', () => {
+    stubDeviceLocale('nl-NL');
+    expect(getAppLanguage()).toBe('en');
+  });
+});

--- a/src/lib/language.ts
+++ b/src/lib/language.ts
@@ -1,0 +1,57 @@
+/**
+ * Device-local app language (#304). Drives kid-facing copy (kidCopy) and
+ * default TTS voice selection (speech). Stored per device like speechPrefs
+ * and pin — nothing in the app is per-account yet; if settings ever move to
+ * the DB, migrate this alongside the other prefs.
+ */
+
+const STORAGE_KEY = 'talrum:language';
+
+export const APP_LANGUAGES = ['en', 'da'] as const;
+export type AppLanguage = (typeof APP_LANGUAGES)[number];
+
+export const isAppLanguage = (v: unknown): v is AppLanguage =>
+  typeof v === 'string' && (APP_LANGUAGES as readonly string[]).includes(v);
+
+/** Primary BCP-47 subtag, lowercased: 'da-DK', 'da_DK' (Android), 'da' → 'da'. */
+export const primarySubtag = (lang: string): string => lang.toLowerCase().split(/[-_]/)[0] ?? '';
+
+/** The explicit user choice, or null when following the device locale. */
+export const getLanguagePref = (): AppLanguage | null => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return isAppLanguage(raw) ? raw : null;
+  } catch {
+    return null;
+  }
+};
+
+/** null = follow the device locale again. */
+export const setLanguagePref = (lang: AppLanguage | null): void => {
+  try {
+    if (lang === null) localStorage.removeItem(STORAGE_KEY);
+    else localStorage.setItem(STORAGE_KEY, lang);
+  } catch {
+    // ignore quota / privacy mode errors — feature is best-effort
+  }
+};
+
+/**
+ * Resolved language for kid-facing copy: explicit pref, else the device
+ * locale when we have copy for it, else English.
+ */
+export const getAppLanguage = (): AppLanguage => {
+  const pref = getLanguagePref();
+  if (pref) return pref;
+  const device = primarySubtag(navigator.language);
+  return isAppLanguage(device) ? device : 'en';
+};
+
+/**
+ * Target language for TTS voice matching: explicit pref, else the device
+ * locale's primary subtag. Unlike getAppLanguage this is not clamped to
+ * APP_LANGUAGES — we can match a voice for any device locale even when we
+ * have no copy for it.
+ */
+export const getVoiceLanguage = (): string =>
+  getLanguagePref() ?? primarySubtag(navigator.language);

--- a/src/lib/speech.test.ts
+++ b/src/lib/speech.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { setLanguagePref } from './language';
 import { __resetSpeechForTests, getAvailableVoices, isSpeechSupported, speak } from './speech';
 import { setSpeechPrefs } from './speechPrefs';
 
@@ -43,6 +44,7 @@ class StubUtterance {
 beforeEach(() => {
   (globalThis as { SpeechSynthesisUtterance: unknown }).SpeechSynthesisUtterance = StubUtterance;
   window.localStorage.removeItem('talrum:speech-prefs');
+  window.localStorage.removeItem('talrum:language');
   __resetSpeechForTests();
 });
 
@@ -123,6 +125,36 @@ describe('speak()', () => {
     speak('støj');
 
     expect(utters[0]?.voice?.name).toBe('Sara');
+  });
+
+  it('lets an explicit language pref override the device locale (#304)', () => {
+    stubDeviceLocale('en-US');
+    setLanguagePref('da');
+    const { synth, utters } = makeFakeSynth([
+      { name: 'Samantha', lang: 'en-US' },
+      { name: 'Sara', lang: 'da-DK' },
+    ]);
+    (globalThis as { speechSynthesis: unknown }).speechSynthesis = synth;
+
+    speak('støj');
+
+    expect(utters[0]?.voice?.name).toBe('Sara');
+  });
+
+  it('re-picks the voice when the language pref changes between taps (#304)', () => {
+    stubDeviceLocale('en-US');
+    const { synth, utters } = makeFakeSynth([
+      { name: 'Samantha', lang: 'en-US' },
+      { name: 'Sara', lang: 'da-DK' },
+    ]);
+    (globalThis as { speechSynthesis: unknown }).speechSynthesis = synth;
+
+    speak('hello');
+    setLanguagePref('da');
+    speak('støj');
+
+    expect(utters[0]?.voice?.name).toBe('Samantha');
+    expect(utters[1]?.voice?.name).toBe('Sara');
   });
 
   it('falls back to an English voice when nothing matches the device locale', () => {

--- a/src/lib/speech.ts
+++ b/src/lib/speech.ts
@@ -3,40 +3,46 @@
  *
  * `speechSynthesis.getVoices()` is async on first call in Chromium — voices
  * arrive via a `voiceschanged` event. We cache a heuristic-picked voice once
- * it's known so each `speak()` isn't a fresh lookup. The user's saved
- * `voiceURI` (from speechPrefs) overrides the heuristic when present.
+ * it's known so each `speak()` isn't a fresh lookup; the cache is keyed on
+ * the target language so a settings change applies on the next tap. The
+ * user's saved `voiceURI` (from speechPrefs) overrides the heuristic when
+ * present.
  */
 
+import { getVoiceLanguage, primarySubtag } from './language';
 import { getSpeechPrefs } from './speechPrefs';
 
 let cachedVoice: SpeechSynthesisVoice | null = null;
+let cachedVoiceLang: string | null = null;
 let listenerAttached = false;
 
 const getSynth = (): SpeechSynthesis | null =>
   typeof window !== 'undefined' && 'speechSynthesis' in window ? window.speechSynthesis : null;
 
-/** Primary BCP-47 subtag, lowercased: 'da-DK', 'da_DK' (Android), 'da' → 'da'. */
-const primarySubtag = (lang: string): string => lang.toLowerCase().split(/[-_]/)[0] ?? '';
-
 /**
- * Default-voice heuristic: prefer the device locale's language — a Danish
- * household's iPad should read Danish labels with a Danish voice (#304) —
- * then English (the app's own copy), then anything.
+ * Default-voice heuristic: prefer the target language (chosen app language,
+ * else device locale — a Danish household's iPad should read Danish labels
+ * with a Danish voice, #304), then English (the app's own copy), then
+ * anything.
  */
-const pickVoice = (voices: readonly SpeechSynthesisVoice[]): SpeechSynthesisVoice | null => {
+const pickVoice = (
+  voices: readonly SpeechSynthesisVoice[],
+  targetLang: string,
+): SpeechSynthesisVoice | null => {
   if (voices.length === 0) return null;
-  const deviceLang = primarySubtag(navigator.language);
-  const matchesDevice = voices.filter((v) => primarySubtag(v.lang) === deviceLang);
+  const matchesTarget = voices.filter((v) => primarySubtag(v.lang) === targetLang);
   const english = voices.filter((v) => primarySubtag(v.lang) === 'en');
-  const pool = matchesDevice.length > 0 ? matchesDevice : english.length > 0 ? english : voices;
+  const pool = matchesTarget.length > 0 ? matchesTarget : english.length > 0 ? english : voices;
   return pool.find((v) => /female|samantha|karen|victoria/i.test(v.name)) ?? pool[0] ?? null;
 };
 
 const ensureVoice = (synth: SpeechSynthesis): void => {
-  if (cachedVoice) return;
+  const targetLang = getVoiceLanguage();
+  if (cachedVoice && cachedVoiceLang === targetLang) return;
   const voices = synth.getVoices();
   if (voices.length > 0) {
-    cachedVoice = pickVoice(voices);
+    cachedVoice = pickVoice(voices, targetLang);
+    cachedVoiceLang = targetLang;
     return;
   }
   if (listenerAttached) return;
@@ -44,7 +50,9 @@ const ensureVoice = (synth: SpeechSynthesis): void => {
   synth.addEventListener(
     'voiceschanged',
     () => {
-      cachedVoice = pickVoice(synth.getVoices());
+      const lang = getVoiceLanguage();
+      cachedVoice = pickVoice(synth.getVoices(), lang);
+      cachedVoiceLang = lang;
     },
     { once: true },
   );
@@ -98,5 +106,6 @@ export const speak = (text: string): void => {
 
 export const __resetSpeechForTests = (): void => {
   cachedVoice = null;
+  cachedVoiceLang = null;
   listenerAttached = false;
 };

--- a/src/ui/KidModeGate/KidModeGate.tsx
+++ b/src/ui/KidModeGate/KidModeGate.tsx
@@ -1,6 +1,6 @@
 import { type JSX, type ReactNode, useState } from 'react';
 
-import { kidCopy } from '@/lib/kidCopy';
+import { getKidCopy } from '@/lib/kidCopy';
 import { hasPin, pinGateDisabled, setPin, verifyPin } from '@/lib/pin';
 import { Modal } from '@/ui/Modal/Modal';
 
@@ -18,6 +18,7 @@ interface KidModeGateProps {
 }
 
 export const KidModeGate = ({ onExitConfirmed, children }: KidModeGateProps): JSX.Element => {
+  const kidCopy = getKidCopy();
   const [stage, setStage] = useState<Stage>({ kind: 'idle' });
 
   const requestExit = (): void => {


### PR DESCRIPTION
Closes #304.

## What

A Danish kid heard Danish labels read by an English voice next to English prompts. This adds the missing language plumbing, device-locally:

- **`src/lib/language.ts`** — `'da' | 'en'` pref in localStorage, per device like the PIN and speech prefs (nothing in the app is per-account yet; deliberate scope choice, see below). Unset = follow the device locale. `getAppLanguage()` clamps to supported copy languages; `getVoiceLanguage()` doesn't, so voice matching keeps working for any device locale (preserves #312 behavior exactly when unset).
- **`kidCopy` is language-keyed** — components resolve via `getKidCopy()` at render time, so a settings change applies without reload. **🇩🇰 The Danish strings are my draft — please review them as the native speaker.**
- **`pickVoice()`** targets the chosen language (else device locale); the voice cache is re-keyed on language so a change applies on the next tap, not the next reload.
- **Settings** gains a Language section (Automatic / Dansk / English); the voice picker now sorts target-language voices first instead of English-first.
- **user-stories.md Epic 14** marked shipped; per-board override and per-account DB sync recorded as 💭 candidates.

## Why device-local, not per-account

The issue said "per account is probably enough to start", but nothing in the app is per-account today — even the parent PIN is device-local. A DB-backed setting would be the first of its kind (migration + RLS + grants + types + outbox). If multi-device sync ever matters, migrating language + PIN + speech prefs together is one coherent project; doing language alone now would be an inconsistent half-step.

## Verification

TDD throughout (locale tests red against the old code first). 456/456 tests (17 new: language pref storage/resolution, Danish copy switching, voice override + cache re-key, section persistence, picker sort, route render). typecheck / lint / lint:css clean.