### PR TITLE
ci: make the migration-drift check survive free-tier project pauses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,11 @@ jobs:
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+      # Optional: session-pooler (IPv4) connection string. Without it the CLI's
+      # --linked fallback can dial the direct IPv6 address — unreachable from
+      # GitHub-hosted runners — when the project is paused or freshly resumed
+      # (observed 2026-07-05 after a free-tier auto-pause).
+      SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
       # Same telemetry opt-out as the verify job.
       DO_NOT_TRACK: '1'
     steps:

--- a/scripts/check-migration-drift.test.ts
+++ b/scripts/check-migration-drift.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  connectivityHint,
   findOrphans,
   formatOrphanError,
+  migrationListArgs,
   parseLocalVersions,
   parseRemoteVersions,
 } from './check-migration-drift.ts';
@@ -81,5 +83,29 @@ describe('formatOrphanError', () => {
     expect(msg).toContain('  - 20260501134522');
     expect(msg).toContain('CLAUDE.md');
     expect(msg).toContain('MCP');
+  });
+});
+
+describe('migrationListArgs', () => {
+  it('uses --db-url when a pooler connection string is provided', () => {
+    const url = 'postgresql://u:p@aws-0-eu-central-1.pooler.supabase.com:5432/postgres';
+    expect(migrationListArgs(url)).toEqual(['migration', 'list', '--db-url', url]);
+  });
+
+  it('falls back to --linked when no URL is set', () => {
+    expect(migrationListArgs(undefined)).toEqual(['migration', 'list', '--linked']);
+  });
+});
+
+describe('connectivityHint', () => {
+  it('maps the IPv6 dial failure to a paused-project hint', () => {
+    const reason = 'IPv6 is not supported on your current network: dial tcp [2a05::1]:5432';
+    const hint = connectivityHint(reason);
+    expect(hint).toContain('paused');
+    expect(hint).toContain('SUPABASE_DB_URL');
+  });
+
+  it('returns null for unrelated failures', () => {
+    expect(connectivityHint('permission denied for schema supabase_migrations')).toBeNull();
   });
 });

--- a/scripts/check-migration-drift.ts
+++ b/scripts/check-migration-drift.ts
@@ -63,12 +63,35 @@ export function formatOrphanError(orphans: readonly string[]): string {
 
 const MIGRATIONS_DIR = 'supabase/migrations';
 
+export function migrationListArgs(dbUrl: string | undefined): string[] {
+  // With SUPABASE_DB_URL set (session-pooler connection string, IPv4), connect
+  // through the pooler. Without it, `--linked` lets the CLI pick — which can
+  // fall back to the direct db.<ref>.supabase.co address (IPv6-only) while the
+  // project is paused or freshly resumed, unreachable from GitHub-hosted runners.
+  return dbUrl ? ['migration', 'list', '--db-url', dbUrl] : ['migration', 'list', '--linked'];
+}
+
+const IPV6_FALLBACK_RE = /IPv6 is not supported|network is unreachable/i;
+
+export function connectivityHint(reason: string): string | null {
+  if (!IPV6_FALLBACK_RE.test(reason)) return null;
+  return [
+    '[migration-drift] The CLI dialed the direct IPv6 connection, which',
+    'GitHub-hosted runners cannot reach. This happens when the Supabase project',
+    'is paused (free tier pauses after ~1 week idle) — resume it in the',
+    'dashboard and re-run this job. To make the check pause-proof, set a',
+    'SUPABASE_DB_URL repo secret with the session-pooler (IPv4) connection',
+    'string from the dashboard.',
+  ].join('\n');
+}
+
 function runSupabaseMigrationList(): { ok: true; stdout: string } | { ok: false; reason: string } {
+  const args = migrationListArgs(process.env.SUPABASE_DB_URL || undefined);
   // Single retry with 5s backoff. CI flakes on transient network errors are common enough
   // that a one-shot retry is worth it; deeper than that and the failure is real.
   for (let attempt = 0; attempt < 2; attempt++) {
     if (attempt > 0) spawnSync('sleep', ['5']);
-    const res = spawnSync('supabase', ['migration', 'list', '--linked'], {
+    const res = spawnSync('supabase', args, {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -89,7 +112,9 @@ export function main(): number {
 
   const result = runSupabaseMigrationList();
   if (!result.ok) {
-    console.error(`[migration-drift] supabase migration list --linked failed: ${result.reason}`);
+    console.error(`[migration-drift] supabase migration list failed: ${result.reason}`);
+    const hint = connectivityHint(result.reason);
+    if (hint) console.error(hint);
     return 1;
   }
 


### PR DESCRIPTION
## What happened

The `migration-drift` job failed on #314 with:

```
IPv6 is not supported on your current network: dial tcp [...]:5432: connect: network is unreachable
```

Root cause (corrected from the first diagnosis — the CLI was already pinned at 2.105.0): while the free-tier project was **auto-paused** (and for a window right after resume), `supabase migration list --linked` falls back to the direct `db.<ref>.supabase.co` connection, which is IPv6-only — and GitHub-hosted runners have no IPv6. Once the project was fully resumed, the same job went green on main with zero changes. So this recurs after every ~1-week idle pause.

## Changes

- `check-migration-drift.ts`: honor an optional `SUPABASE_DB_URL` env var — when set, connect with `--db-url` (session pooler, IPv4) instead of `--linked`, sidestepping the IPv6 fallback entirely.
- Map the IPv6 dial failure to an actionable error: *project is probably paused — resume and re-run, or set SUPABASE_DB_URL*. Beats reverse-engineering a network error at the worst moment.
- `ci.yml`: pass `SUPABASE_DB_URL` from repo secrets into the job (empty/unset → behavior unchanged, `--linked` as today).
- Unit tests for both new functions, matching the existing vitest style.

## After merging (optional but recommended)

Add a `SUPABASE_DB_URL` repo secret with the **session pooler** connection string (dashboard → Connect → Session pooler, port 5432, includes the DB password). Without it everything keeps working as before — you just keep the pause-time failure mode, now with a readable error.